### PR TITLE
Clarify some wording

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -814,14 +814,14 @@ with a given \merkleRoot $\rt = \MerkleNode{0}{0}$.
 \subsection{\NullifierSet}
 
 Transactions insert \nullifiers into a \nullifierSet which is maintained
-alongside the UTXO by all nodes.
+alongside the \noteCommitmentTree by all nodes.
 
 \eli{a tx is just a string, so it doesn't insert anything. Rather, nodes process 
 tx's and the ``good'' ones lead to the addition of \nullifiers to the
 \nullifierSet.}
 
-Transactions that attempt to insert a \nullifier into this set that already
-exists within it are invalid as they are attempting to double-spend.
+Transactions that attempt to insert a \nullifier into this set when an identical
+one already exists within it, are invalid as they are attempting to double-spend.
 
 \eli{After defining \term{transaction}, one should define what a \term{legal tx} is
 (this definition depends on a particular blockchain [view]) and only then can one


### PR DESCRIPTION
I was not properly understanding these words, correct me if I have clarified to the wrong conclusion.
1. nullidier set should be maintained along side the \noteCommitmentTree, not the UTXO which does not exist in this protocol.
2. This phrase was very broken so I took a guess: Transactions which attempt to insert a \nullifier when there is an identical (`memcmp()` equivilent)  \nullifier are double-spend attempts.
