### PR TITLE
Replace "confidential" with "protected"

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -946,7 +946,7 @@ views of valid \blocks, and therefore of the sequence of \treestates in those
 \nsubsection{\JoinSplitTransfers{} and Descriptions} \label{joinsplit}
 
 A \joinSplitDescription is data included in a \transaction that describes a \joinSplitTransfer,
-i.e.\ a confidential value transfer. This kind of value transfer is the primary
+i.e.\ a protected value transfer. This kind of value transfer is the primary
 \Zcash-specific operation performed by \transactions; it uses, but should not be
 confused with, the \joinSplitStatement used for the \zkSNARK proof and verification.
 


### PR DESCRIPTION
Line 949 refers to a "confidential value transfer". Suggest replacing "confidential" with "protected" to maintain consistency and avoid the potential for confusion with Confidential Transactions.