### PR TITLE
replace "it" with explicit disambiguation

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1873,7 +1873,7 @@ As in \Bitcoin, this is associated with a private key that can be used to
 spend \notes sent to the address; in \Zcash this is called a \spendingKey.
 
 To each \note there is cryptographically associated a \noteCommitment. Once the
-\transaction creating the \note has been mined, it is associated with a fixed
+\transaction creating the \note has been mined, the note is associated with a fixed
 \notePosition in a tree of \noteCommitments, and with a \nullifier\footnoteref{notesandnullifiers}
 unique to that \note. Computing the \nullifier requires the associated private
 \spendingKey\sapling{ (or the \nullifierKey for \Sapling \notes)}.


### PR DESCRIPTION
I was able to read this "it" as a reference to "the transaction".