### PR TITLE
enhance bind of "note" to "shielded input/output"

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1898,8 +1898,8 @@ which takes in a \transparent value and up to two input \notes, and produces a
 It also includes \joinSplitDescriptions, \spendDescriptions, and \outputDescriptions.
 Together these describe \shieldedTransfers which take in \shieldedInput \notes,
 and/or produce \shieldedOutput \notes.
-(For \Sprout, each \joinSplitDescription handles up to two \shieldedInputs and
-up to two \shieldedOutputs. For \Sapling, each \shieldedInput or \shieldedOutput
+(For \Sprout, each \joinSplitDescription handles up to two \shieldedInput notes and
+up to two \shieldedOutput notes. For \Sapling, each \shieldedInput note or \shieldedOutput note
 has its own description.)
 It is also possible for value to be transferred between the \transparent and
 \shielded domains.
@@ -1928,23 +1928,23 @@ which proves that all of the following hold except with insignificant probabilit
 \transaction also includes computationally sound \zkSNARK proofs and signatures,
 which prove that all of the following hold except with insignificant probability:
 
-For each \shieldedInput,
+For each \shieldedInput note,
 
 \begin{itemize}
   \item \saplingonward{there is a revealed \valueCommitment to the same value as
-        the input \note;}
-  \item if the value is nonzero, some revealed \noteCommitment exists for this \note;
-  \item the prover knew the \authProvingKey of the \note;
+        the shielded input \note;}
+  \item if the value is nonzero, some revealed \noteCommitment exists for this shielded input \note;
+  \item the prover knew the \authProvingKey of the shielded input \note;
   \item the \nullifier and \noteCommitment are computed correctly.
 \end{itemize}
 
-and for each \shieldedOutput,
+and for each \shieldedOutput note,
 
 \begin{itemize}
   \item \saplingonward{there is a revealed \valueCommitment to the same value as
-        the output \note;}
+        the shielded output \note;}
   \item the \noteCommitment is computed correctly;
-  \item it is infeasible to cause the \nullifier of the output \note to collide
+  \item it is infeasible to cause the \nullifier of the shielded output \note to collide
         with the \nullifier of any other \note.
 \end{itemize}
 


### PR DESCRIPTION
If I Understand Correctly "note" is a term introduced in the zcash fork.

Although the document clearly makes the association between "shielded inputs/shielded outputs" and "shielded input notes/shielded output notes" I forgot the binding.  This meant that I didn't realize that, e.g. "shielded input" is _always_ short hand for "shielded input note" (or I am wrong about this which is useful in a different way!).  ;)
This proposed change would reiterate the "shielded [in|out]put note" pattern.  I think this will create a stronger correct association in the minds of new comers.