### PR TITLE
Explain the discrepancy in the number of constraints for blake2s found by QED-it.

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12074,6 +12074,12 @@ final $\xor$ operations), but not the message bits.
         While it might be possible to use variants of functions with low circuit cost
         such as MiMC \cite{AGRRT2017}, it was felt that they had not yet received
         sufficient cryptanalytic attention to confidently use them for \Sapling.
+  \item The actual number of constraints for $\BlakeTwosGeneric$ in the \Sapling
+        circuit is $4 \mult 2 \mult 32 = 256$ fewer than what is calculated
+        above, for a total of 21006 constraints. This is because $v$ is constant
+        at the start of the first round, so in the first four calls to $G$, the
+        parameters $b$ and $d$ are constant, eliminating the constraints for the
+        first two XORs in those four calls to $G$.
 \end{nnotes}
 
 


### PR DESCRIPTION
This is an attempt to explain the discrepancy, noted by QED-it in their latest audit report, between the number of constraints for blake2s in the sapling circuit and the number calculated in the protocol spec.