### PR TITLE
[WIP] [ZIP 400] document wallet.dat format

### DIFF
--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -173,6 +173,7 @@ hdchain
 ======
 
 Hierarchical Deterministic chain code, defined in BIP32 [#BIP32]_ .
+It is derived from the HMAC-SHA512 of hdseed.
 
   * Size: 48 bytes
 
@@ -193,7 +194,11 @@ unix timestamp of when this key was created is stored.
 mkey
 ====
 
-Master key for an encrypted wallet.
+Master key, defined in BIP32 [#BIP32]_ .
+It is derived from the HMAC-SHA512 of hdseed.
+
+   * Size: 32 bytes
+
 
 minversion
 ===========

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -58,34 +58,40 @@ wallet.dat file. Only public keys and private keys exist in wallet.dat files,
 addresses never appear or are stored in any way, they are calculated from
 pubkeys by nodes when the wallet is loaded.
 
-Here is a list of each wallet key type with the kind of data that is stored:
+Here is a concise list of each wallet key type with the kind of data that is stored:
 
-  * bestblock         - data relating to best block, i.e. chaintip
-  * cscript
-  * defaultkey
-  * hdseed
-  * hdchain
-  * key               - transparent pubkey and privkey, with sha256(pubkey+privkey)
-  * keymeta           - transparent key metadata
-  * minversion
+  * bestblock         - Data relating to best block, i.e. chaintip
+  * chdseed           - Encrypted HD seed
+  * cscript           - Redeem script
+  * defaultkey        - Default transparent address pubkey
+  * hdseed            - Hierarchical Deterministic seed
+  * hdchain           - Hierarchical Deterministic chain code, derived from seed
+  * key               - Transparent pubkey and privkey, with sha256(pubkey+privkey)
+  * keymeta           - Transparent key metadata
+  * minversion        - Minimum wallet version required to open this wallet.dat
+  * mkey              - Master key
   * name
-  * orderposnext      - index of next tx
-  * pool              - keypool pub/private keypair
-  * purpose           - purpose of a transparent address
+  * orderposnext      - Index of next tx
+  * pool              - Keypool pub/private keypair
+  * purpose           - Purpose of a transparent address
   * sapzaddr          - Sapling zaddr viewing key
   * sapzkey           - Sapling zaddr pubkey and privkey
-  * sapzkeymeta       - metadata about Sapling pubkeys
-  * tx                - transaction data
+  * sapzkeymeta       - Metadata about Sapling pubkeys
+  * tx                - Transaction data
   * vkey              - Sprout viewing key
   * version
-  * watchs            - watch-only address
-  * witnesscachesize
+  * watchs            - Watch-only address
+  * witnesscachesize  - Shielded Note Witness cache size
   * zkey              - Sprout zaddr pubkey and privkey
-  * zkeymeta          - metadata about Sprout pubkey
+  * zkeymeta          - Metadata about Sprout pubkey
 
-The types zkey, zkeymeta, sapzkey are sapzkeymeta Zcash additions to the
-Bitcoin wallet format, they do not exist in Bitcoin Core wallets. The keys
-`sapzkey` and `sapzkeymeta` do not exist in versions of Zcash prior to Sapling.
+The key types beginning with z* and sapz* are Zcash additions to the
+Bitcoin wallet format, they do not exist in Bitcoin Core wallets.
+
+The following keys only exist in Zcash Sapling-enabled wallets:
+  * sapzkey
+  * sapzaddr
+  * sapzkeymeta
 
 A full description of each key type and the values they store is below.
 
@@ -129,6 +135,11 @@ unix timestamp of when this key was created is stored.
 
   * Size: 12 bytes
 
+mkey
+====
+
+Master key for an encrypted wallet.
+
 minversion
 ===========
   * Size: 4 bytes
@@ -152,7 +163,6 @@ pool
 purpose
 ===========
   * Size: 8 bytes
-
 
 sapzaddr
 =========
@@ -179,7 +189,7 @@ version
 vkey
 =====
 
-Sprout vieing key.
+Sprout viewing key.
 
 watchs
 ======
@@ -193,7 +203,7 @@ witnesscachesize
 zkey
 ================
 
-Sprout shielded address public + private key.
+Sprout shielded address public key and private key.
 
 zkeymeta
 ================

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -58,30 +58,30 @@ wallet.dat file. Only public keys and private keys exist in wallet.dat files,
 addresses never appear or are stored in any way, they are calculated from
 pubkeys by nodes when the wallet is loaded.
 
-Here is a list of each key type with the kind of data that is stored:
+Here is a list of each wallet key type with the kind of data that is stored:
 
-  * bestblock
+  * bestblock         - data relating to best block, i.e. chaintip
   * cscript
   * defaultkey
   * hdseed
   * hdchain
-  * key         - transparent pubkey and privkey, with sha256(pubkey+privkey)
-  * keymeta
+  * key               - transparent pubkey and privkey, with sha256(pubkey+privkey)
+  * keymeta           - transparent key metadata
   * minversion
   * name
-  * orderposnext
-  * pool        - keypool pub/private keypair
-  * purpose
-  * sapzaddr    - Sapling zaddr viewing key
-  * sapzkey     - Sapling zaddr pubkey and privkey
-  * sapzkeymeta - metadata about Sapling pubkeys
-  * tx          - transaction data
-  * vkey        - Sprout viewing key
+  * orderposnext      - index of next tx
+  * pool              - keypool pub/private keypair
+  * purpose           - purpose of a transparent address
+  * sapzaddr          - Sapling zaddr viewing key
+  * sapzkey           - Sapling zaddr pubkey and privkey
+  * sapzkeymeta       - metadata about Sapling pubkeys
+  * tx                - transaction data
+  * vkey              - Sprout viewing key
   * version
-  * watchs      - watch-only address
+  * watchs            - watch-only address
   * witnesscachesize
-  * zkey        - Sprout zaddr pubkey and privkey
-  * zkeymeta    - metadata about Sprout pubkey
+  * zkey              - Sprout zaddr pubkey and privkey
+  * zkeymeta          - metadata about Sprout pubkey
 
 The types zkey, zkeymeta, sapzkey are sapzkeymeta Zcash additions to the
 Bitcoin wallet format, they do not exist in Bitcoin Core wallets. The keys

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -61,6 +61,7 @@ pubkeys by nodes when the wallet is loaded.
 Here is a list of each key type with the kind of data that is stored:
 
   * bestblock
+  * cscript
   * defaultkey
   * hdseed
   * hdchain
@@ -71,10 +72,13 @@ Here is a list of each key type with the kind of data that is stored:
   * orderposnext
   * pool        - keypool pub/private keypair
   * purpose
+  * sapzaddr    - Sapling zaddr viewing key
   * sapzkey     - Sapling zaddr pubkey and privkey
   * sapzkeymeta - metadata about Sapling pubkeys
   * tx          - transaction data
+  * vkey        - Sprout viewing key
   * version
+  * watchs      - watch-only address
   * witnesscachesize
   * zkey        - Sprout zaddr pubkey and privkey
   * zkeymeta    - metadata about Sprout pubkey
@@ -114,8 +118,15 @@ hdchain
 key
 ===
 
+This stores a (public,private) keypair for a transparent address, along with
+SHA256(public+private), where `+` means concatention.
+
 keymeta
 ======
+
+This stores metadata about a transparent key. If no metadata is available, the
+unix timestamp of when this key was created is stored.
+
   * Size: 12 bytes
 
 minversion
@@ -142,6 +153,10 @@ purpose
 ===========
   * Size: 8 bytes
 
+
+sapzaddr
+=========
+
 sapzkey
 ===========
   * Size: 169 bytes
@@ -161,10 +176,15 @@ version
   * Value: unsigned integer
   * Size: 4 bytes
 
+vkey
+=====
+
+Sprout vieing key.
+
 watchs
 ======
 
-A watch only address.
+A watch only transparent address.
 
 witnesscachesize
 ================
@@ -173,8 +193,12 @@ witnesscachesize
 zkey
 ================
 
+Sprout shielded address public + private key.
+
 zkeymeta
 ================
+
+Sprout key metadata.
 
 References
 ==========

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -63,6 +63,7 @@ Here is a list of each key type with the kind of data that is stored:
   * bestblock
   * defaultkey
   * hdseed
+  * hdchain
   * key         - transparent pubkey and privkey, with sha256(pubkey+privkey)
   * keymeta
   * minversion
@@ -78,15 +79,17 @@ Here is a list of each key type with the kind of data that is stored:
   * zkey        - Sprout zaddr pubkey and privkey
   * zkeymeta    - metadata about Sprout pubkey
 
-The types zkey, zkeymeta, sapzkey are sapzkeymeta Zcash additions to the Bitcoin
-wallet format, they do not exist in Bitcoin Core wallets.
+The types zkey, zkeymeta, sapzkey are sapzkeymeta Zcash additions to the
+Bitcoin wallet format, they do not exist in Bitcoin Core wallets. The keys
+`sapzkey` and `sapzkeymeta` do not exist in versions of Zcash prior to Sapling.
 
 A full description of each key type and the values they store is below.
 
 bestblock
 =========
 
-There MUST be only one `bestblock` key per wallet.
+  * There MUST be only one `bestblock` key per wallet.
+  * Size: Variable
 
 defaultkey
 ==========
@@ -97,13 +100,66 @@ defaultkey
     public, private key pair, stored in an element of type `key`.
   * Value: Hex string, high nybble first.
 
+hdseed
+======
+  * Size: 33 bytes
+
+hdchain
+======
+  * Size: 48 bytes
+
+key
+===
+
+keymeta
+======
+  * Size: 12 bytes
+
+minversion
+===========
+  * Size: 4 bytes
+
+name
+===========
+
+orderposnext
+===========
+
+pool
+===========
+  * Size: 46 bytes
+
+purpose
+===========
+  * Size: 8 bytes
+
+sapzkey
+===========
+  * Size: 169 bytes
+
+sapzkeymeta
+===========
+  * Size: 58 bytes
+
+tx
+===========
+
 version
 =======
 
-There MUST be only one `version` key per wallet.
+  * There MUST be only one `version` key per wallet.
+  * Value: unsigned integer
+  * Size: 4 bytes
 
-Value: unsigned integer
+witnesscachesize
+================
+  * Size: 8 bytes
 
+zkey
+================
+
+zkeymeta
+================
 
 References
 ==========

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -74,8 +74,9 @@ than transparent keys.
 
 The reader should note that Zcash addresses are almost never stored in a
 wallet.dat file. Only transparent public keys and private keys exist in
-wallet.dat files, transparent addresses never appear or are stored in any way,
-they are calculated from pubkeys by nodes when the wallet is loaded.
+wallet.dat files, transparent addresses in general, are not stored directly,
+they are calculated from pubkeys by nodes when the wallet is loaded. Metadata
+about some transparent addresses is stored, such as in the `purpose` key type.
 
 Sprout shielded addresses work the same as above, only pubkeys and private keys
 are stored in wallet.dat. But in Zcash Sapling, there can be more than one
@@ -238,7 +239,8 @@ purpose
 
 Purpose of an address, i.e. "receive" or "change" etc.
 
-  * Size: 8 bytes
+  * Key Size: 36 bytes
+  * Value Size: 8 bytes
 
 sapzaddr
 =========

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -165,14 +165,14 @@ defaultkey
 hdseed
 ======
 
-Hierarchical Deterministic seed.
+Hierarchical Deterministic seed, defined in BIP32 [#BIP32]_ .
 
   * Size: 33 bytes
 
 hdchain
 ======
 
-Hierarchical Deterministic chain code.
+Hierarchical Deterministic chain code, defined in BIP32 [#BIP32]_ .
 
   * Size: 48 bytes
 
@@ -301,3 +301,4 @@ References
 ==========
 
 .. [#RFC2119] `Key words for use in RFCs to Indicate Requirement Levels <https://tools.ietf.org/html/rfc2119>`_
+.. [#BIP32] `Hierarchical Deterministic Wallets <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>`_

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -27,7 +27,7 @@ Motivation
 Specification
 ===============
 
-Zcash wallet.dat format is inherited from Bitcoin 0.11 wallet format with
+Zcash wallet.dat format is inherited from Bitcoin 0.11.2 wallet format with
 various additions to store data related to Sprout and Sapling shielded
 addresses, and transactions involving them. Transparent addresses and
 transactions involving them are identical, with exceptions being mentioned in
@@ -53,19 +53,31 @@ addresses. This key type simply stores a public and private key, without a
 hash of the values. This means that these entries take up much less space
 than transparent keys.
 
-The reader should note that Zcash addresses of any kind never appear in a
-wallet.dat file. Only public keys and private keys exist in wallet.dat files,
-addresses never appear or are stored in any way, they are calculated from
-pubkeys by nodes when the wallet is loaded.
+The reader should note that Zcash addresses are almost never stored in a
+wallet.dat file. Only transparent public keys and private keys exist in
+wallet.dat files, transparent addresses never appear or are stored in any way,
+they are calculated from pubkeys by nodes when the wallet is loaded.
+
+Sprout shielded addresses work the same as above, only pubkeys and private keys
+are stored in wallet.dat. But in Zcash Sapling, there can be more than one
+diversified address for an incoming viewing key (IVK), so pairs of data of the
+form
+
+    (IVK,sapling_zaddr)
+
+are stored in the wallet, the only actual addresses stored directly.
 
 Here is a concise list of each wallet key type with the kind of data that is stored:
 
   * bestblock         - Data relating to best block, i.e. chaintip
   * chdseed           - Encrypted HD seed
+  * ckey              - Encrypted transparent pubkey and private key
+  * csapzkey          - Encrypted Sapling zaddr pubkey and privkey
   * cscript           - Redeem script
+  * czkey             - Encrypted Sprout zaddr pubkey and privkey
   * defaultkey        - Default transparent address pubkey
-  * hdseed            - Hierarchical Deterministic seed
   * hdchain           - Hierarchical Deterministic chain code, derived from seed
+  * hdseed            - Hierarchical Deterministic seed
   * key               - Transparent pubkey and privkey, with sha256(pubkey+privkey)
   * keymeta           - Transparent key metadata
   * minversion        - Minimum wallet version required to open this wallet.dat
@@ -73,20 +85,29 @@ Here is a concise list of each wallet key type with the kind of data that is sto
   * name
   * orderposnext      - Index of next tx
   * pool              - Keypool pub/private keypair
-  * purpose           - Purpose of a transparent address
-  * sapzaddr          - Sapling zaddr viewing key
+  * purpose           - Purpose of an address
+  * sapzaddr          - Sapling zaddr viewing key and address
   * sapzkey           - Sapling zaddr pubkey and privkey
   * sapzkeymeta       - Metadata about Sapling pubkeys
   * tx                - Transaction data
+  * version           - Wallet version (different from source code version)
   * vkey              - Sprout viewing key
-  * version
   * watchs            - Watch-only address
   * witnesscachesize  - Shielded Note Witness cache size
+  * wkey
   * zkey              - Sprout zaddr pubkey and privkey
   * zkeymeta          - Metadata about Sprout pubkey
 
-The key types beginning with z* and sapz* are Zcash additions to the
-Bitcoin wallet format, they do not exist in Bitcoin Core wallets.
+The following are Zcash additions to the Bitcoin wallet format, they do not
+exist in Bitcoin Core wallets:
+
+  * zkey
+  * zkeymeta
+  * czkey
+  * sapzaddr
+  * sapzkey
+  * csapzkey
+  * sapzkeymeta
 
 The following keys only exist in Zcash Sapling-enabled wallets:
   * sapzkey

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -127,6 +127,8 @@ bestblock
 cscript
 =======
 
+A redeem script.
+
 defaultkey
 ==========
 
@@ -165,6 +167,9 @@ Master key for an encrypted wallet.
 
 minversion
 ===========
+
+Minimum wallet version needed to open this wallet.
+
   * Size: 4 bytes
 
 name
@@ -189,13 +194,21 @@ pool
 
 purpose
 ===========
+
+Purpose of an address, i.e. "receive" or "change" etc.
+
   * Size: 8 bytes
 
 sapzaddr
 =========
 
+A Sapling incoming viewing key and address pair.
+
 sapzkey
 ===========
+
+A Sapling shielded address pubkey and private key.
+
   * Size: 169 bytes
 
 sapzkeymeta
@@ -235,6 +248,7 @@ A wallet private key, used in encrypted wallets.
 
 witnesscachesize
 ================
+  * Value: unsigned integer
   * Size: 8 bytes
 
 zkey

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -82,7 +82,12 @@ are stored in wallet.dat. But in Zcash Sapling, there can be more than one
 diversified address for an incoming viewing key (IVK), so pairs of data of the
 form
 
-    (IVK,sapling_zaddr)
+::
+
+    <------ KEY ----------+- VALUE ->
+    ---------------------------------
+    | 8  | sapzaddr | IVK | zaddr   |
+    ---------------------------------
 
 are stored in the wallet, the only actual addresses stored directly.
 

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -146,7 +146,10 @@ A full description of each key type and the values they store is below.
 bestblock
 =========
 
-  * There MUST be only one `bestblock` key per wallet.
+The current best block hash, in hex.
+
+  * There MUST be at most one `bestblock` key per wallet.
+  * Type: CBlockLocator defined in src/primitives/block.h
   * Size: Variable
 
 cscript
@@ -185,7 +188,7 @@ key
 ===
 
 This stores a (public,private) keypair for a transparent address, along with
-SHA256(public+private), where `+` means concatention.
+SHA256(public+private), where `+` means concatenation.
 
   * Size: 257 bytes
 

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -91,6 +91,9 @@ bestblock
   * There MUST be only one `bestblock` key per wallet.
   * Size: Variable
 
+cscript
+=======
+
 defaultkey
 ==========
 
@@ -125,6 +128,12 @@ name
 orderposnext
 ===========
 
+This stores the next valid index to be used in the array of transactions,
+which is also equal to the number of transactions stored in the wallet.
+
+  * There MUST be only one `orderposnext` key per wallet.
+  * Size: 8 bytes
+
 pool
 ===========
   * Size: 46 bytes
@@ -143,6 +152,7 @@ sapzkeymeta
 
 tx
 ===========
+  * Size: Variable
 
 version
 =======
@@ -150,6 +160,11 @@ version
   * There MUST be only one `version` key per wallet.
   * Value: unsigned integer
   * Size: 4 bytes
+
+watchs
+======
+
+A watch only address.
 
 witnesscachesize
 ================

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -251,7 +251,9 @@ tx
 
 A transaction, potentially containing both transparent and shielded inputs and outputs.
 
-  * Size: Variable
+  * Key Size: 64 bytes
+  * Value: CMerkleTx
+  * Value size: Variable
 
 version
 =======
@@ -275,10 +277,13 @@ wkey
 
 A wallet private key, used in encrypted wallets.
 
-  * CWalletKey
+  * Value: CWalletKey
 
 witnesscachesize
 ================
+
+Shielded note witness cache size, which includes both Sprout and Sapling notes.
+
   * Value: unsigned integer
   * Size: 8 bytes
 

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -3,7 +3,7 @@
   ZIP: 400
   Title: Format of Zcash wallet.dat files
   Author: Duke Leto <duke@leto.net>
-  Category: XXX
+  Category: Standards
   Created: 2018-12-15
   License: MIT
 
@@ -16,7 +16,8 @@ The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpret
 Abstract
 ===========
 
-This is a Standards ZIP describing the format of Zcash wallet.dat files.
+This is a Standards ZIP describing the format of Zcash wallet.dat files, inherited
+from Bitcoin wallet format.
 
 Motivation
 ===========
@@ -47,6 +48,15 @@ stored as an `unsigned char`.
 The rest of the data in the BTree key is actual public key data. The value of
 each key stores the private key associated with that pubkey and the SHA256 of
 the public and private key concatenated together.
+
+Here is a visual representation of one (key,pair) value for a transparent
+public key:
+
+    <------ KEY -------+--------- VALUE ------------------>
+    -------------------------------------------------------
+    | 3 | key | pubkey | privkey | sha256(pubkey,privkey) |
+    -------------------------------------------------------
+
 
 Similarly, there is a "zkey" type which stored data related to Sprout shielded
 addresses. This key type simply stores a public and private key, without a

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -1,0 +1,86 @@
+::
+
+  ZIP: 400
+  Title: Format of Zcash wallet.dat files
+  Author: Duke Leto <duke@leto.net>
+  Category: XXX
+  Created: 2018-12-15
+  License: MIT
+
+Terminology
+===========
+
+The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in RFC 2119.
+[#RFC2119]_
+
+Abstract
+===========
+
+This is a Standards ZIP describing the format of Zcash wallet.dat files.
+
+Motivation
+===========
+
+"We need to understand the current wallet format in order to design a new format." -- Daira
+    https://github.com/zcash/zcash/issues/2312
+
+Specification
+===============
+
+Zcash wallet.dat format is inherited from Bitcoin 0.11 wallet format with
+various additions to store data related to Sprout and Sapling shielded
+addresses, and transactions involving them. Transarent addresses and
+transactions involving them are identical, with exceptions being mentioned in
+this document.
+
+The wallet.dat is a BerkeleyDB BTree (binary tree) binary file, where all
+contents MUST be in a subtree called "main". Zcash nodes MUST NOT store
+any data outside of the "main" subtree to maintain backward compatibility
+with software meant to work on Bitcoin wallets.
+
+The binary tree has keys and values. The keys consist of multiple units of
+data, a length, a type and an actual key value, in that order. For example, an
+entry for the pubkey of a transparent address MUST have type "key", and length
+MUST correspond to the length of the string "key", i.e. 3. The rest of the
+data is actual public key data. The value of each key stores the private key
+associated with that pubkey and the SHA256 of the public and private key
+concatenated together.
+
+Similarly, there is a "zkey" type which stored data related to Sprout shielded
+addresses. This key type simply stores a public and private key, without a
+hash of the values. This means that these entries take up much less space
+than transparent keys.
+
+The reader should note that Zcash addresses of any kind never appear in a
+wallet.dat file. Only public keys and private keys exist in wallet.dat files,
+addresses never appear or are stored in any way, they are calculated from
+pubkeys by nodes when the wallet is loaded.
+
+Here is a list of each type with the kind of data that is stored:
+
+  * bestblock
+  * defaultkey
+  * hdseed
+  * key         - transparent pubkey and privkey, with sha256(pubkey+privkey)
+  * keymeta
+  * minversion
+  * name
+  * orderposnext
+  * pool        - keypool pub/private keypair
+  * purpose
+  * sapzkey     - Sapling zaddr pubkey and privkey
+  * sapzkeymeta - metadata about Sapling pubkeys
+  * tx          - transaction data
+  * version
+  * witnesscachesize
+  * zkey        - Sprout zaddr pubkey and privkey
+  * zkeymeta    - metadata about Sprout pubkey
+
+The types zkey, zkeymeta, sapzkey are sapzkeymeta Zcash additions to the Bitcoin
+wallet format, they do not exist in Bitcoin Core wallets.
+
+
+References
+==========
+
+.. [#RFC2119] `Key words for use in RFCs to Indicate Requirement Levels <https://tools.ietf.org/html/rfc2119>`_

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -29,7 +29,7 @@ Specification
 
 Zcash wallet.dat format is inherited from Bitcoin 0.11 wallet format with
 various additions to store data related to Sprout and Sapling shielded
-addresses, and transactions involving them. Transarent addresses and
+addresses, and transactions involving them. Transparent addresses and
 transactions involving them are identical, with exceptions being mentioned in
 this document.
 
@@ -41,10 +41,12 @@ with software meant to work on Bitcoin wallets.
 The binary tree has keys and values. The keys consist of multiple units of
 data, a length, a type and an actual key value, in that order. For example, an
 entry for the pubkey of a transparent address MUST have type "key", and length
-MUST correspond to the length of the string "key", i.e. 3. The rest of the
-data is actual public key data. The value of each key stores the private key
-associated with that pubkey and the SHA256 of the public and private key
-concatenated together.
+MUST correspond to the length of the string "key", i.e. 3. This number is
+stored as an `unsigned char`.
+
+The rest of the data in the BTree key is actual public key data. The value of
+each key stores the private key associated with that pubkey and the SHA256 of
+the public and private key concatenated together.
 
 Similarly, there is a "zkey" type which stored data related to Sprout shielded
 addresses. This key type simply stores a public and private key, without a
@@ -56,7 +58,7 @@ wallet.dat file. Only public keys and private keys exist in wallet.dat files,
 addresses never appear or are stored in any way, they are calculated from
 pubkeys by nodes when the wallet is loaded.
 
-Here is a list of each type with the kind of data that is stored:
+Here is a list of each key type with the kind of data that is stored:
 
   * bestblock
   * defaultkey
@@ -78,6 +80,29 @@ Here is a list of each type with the kind of data that is stored:
 
 The types zkey, zkeymeta, sapzkey are sapzkeymeta Zcash additions to the Bitcoin
 wallet format, they do not exist in Bitcoin Core wallets.
+
+A full description of each key type and the values they store is below.
+
+bestblock
+=========
+
+There MUST be only one `bestblock` key per wallet.
+
+defaultkey
+==========
+
+  * Default transparent public key of the wallet.
+  * There MUST be only one `defaultkey` key per wallet.
+  * The pubkey value of this key MUST exist in the current wallet as a
+    public, private key pair, stored in an element of type `key`.
+  * Value: Hex string, high nybble first.
+
+version
+=======
+
+There MUST be only one `version` key per wallet.
+
+Value: unsigned integer
 
 
 References

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -280,6 +280,8 @@ Sprout viewing key.
 watchs
 ======
 
+  * Size: 26 bytes
+
 A watch only transparent address.
 
 wkey
@@ -304,6 +306,7 @@ Sprout shielded address public key and private key.
 
 zkeymeta
 ================
+   * Size: variable
 
 Sprout key metadata.
 

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -52,6 +52,7 @@ the public and private key concatenated together.
 Here is a visual representation of one (key,pair) value for a transparent
 public key:
 
+::
     <------ KEY -------+--------- VALUE ------------------>
     -------------------------------------------------------
     | 3 | key | pubkey | privkey | sha256(pubkey,privkey) |

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -164,10 +164,16 @@ defaultkey
 
 hdseed
 ======
+
+Hierarchical Deterministic seed.
+
   * Size: 33 bytes
 
 hdchain
 ======
+
+Hierarchical Deterministic chain code.
+
   * Size: 48 bytes
 
 key
@@ -199,9 +205,10 @@ Minimum wallet version needed to open this wallet.
 name
 ===========
 
+Most recently added address to the addressbook.
+
   * String
 
-Most recently added address to the addressbook.
 
 orderposnext
 ===========

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -82,7 +82,7 @@ Here is a concise list of each wallet key type with the kind of data that is sto
   * keymeta           - Transparent key metadata
   * minversion        - Minimum wallet version required to open this wallet.dat
   * mkey              - Master key
-  * name
+  * name              - Most recent address added to addressbook
   * orderposnext      - Index of next tx
   * pool              - Keypool pub/private keypair
   * purpose           - Purpose of an address
@@ -94,7 +94,7 @@ Here is a concise list of each wallet key type with the kind of data that is sto
   * vkey              - Sprout viewing key
   * watchs            - Watch-only address
   * witnesscachesize  - Shielded Note Witness cache size
-  * wkey
+  * wkey              - Wallet Key
   * zkey              - Sprout zaddr pubkey and privkey
   * zkeymeta          - Metadata about Sprout pubkey
 
@@ -168,6 +168,10 @@ minversion
 name
 ===========
 
+  * String
+
+Most recently added address to the addressbook.
+
 orderposnext
 ===========
 
@@ -198,6 +202,9 @@ sapzkeymeta
 
 tx
 ===========
+
+A transaction, potentially containing both transparent and shielded inputs and outputs.
+
   * Size: Variable
 
 version
@@ -216,6 +223,13 @@ watchs
 ======
 
 A watch only transparent address.
+
+wkey
+=====
+
+A wallet private key, used in encrypted wallets.
+
+  * CWalletKey
 
 witnesscachesize
 ================

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -151,6 +151,8 @@ bestblock
 cscript
 =======
 
+  * Size: 42 bytes
+
 A redeem script.
 
 defaultkey
@@ -161,6 +163,7 @@ defaultkey
   * The pubkey value of this key MUST exist in the current wallet as a
     public, private key pair, stored in an element of type `key`.
   * Value: Hex string, high nybble first.
+  * Size: 34 bytes
 
 hdseed
 ======
@@ -182,6 +185,8 @@ key
 
 This stores a (public,private) keypair for a transparent address, along with
 SHA256(public+private), where `+` means concatention.
+
+  * Size: 257 bytes
 
 keymeta
 ======

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -53,6 +53,7 @@ Here is a visual representation of one (key,pair) value for a transparent
 public key:
 
 ::
+
     <------ KEY -------+--------- VALUE ------------------>
     -------------------------------------------------------
     | 3 | key | pubkey | privkey | sha256(pubkey,privkey) |
@@ -63,6 +64,13 @@ Similarly, there is a "zkey" type which stored data related to Sprout shielded
 addresses. This key type simply stores a public and private key, without a
 hash of the values. This means that these entries take up much less space
 than transparent keys.
+
+::
+
+    <------ KEY --------+- VALUE ->
+    -------------------------------
+    | 4 | zkey | pubkey | privkey |
+    -------------------------------
 
 The reader should note that Zcash addresses are almost never stored in a
 wallet.dat file. Only transparent public keys and private keys exist in

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -110,6 +110,8 @@ exist in Bitcoin Core wallets:
   * sapzkeymeta
 
 The following keys only exist in Zcash Sapling-enabled wallets:
+
+  * csapzkey
   * sapzkey
   * sapzaddr
   * sapzkeymeta


### PR DESCRIPTION
I saw https://github.com/zcash/zcash/issues/2312 which prompted me to write this ZIP.

This early submission is to gather initial feedback on whether further work on this ZIP should be continued. All known wallet key types are listed in this document, but the exact details of the format of their keys and values is not yet complete.

The goal of this ZIP is to make the format of wallet.dat less mysterious and clearly document each type of key+value that is stored in the database. This will be valuable to Zcash developers as well as many downstream developers that use and rely on Zcash wallet format.

@daira and @bitcartel are probably good candidates for reviewing this, any feedback is very welcome.