### PR TITLE
Removes development mailing list and changes to community forums

### DIFF
--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -60,8 +60,8 @@ brought forward for changing Zcash that have been rejected for various
 reasons. The first step should be to search past discussions to see if
 an idea has been considered before, and if so, what issues arose in its
 progression. After investigating past work, the best way to proceed is
-by posting about the new idea to the `Zcash Ecosystem Development
-list <https://lists.z.cash.foundation/mailman/listinfo/zcash-ecosystem-dev>`__.
+by posting about the new idea to the `Zcash Community Forum
+<https://forum.zcashcommunity.com/>`__.
 
 Vetting an idea publicly before going as far as writing a ZIP is meant
 to save both the potential Owner and the wider community time. Asking
@@ -75,8 +75,7 @@ where Zcash is used.
 
 Once the Owner has asked the Zcash community as to whether an idea
 has any chance of acceptance, a draft ZIP should be presented to the
-`Zcash Ecosystem Development list
-<https://lists.z.cash.foundation/mailman/listinfo/zcash-ecosystem-dev>`__.
+`Zcash Community Forum <https://forum.zcashcommunity.com/>`__.
 This gives the Owner a chance to flesh out the draft ZIP to make it
 properly formatted, of high quality, and to address additional concerns
 about the proposal. Following a discussion, the proposal should be
@@ -88,8 +87,7 @@ it a ZIP number (Owners MUST NOT self-assign ZIP numbers).
 
 ZIP Owners are responsible for collecting community feedback on both
 the initial idea and the ZIP before submitting it for review. However,
-wherever possible, long open-ended discussions on public mailing lists
-should be avoided.
+wherever possible, long open-ended discussions on forums should be avoided.
 
 It is highly recommended that a single ZIP contain a single key proposal
 or new idea. The more focused the ZIP, the more successful it tends to
@@ -147,7 +145,7 @@ be selected by consensus among the current Editors.
 ZIP Editor Responsibilities & Workflow
 --------------------------------------
 
-The ZIP Editors subscribe to the Zcash Ecosystem Development list.
+The ZIP Editors subscribe to the Zcash Community Forum.
 
 For each new ZIP that comes in an Editor confirms the following:
 
@@ -155,8 +153,8 @@ For each new ZIP that comes in an Editor confirms the following:
   must make technical sense, even if they don't seem likely to be
   accepted.
 * The title should accurately describe the content.
-* The ZIP draft must have been sent to the Zcash Ecosystem Development
-  mailing list or another suitable forum for discussion.
+* The ZIP draft must have been sent to the Zcash Community Forum or as
+  a PR to the `ZIPs git repository <https://github.com/zcash/zips>`__
 * Motivation and backward compatibility (when applicable) must be
   addressed.
 * The licensing terms are acceptable for ZIPs.
@@ -313,10 +311,9 @@ Owners of the ZIP. The format of the Owners header value SHOULD be::
 If there are multiple Owners, each should be on a separate line.
 
 While a ZIP is in private discussions (usually during the initial Draft
-phase), a Discussions-To header will indicate the mailing list or URL
-where the ZIP is being discussed. No Discussions-To header is necessary
-if the ZIP is being discussed privately with the Owner, or on the
-Zcash email mailing lists.
+phase), a Discussions-To header will indicate the URL where the ZIP is
+being discussed. No Discussions-To header is necessary if the ZIP is being
+discussed privately with the Owner.
 
 The Category header specifies the type of ZIP: Consensus, Standards Track,
 Informational, or Process.
@@ -378,12 +375,11 @@ ZIP Status Field
   consideration by the community, they may set the status to Withdrawn.
 
 * Active: Typically only used for Process/Informational ZIPs, achieved
-  once rough consensus is reached in PR/mailing list from Draft Process
-  ZIP.
+  once rough consensus is reached in PR/forum posts from Draft Process ZIP.
 
 * Proposed: Typically the stage after Draft, added to a ZIP after
-  consideration, feedback, and rough consensus from the community. The ZIP Editors must
-  validate this change before it is approved.
+  consideration, feedback, and rough consensus from the community. The ZIP
+  Editors must validate this change before it is approved.
 
 * Rejected: The status when progress hasn't been made on the ZIP in one
   year. Can revert back to Draft/Proposed if the Owner resumes work
@@ -408,13 +404,13 @@ Draft or Withdrawn.
 
 A ZIP may only change status from Draft (or Rejected) to Proposed, when
 the Owner deems it is complete and there is rough consensus on the
-mailing list, validated by both the Electric Coin Company and Zcash Foundation
+forums, validated by both the Electric Coin Company and Zcash Foundation
 Editors. One Editor will not suffice -- there needs to be consensus
 among the Editors. If it's a Standards Track ZIP, upon changing status to
 Proposed the Editors will add the optional ``Network Upgrade`` header
 to the preamble, indicating the intent for the ZIP to be implemented in
 the specified network upgrade. (All ``Network Upgrade`` schedules will be
-distributed via the Zcash Ecosystem Developer list by the Editors.)
+distributed via the Zcash Community Forum by the Editors.)
 
 A Standards Track ZIP may only change status from Proposed to
 Implemented once the Owner provides an associated reference
@@ -435,9 +431,9 @@ A Consensus or Standards Track ZIP becomes Final when its associated
 network upgrade or other protocol change is activated on Zcash's mainnet.
 
 A Process or Informational ZIP may change status from Draft to Active
-when it achieves rough consensus on the mailing list. Such a proposal is
+when it achieves rough consensus on the forum or PR. Such a proposal is
 said to have rough consensus if it has been open to discussion on the
-development mailing list for at least one month, and no person maintains
+forum or GitHub PR for at least one month, and no person maintains
 any unaddressed substantiated objections to it. Addressed or obstructive
 objections may be ignored/overruled by general agreement that they have
 been sufficiently addressed, but clear reasoning must be given in such
@@ -454,7 +450,7 @@ ZIP Comments
 ============
 
 Comments from the community on the ZIP should occur on the Zcash
-Ecosystem Developer list and the comment fields of the pull requests in
+Community Forum and the comment fields of the pull requests in
 any open ZIPs. Editors will use these sources to judge rough consensus.
 
 


### PR DESCRIPTION
Changes ZIP-0000 to direct discussion to community forums from ecosystem development mailing list (which will be deprecated).