### PR TITLE
Add link to ZIP 0 in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,9 @@ cryptocurrency <https://z.cash/>`__.
 Participation in the Zcash project is subject to a `Code of
 Conduct <https://github.com/zcash/zcash/blob/master/code_of_conduct.md>`__.
 
+The ZIP process is documented in `ZIP 0 <zip-0000.rst>`__.
+
+
 NU3 ZIPs for consideration
 --------------------------
 

--- a/README.template
+++ b/README.template
@@ -9,6 +9,9 @@ cryptocurrency <https://z.cash/>`__.
 Participation in the Zcash project is subject to a `Code of
 Conduct <https://github.com/zcash/zcash/blob/master/code_of_conduct.md>`__.
 
+The ZIP process is documented in `ZIP 0 <zip-0000.rst>`__.
+
+
 NU3 ZIPs for consideration
 --------------------------
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
         <!-- Title: Specifications and Zcash Improvement Proposals -->
         <p>Specifications and Zcash Improvement Proposals for the <a href="https://z.cash/">Zcash cryptocurrency</a>.</p>
         <p>Participation in the Zcash project is subject to a <a href="https://github.com/zcash/zcash/blob/master/code_of_conduct.md">Code of Conduct</a>.</p>
+        <p>The ZIP process is documented in <a href="zip-0000">ZIP 0</a>.</p>
         <section id="nu3-zips-for-consideration">
             <h2>NU3 ZIPs for consideration</h2>
             <p>This is the list of ZIPs that were under consideration for the NU3 upgrade (around ~April 2020).</p>


### PR DESCRIPTION
Currently when you land on the repo, it's not obvious that ZIP 0 contains crucial information about how the ZIP process works, and how to navigate it. Let's add a link to make that clear :)