### PR TITLE
fix a small typo in 4.8 Merkle path validity

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -4509,7 +4509,7 @@ Let $\MerkleDepth$ be $\MerkleDepthSprout$ for the \Sprout \noteCommitmentTree\s
 or $\MerkleDepthSapling$ for the \Sapling \noteCommitmentTree}. These constants are
 defined in \crossref{constants}.
 
-Similarly, let $\MerkleCRH$ be $\MerkleCRHSprout$ for \Sprout\sapling{, or $\MerkleDepthSapling$
+Similarly, let $\MerkleCRH$ be $\MerkleCRHSprout$ for \Sprout\sapling{, or $\MerkleCRHSapling$
 for \Sapling}.
 
 The following discussion applies independently to the \Sprout and \Sapling \noteCommitmentTrees.


### PR DESCRIPTION
Similarly, let MerkleCRH be MerkleCRH^{Sprout} for Sprout, or **MerkleDepth^{Sapling}** for Sapling.

becomes

Similarly, let MerkleCRH be MerkleCRH^{Sprout} for Sprout, or **MerkleCRH^{Sapling}** for Sapling.