### PR TITLE
The text surrounding the figures refers to the "Shielded Payment Address"

### DIFF
--- a/protocol/key_components.svg
+++ b/protocol/key_components.svg
@@ -351,7 +351,7 @@
          y="784.07965"
          x="176.54729"
          id="tspan3852-97"
-         sodipodi:role="line">Payment address</tspan></text>
+         sodipodi:role="line">Shielded Payment address</tspan></text>
     <rect
        ry="26.666662"
        y="936.75397"

--- a/protocol/key_components_sapling.svg
+++ b/protocol/key_components_sapling.svg
@@ -625,7 +625,7 @@
          y="512.10144"
          x="181.49651"
          id="tspan3852-97"
-         sodipodi:role="line">Payment address</tspan></text>
+         sodipodi:role="line">Shielded Payment address</tspan></text>
     <rect
        ry="26.666662"
        y="647.65533"


### PR DESCRIPTION
This commit, would make the figures' terminology agree with the text.