### PR TITLE
ZIP-####-KISZ.rst "Keep It Simple, Zcashers (KISZ): 10% ECC, 10% ZFnd"

### DIFF
--- a/zip-####-KISZ.rst
+++ b/zip-####-KISZ.rst
@@ -1,0 +1,117 @@
+::
+
+  ZIP: Unassigned 
+  Title: Keep It Simple, Zcashers (KISZ): 10% to ECC, 10% to ZFnd
+  Owners: Gordon Mohr (@gojomo on relevant forums)
+  Status: Draft
+  Category: Process
+  Created: 2019-11-14
+  License: Public Domain
+
+Terminology
+===========
+
+The terms below are to be interpreted as follows:
+
+ECC
+  Electric Coin Company, a US-based limited-liability corporation
+ZFnd
+  Zcash Foundation, a US-based non-profit corporation
+Halvening
+  a regularly-scheduled discontinuity where the rate of ZEC issuance halves, 
+  expected first in roughyl October 2020 then next in roughly October 2024
+
+
+Abstract
+========
+
+This ZIP proposes:
+
+After the 1st Zcash Halvening, when the "Founder's Reward" system-bootstrapping 
+protocol-based development funding expires, continue to direct 20% of new 
+ZEC issuance to development-related activities for ongoing  research, development, 
+innovation, and maintenance of Zcash. 
+
+Assign half of such funds to the ECC, and half to the ZFnd. Continue this 
+allocation until the 2nd Halvening. 
+
+Motivation
+==========
+
+There have been many proposals for potential allocations of Zcash block 
+rewards (ZEC inflation) after the 1st Halvening. Many cluster around similar 
+broad parameters:
+
+* 20% of block rewards for continuing development efforts;
+* provided to some combination of the Electric Coin Company (ECC), 
+  Zcash Foundation (ZFnd), and other named or to-be-determined entities;
+* conditioned on certain new allocation formulas or management practices, 
+  often involving novel entities, personnel, and feedback/deliberation 
+  processes
+
+However, no existing ZIPs explicitly propose the most simple variation 
+on this theme - one that maintains maximal continuity with prior practice. 
+This 'KISZ' ZIP aims to fill that gap. 
+
+Requirements
+============
+
+This proposal intends to be easy to describe, understand, and implement.
+
+Non-requirements
+================
+
+This proposal does not seek to propose any particular course of action 
+past the 2nd Halvening.
+
+Specification
+=============
+
+To implement this ZIP, the Zcash protocol and compatible software should:
+
+* maintain a 20% allotment of new ZEC issuance to development activities 
+  through to the 2nd Halvening event (expected around October 2024)
+* formalize a 50-50 relative allocation between the ECC and ZFnd
+* deliver these ZEC to addresses provided by the recipients, in a manner 
+  analogous to the original "Founder's Reward" consensus-encoded block 
+  rewards, or any other technically- and/or legally- preferred method 
+  agreed-to by the ECC & ZFnd
+  
+This proposal specifically refrains from adding any new conditions or 
+procedural formalities, technical or legal, on the delivery of development
+funds. 
+
+There is only the expectation that these recipients should continue the 
+stated missions, practices of transparency, and responsiveness to community 
+input that they have demonstrated thus far.
+
+
+Discussion
+==========
+
+This proposal primarily differs from similar proposals in two ways: (1) it places
+no new comditions/processes on the disbursement of ZEC development funds; (2) it 
+specifies a fixed, 50-50 division-of-funds between the ECC and ZFnd. 
+
+These differences are motivated by a desire for simplicity and continuity. This
+allocation can be implemented technically without novel institutions, processes, 
+or legal agreements. 
+
+Rather than relying on lists-of-conditions with underspecified enforcement or 
+dispute-resolution mechanisms, the adequate performance of fund recipients is
+expected due to:
+
+* aligned incentives, especially the fact that the value of all funds received 
+  over 4 years depends completely on the continued health & growth of the Zcash 
+  ecosystem
+* proven records of dedication to the Zcash project, and effective efforts on 
+  related projects, by receipient entities & personnel – even in the absence 
+  of formalized funding conditions
+  
+From original "Founder's Reward"-era development-funds, roughly 15% has been directed
+to the ZFnd. (Or, about 3 points of the full 20 points of bootstrap-funds.) However, 
+from its later start, the ZFnd has recently grown its technical, grantmaking, and
+organizational capabilities, and wide sentiment in the Zcash community, ECC, and ZFnd 
+desires the ZFnd grow to a role of equivalent or greater importance as the ECC for 
+long-term Zcash evolution. Thus this proposal specifies a 50:50 split of future 
+development funds, rather than continuing any prior proportions. 

--- a/zip-####-KISZ.rst
+++ b/zip-####-KISZ.rst
@@ -19,7 +19,7 @@ ZFnd
   Zcash Foundation, a US-based non-profit corporation
 Halvening
   a regularly-scheduled discontinuity where the rate of ZEC issuance halves, 
-  expected first in roughyl October 2020 then next in roughly October 2024
+  expected first in roughly October 2020 then next in roughly October 2024
 
 
 Abstract


### PR DESCRIPTION
ABSTRACT:

This ZIP proposes:

After the 1st Zcash Halvening, when the "Founder's Reward" system-bootstrapping 
protocol-based development funding expires, continue to direct 20% of new 
ZEC issuance to development-related activities for ongoing research, development, 
innovation, and maintenance of Zcash. 

Assign half of such funds to the ECC, and half to the ZFnd. Continue this 
allocation until the 2nd Halvening.