### PR TITLE
Fix sectioning in draft ZIP 1012

### DIFF
--- a/zip-1012.html
+++ b/zip-1012.html
@@ -150,22 +150,22 @@ Discussions-To: &lt;https://forum.zcashcommunity.com/t/dev-fund-proposal-dev-fun
                     <p>ECC and ZF will contractually commit to each other to fulfill these conditions, and the prescribed use of funds, such that substantial violation, not promptly remedied, will permit the other party to issue a modified version of Zcash node software that removes the violating party's Dev Fund slice, and use the Zcash trademark for this modified version. The slice's funds will be reassigned to ZF-MG (whose integrity is legally protected by the Restricted Fund treatment).</p>
                 </section>
             </section>
-        </section>
-        <section id="future-community-governance">
-            <h2>Future Community Governance</h2>
-            <p>Decentralized community governance is used in this proposal in the following places:</p>
-            <ol type="1">
-                <li>As advisory input to the <a href="#zf-mg-slice-zcash-foundation-for-major-grants">ZF-MG slice (Zcash Foundation, for major grants)</a>.</li>
-                <li>For changing the <a href="#funding-target-and-volatility-reserve">Funding Target and Volatility Reserve</a> (which is an incentive for ECC and ZF to <em>create</em> the voting mechanism).</li>
-                <li>In ZF's future board composition (see below).</li>
-            </ol>
-            <p>It is highly desirable to develop robust means of decentralized community voting and governance, and to integrate them into all of the above processes, by the end of 2021. ECC and ZF should place high priority on such development and its deployment, in their activities and grant selection.</p>
-        </section>
-        <section id="zf-board-composition">
-            <h2>ZF Board Composition</h2>
-            <p>ZF should formally integrate robust means of decentralized community voting into its Board of Director elections, in a way that is consistent with ZF's mission and values. ZF should lead the process for determining and implementing this, legally and technically, by the end of 2021.</p>
-            <p>Members of ZF's Board of Directors must not hold equity in ECC or have current business or employment relationships with ECC.</p>
-            <p>Grace period: members of the board who hold ECC equity (but do not have other current relationships to ECC) may dispose of their equity, or quit the Board, by 1 March 2021. (The grace period is to allow for orderly replacement, and also to allow time for ECC corporate reorganization related to Dev Fund receipt, which may affect how disposition of equity would be executed.)</p>
+            <section id="future-community-governance">
+                <h3>Future Community Governance</h3>
+                <p>Decentralized community governance is used in this proposal in the following places:</p>
+                <ol type="1">
+                    <li>As advisory input to the <a href="#zf-mg-slice-zcash-foundation-for-major-grants">ZF-MG slice (Zcash Foundation, for major grants)</a>.</li>
+                    <li>For changing the <a href="#funding-target-and-volatility-reserve">Funding Target and Volatility Reserve</a> (which is an incentive for ECC and ZF to <em>create</em> the voting mechanism).</li>
+                    <li>In ZF's future board composition (see below).</li>
+                </ol>
+                <p>It is highly desirable to develop robust means of decentralized community voting and governance, and to integrate them into all of the above processes, by the end of 2021. ECC and ZF should place high priority on such development and its deployment, in their activities and grant selection.</p>
+            </section>
+            <section id="zf-board-composition">
+                <h3>ZF Board Composition</h3>
+                <p>ZF should formally integrate robust means of decentralized community voting into its Board of Director elections, in a way that is consistent with ZF's mission and values. ZF should lead the process for determining and implementing this, legally and technically, by the end of 2021.</p>
+                <p>Members of ZF's Board of Directors must not hold equity in ECC or have current business or employment relationships with ECC.</p>
+                <p>Grace period: members of the board who hold ECC equity (but do not have other current relationships to ECC) may dispose of their equity, or quit the Board, by 1 March 2021. (The grace period is to allow for orderly replacement, and also to allow time for ECC corporate reorganization related to Dev Fund receipt, which may affect how disposition of equity would be executed.)</p>
+            </section>
         </section>
         <section id="disclosures">
             <h2>Disclosures</h2>

--- a/zip-1012.rst
+++ b/zip-1012.rst
@@ -351,7 +351,7 @@ Fund treatment).
 
 
 Future Community Governance
-===========================
+---------------------------
 
 Decentralized community governance is used in this proposal in the following
 places:
@@ -370,7 +370,7 @@ and its deployment, in their activities and grant selection.
 
 
 ZF Board Composition
-======================
+--------------------
 
 ZF should formally integrate robust means of decentralized community voting
 into its Board of Director elections, in a way that is consistent with ZF's


### PR DESCRIPTION
Fix sectioning levels in draft ZIP 1012:
"ZF Board Composition" and "Future Community Governance" should be subsections under "Specification".