### PR TITLE
Support rendering via Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,14 @@ FROM debian:latest
 
 RUN apt-get update \
         && apt-get install -y \
+        gawk \
+        biber \
+        latexmk \
+        perl \
         python3 \
-        python-pip
+        python-pip \
+        texlive-bibtex-extra \
+        texlive-generic-recommended
 
 RUN pip install rst2html5
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:latest
+
+RUN apt-get update \
+        && apt-get install -y \
+        python3 \
+        python-pip
+
+RUN pip install rst2html5
+
+WORKDIR "/zips"
+ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,15 @@
 # sudo apt-get install python-pip
 # sudo pip install rst2html5
 
-.PHONY: all
-all:
+.PHONY: all all-zips protocol
+all-zips:
 	$(MAKE) README.rst
 	$(MAKE) index.html $(addsuffix .html,$(filter-out README,$(basename $(wildcard *.rst))))
+
+all: all-zips protocol
+
+protocol:
+	$(MAKE) -C protocol
 
 index.html: README.rst
 	$(eval TITLE::=$(shell echo '$(basename $<)' | sed -r 's|zip-0{0,3}|ZIP |'): $(shell grep -E '^(\.\.)?\s*Title:' $< |sed 's|.*Title:\s*||'))

--- a/render-via-docker.sh
+++ b/render-via-docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -efuxo pipefail
+
+TAG='zcash-zips-render'
+
+docker build -t "$TAG" .
+docker run -v "$(pwd):/zips" "$TAG"


### PR DESCRIPTION
I prefer to render with this approach, so that so long as my development system has bash and docker, I can render the repository without installing the rendering toolchain on my base system.

In this branch, running `./render-via-docker.sh` claims everything is up-to-date and no changes are introduced to rendered files. However, I'm not sure if there could be edge cases for missing render dependencies, for example for math markup.