### PR TITLE
ZIP 1014: remove "audited" from "Annual audited financial report"

### DIFF
--- a/zip-1014.html
+++ b/zip-1014.html
@@ -128,7 +128,7 @@ Discussions-To: &lt;https://forum.zcashcommunity.com/t/community-sentiment-polli
                         <li>Quarterly reports, detailing future plans, execution on previous plans, and finances (balances, and spending broken down by major categories).</li>
                         <li>Monthly developer calls, or a brief report, on recent and forthcoming tasks. (Developer calls may be shared.)</li>
                         <li>Annual detailed review of the organization performance and future plans.</li>
-                        <li>Annual audited financial report (IRS Form 990, or substantially similar information).</li>
+                        <li>Annual financial report (IRS Form 990, or substantially similar information).</li>
                     </ul>
                     <p>These reports may be either organization-wide, or restricted to the income, expenses, and work associated with the receipt of Dev Fund.</p>
                     <p>It is expected that ECC, ZF, and Major Grant recipients will be focused primarily (in their attention and resources) on Zcash. Thus, they MUST promptly disclose:</p>

--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -313,8 +313,7 @@ Ongoing public reporting requirements:
 * Monthly developer calls, or a brief report, on recent and forthcoming tasks.
   (Developer calls may be shared.)
 * Annual detailed review of the organization performance and future plans.
-* Annual audited financial report (IRS Form 990, or substantially similar
-  information).
+* Annual financial report (IRS Form 990, or substantially similar information).
 
 These reports may be either organization-wide, or restricted to the income,
 expenses, and work associated with the receipt of Dev Fund.


### PR DESCRIPTION
closes #313

Signed-off-by: Daira Hopwood <daira@jacaranda.org>