### PR TITLE
Load MathJax.js over https when browser is using https

### DIFF
--- a/zip-1011.html
+++ b/zip-1011.html
@@ -3,7 +3,7 @@
 <head>
     <title>ZIP 1011: Decentralize the Dev Fee</title>
     <meta charset="utf-8" />
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="css/style.css"></head>
 <body>
     <section>


### PR DESCRIPTION
Closes #321 but I'm worried that this will be overwritten on build.