### PR TITLE
Remove Howard Loo from credits section

### DIFF
--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -6,7 +6,6 @@
           Zooko Wilcox <zooko@electriccoin.co>
   Original-Author: Eran Tromer
   Credits: Matt Luongo
-           Howard Loo
            @aristarchus
            @dontbeevil
            Daira Hopwood
@@ -363,7 +362,7 @@ Funding Streams' (ZIP 1010) [#zip-1010]_, and extensive discussions in the
 `Zcash Community Forum`_.
 
 The authors are grateful to all of the above for their excellent ideas and
-any insightful discussions, and to Howard Loo and forum users *@aristarchus*
+any insightful discussions, and to forum users *@aristarchus*
 and *@dontbeevil* for valuable initial comments on ZIP 1012.
 
 .. _Zcash Community Forum: https://forum.zcashcommunity.com/


### PR DESCRIPTION
I request that my name please be removed from this ZIP. I do not support it and as a member of the Community Panel I voted against it. I merely provided @tromer with some brief feedback one evening about the copyright portions of the ZIP. I did give permission for my name to be mentioned publicly as having provided feedback, but I did not realize that my name would be part of the actual ZIP text. Thank you for considering my request.