### PR TITLE
Update the funding stream start and end heights and addresses for the Dev Fund on Testnet, and set the Canopy Testnet activation height

### DIFF
--- a/zip-0214.html
+++ b/zip-0214.html
@@ -83,8 +83,48 @@ Discussions-To: &lt;https://forum.zcashcommunity.com/t/community-sentiment-polli
                 </table>
             </blockquote>
             <p>As specified in <a id="id12" class="footnote_reference" href="#zip-0207">9</a>, a funding stream is active for a span of blocks that includes the block at its start height, but excludes the block at its end height.</p>
-            <p>The funding streams defined for Testnet are identical except that the start height of each stream is the activation height of Canopy on Testnet, i.e. TODO.</p>
-            <p>Note: on Testnet, the activation height of Canopy will be before the first halving. Therefore, the consequence of the above rules for Testnet is that the amount sent to each Zcash Development Fund recipient address will initially (before Testnet block height 1046400) be double the number of currency units as the corresponding initial amount on Mainnet. This reduces to the same number of currency units as on Mainnet, from Testnet block heights 1046400 (inclusive) to 2726400 (exclusive).</p>
+            <p>The following funding streams are defined for Testnet:</p>
+            <blockquote>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Stream</th>
+                            <th>Numerator</th>
+                            <th>Denominator</th>
+                            <th>Start height</th>
+                            <th>End height</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>FS_ZIP214_ECC</code></td>
+                            <td>7</td>
+                            <td>100</td>
+                            <td>1028500</td>
+                            <td>2796000</td>
+                        </tr>
+                        <tr>
+                            <td><code>FS_ZIP214_ZF</code></td>
+                            <td>5</td>
+                            <td>100</td>
+                            <td>1028500</td>
+                            <td>2796000</td>
+                        </tr>
+                        <tr>
+                            <td><code>FS_ZIP214_MG</code></td>
+                            <td>8</td>
+                            <td>100</td>
+                            <td>1028500</td>
+                            <td>2796000</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </blockquote>
+            <p>Notes:</p>
+            <ul>
+                <li>The block heights of halvings are different between Testnet and Mainnet, as a result of different activation heights for the Blossom network upgrade (which changed the block target spacing). The end height of these funding streams corresponds to the second halving on each network.</li>
+                <li>On Testnet, the activation height of Canopy will be before the first halving. Therefore, the consequence of the above rules for Testnet is that the amount sent to each Zcash Development Fund recipient address will initially (before Testnet block height 1116000) be double the number of currency units as the corresponding initial amount on Mainnet. This reduces to the same number of currency units as on Mainnet, from Testnet block heights 1116000 (inclusive) to 2796000 (exclusive).</li>
+            </ul>
             <section id="dev-fund-recipient-addresses"><h3><span class="section-heading">Dev Fund Recipient Addresses</span><span class="section-anchor"> <a rel="bookmark" href="#dev-fund-recipient-addresses"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>For each of Testnet and Mainnet, before deploying this ZIP in a node implementation with the activation height set for that network, each of the parties (ECC and ZF) SHALL generate sequences of recipient addresses to be used for each stream in each funding period:</p>
                 <ul>
@@ -101,25 +141,76 @@ Discussions-To: &lt;https://forum.zcashcommunity.com/t/community-sentiment-polli
                 </section>
             </section>
             <section id="mainnet-recipient-addresses"><h3><span class="section-heading">Mainnet Recipient Addresses</span><span class="section-anchor"> <a rel="bookmark" href="#mainnet-recipient-addresses"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <blockquote>
-                    <dl>
-                        <dt>FS_ECC_Addresses[0..47] = [</dt>
-                        <dd>"TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO" ]</dd>
-                        <dt>FS_ZF_Addresses[0..47] = [</dt>
-                        <dd>"TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO" ]</dd>
-                        <dt>FS_MG_Addresses[0..47] = [</dt>
-                        <dd>"TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO", "TODO" ]</dd>
-                    </dl>
-                </blockquote>
+                <pre>FS_ECC_Addresses[0..47] = TODO
+
+FS_ZF_Addresses[0..47] = TODO
+
+FS_MG_Addresses[0..47] = TODO</pre>
             </section>
             <section id="testnet-recipient-addresses"><h3><span class="section-heading">Testnet Recipient Addresses</span><span class="section-anchor"> <a rel="bookmark" href="#testnet-recipient-addresses"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>TODO</p>
+                <pre>FS_ECC_Addresses[0..50] = [
+  "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+  "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+  "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+  "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+  "t2NNHrgPpE388atmWSF4DxAb3xAoW5Yp45M",
+  "t2VMN28itPyMeMHBEd9Z1hm6YLkQcGA1Wwe",
+  "t2CHa1TtdfUV8UYhNm7oxbzRyfr8616BYh2",
+  "t2F77xtr28U96Z2bC53ZEdTnQSUAyDuoa67",
+  "t2ARrzhbgcpoVBDPivUuj6PzXzDkTBPqfcT",
+  "t278aQ8XbvFR15mecRguiJDQQVRNnkU8kJw",
+  "t2Dp1BGnZsrTXZoEWLyjHmg3EPvmwBnPDGB",
+  "t2KzeqXgf4ju33hiSqCuKDb8iHjPCjMq9iL",
+  "t2Nyxqv1BiWY1eUSiuxVw36oveawYuo18tr",
+  "t2DKFk5JRsVoiuinK8Ti6eM4Yp7v8BbfTyH",
+  "t2CUaBca4k1x36SC4q8Nc8eBoqkMpF3CaLg",
+  "t296SiKL7L5wvFmEdMxVLz1oYgd6fTfcbZj",
+  "t29fBCFbhgsjL3XYEZ1yk1TUh7eTusB6dPg",
+  "t2FGofLJXa419A76Gpf5ncxQB4gQXiQMXjK",
+  "t2ExfrnRVnRiXDvxerQ8nZbcUQvNvAJA6Qu",
+  "t28JUffLp47eKPRHKvwSPzX27i9ow8LSXHx",
+  "t2JXWPtrtyL861rFWMZVtm3yfgxAf4H7uPA",
+  "t2QdgbJoWfYHgyvEDEZBjHmgkr9yNJff3Hi",
+  "t2QW43nkco8r32ZGRN6iw6eSzyDjkMwCV3n",
+  "t2DgYDXMJTYLwNcxighQ9RCgPxMVATRcUdC",
+  "t2Bop7dg33HGZx3wunnQzi2R2ntfpjuti3M",
+  "t2HVeEwovcLq9RstAbYkqngXNEsCe2vjJh9",
+  "t2HxbP5keQSx7p592zWQ5bJ5GrMmGDsV2Xa",
+  "t2TJzUg2matao3mztBRJoWnJY6ekUau6tPD",
+  "t29pMzxmo6wod25YhswcjKv3AFRNiBZHuhj",
+  "t2QBQMRiJKYjshJpE6RhbF7GLo51yE6d4wZ",
+  "t2F5RqnqguzZeiLtYHFx4yYfy6pDnut7tw5",
+  "t2CHvyZANE7XCtg8AhZnrcHCC7Ys1jJhK13",
+  "t2BRzpMdrGWZJ2upsaNQv6fSbkbTy7EitLo",
+  "t2BFixHGQMAWDY67LyTN514xRAB94iEjXp3",
+  "t2Uvz1iVPzBEWfQBH1p7NZJsFhD74tKaG8V",
+  "t2CmFDj5q6rJSRZeHf1SdrowinyMNcj438n",
+  "t2ErNvWEReTfPDBaNizjMPVssz66aVZh1hZ",
+  "t2GeJQ8wBUiHKDVzVM5ZtKfY5reCg7CnASs",
+  "t2L2eFtkKv1G6j55kLytKXTGuir4raAy3yr",
+  "t2EK2b87dpPazb7VvmEGc8iR6SJ289RywGL",
+  "t2DJ7RKeZJxdA4nZn8hRGXE8NUyTzjujph9",
+  "t2K1pXo4eByuWpKLkssyMLe8QKUbxnfFC3H",
+  "t2TB4mbSpuAcCWkH94Leb27FnRxo16AEHDg",
+  "t2Phx4gVL4YRnNsH3jM1M7jE4Fo329E66Na",
+  "t2VQZGmeNomN8c3USefeLL9nmU6M8x8CVzC",
+  "t2RicCvTVTY5y9JkreSRv3Xs8q2K67YxHLi",
+  "t2JrSLxTGc8wtPDe9hwbaeUjCrCfc4iZnDD",
+  "t2Uh9Au1PDDSw117sAbGivKREkmMxVC5tZo",
+  "t2FDwoJKLeEBMTy3oP7RLQ1Fihhvz49a3Bv",
+  "t2FY18mrgtb7QLeHA8ShnxLXuW8cNQ2n1v8",
+  "t2L15TkDYum7dnQRBqfvWdRe8Yw3jVy9z7g"
+]
+
+FS_ZF_Addresses[0..50] = ["t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v"] * 51
+
+FS_MG_Addresses[0..50] = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"] * 51</pre>
+                <p>(i.e. <code>FS_ZF_Addresses</code> and <code>FS_MG_Addresses</code> each consist of 51 repetitions of the same address).</p>
             </section>
         </section>
         <section id="rationale"><h2><span class="section-heading">Rationale</span><span class="section-anchor"> <a rel="bookmark" href="#rationale"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The rationale for ZF generating the addresses for the <code>ZF_MG</code> funding stream is that ZF is the financial recipient of the <strong>MG slice</strong> as specified in ZIP 1014. <a id="id15" class="footnote_reference" href="#zip-1014">12</a></p>
             <p>Generation of recipient addresses for Testnet is specified to be done by the same parties as on Mainnet, in order to allow practicing each party's security procedures.</p>
-            <p>Since Testnet is ahead of Mainnet in terms of block height (by ~77000 blocks at the time of writing, which is the equivalent of ~67 days at the post-Blossom block target spacing), the activation height and the start heights of the funding streams could have also been set to 1046400 on Testnet. However, 67 days is arguably too short a testing period, and the block rate on Testnet is less predictable than on Mainnet.</p>
             <p>It was judged to be unnecessary to have a mechanism to update funding stream definitions (in case of security breach or changes to direct grant recipients) other than at network upgrades.</p>
         </section>
         <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zip-0214.rst
+++ b/zip-0214.rst
@@ -114,15 +114,28 @@ As specified in [#zip-0207]_, a funding stream is active for a span of blocks
 that includes the block at its start height, but excludes the block at its end
 height.
 
-The funding streams defined for Testnet are identical except that the start height
-of each stream is the activation height of Canopy on Testnet, i.e. TODO.
+The following funding streams are defined for Testnet:
 
-Note: on Testnet, the activation height of Canopy will be before the first halving.
-Therefore, the consequence of the above rules for Testnet is that the amount sent
-to each Zcash Development Fund recipient address will initially (before Testnet
-block height 1046400) be double the number of currency units as the corresponding
-initial amount on Mainnet. This reduces to the same number of currency units as on
-Mainnet, from Testnet block heights 1046400 (inclusive) to 2726400 (exclusive).
+  ================= =========== ============= ============== ============
+        Stream       Numerator   Denominator   Start height   End height
+  ================= =========== ============= ============== ============
+  ``FS_ZIP214_ECC``      7           100          1028500       2796000
+  ``FS_ZIP214_ZF``       5           100          1028500       2796000
+  ``FS_ZIP214_MG``       8           100          1028500       2796000
+  ================= =========== ============= ============== ============
+
+Notes:
+
+* The block heights of halvings are different between Testnet and Mainnet, as a
+  result of different activation heights for the Blossom network upgrade (which
+  changed the block target spacing). The end height of these funding streams
+  corresponds to the second halving on each network.
+* On Testnet, the activation height of Canopy will be before the first halving.
+  Therefore, the consequence of the above rules for Testnet is that the amount sent
+  to each Zcash Development Fund recipient address will initially (before Testnet
+  block height 1116000) be double the number of currency units as the corresponding
+  initial amount on Mainnet. This reduces to the same number of currency units as on
+  Mainnet, from Testnet block heights 1116000 (inclusive) to 2796000 (exclusive).
 
 
 Dev Fund Recipient Addresses
@@ -168,160 +181,80 @@ grantees, a separate ZIP SHOULD be published specifying those modifications.
 Mainnet Recipient Addresses
 ---------------------------
 
-  FS_ECC_Addresses[0..47] = [
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO" ]
+::
 
-  FS_ZF_Addresses[0..47] = [
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO" ]
+  FS_ECC_Addresses[0..47] = TODO
 
-  FS_MG_Addresses[0..47] = [
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO",
-    "TODO" ]
+  FS_ZF_Addresses[0..47] = TODO
+
+  FS_MG_Addresses[0..47] = TODO
+
 
 Testnet Recipient Addresses
 ---------------------------
 
-TODO
+::
+
+  FS_ECC_Addresses[0..50] = [
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t26ovBdKAJLtrvBsE2QGF4nqBkEuptuPFZz",
+    "t2NNHrgPpE388atmWSF4DxAb3xAoW5Yp45M",
+    "t2VMN28itPyMeMHBEd9Z1hm6YLkQcGA1Wwe",
+    "t2CHa1TtdfUV8UYhNm7oxbzRyfr8616BYh2",
+    "t2F77xtr28U96Z2bC53ZEdTnQSUAyDuoa67",
+    "t2ARrzhbgcpoVBDPivUuj6PzXzDkTBPqfcT",
+    "t278aQ8XbvFR15mecRguiJDQQVRNnkU8kJw",
+    "t2Dp1BGnZsrTXZoEWLyjHmg3EPvmwBnPDGB",
+    "t2KzeqXgf4ju33hiSqCuKDb8iHjPCjMq9iL",
+    "t2Nyxqv1BiWY1eUSiuxVw36oveawYuo18tr",
+    "t2DKFk5JRsVoiuinK8Ti6eM4Yp7v8BbfTyH",
+    "t2CUaBca4k1x36SC4q8Nc8eBoqkMpF3CaLg",
+    "t296SiKL7L5wvFmEdMxVLz1oYgd6fTfcbZj",
+    "t29fBCFbhgsjL3XYEZ1yk1TUh7eTusB6dPg",
+    "t2FGofLJXa419A76Gpf5ncxQB4gQXiQMXjK",
+    "t2ExfrnRVnRiXDvxerQ8nZbcUQvNvAJA6Qu",
+    "t28JUffLp47eKPRHKvwSPzX27i9ow8LSXHx",
+    "t2JXWPtrtyL861rFWMZVtm3yfgxAf4H7uPA",
+    "t2QdgbJoWfYHgyvEDEZBjHmgkr9yNJff3Hi",
+    "t2QW43nkco8r32ZGRN6iw6eSzyDjkMwCV3n",
+    "t2DgYDXMJTYLwNcxighQ9RCgPxMVATRcUdC",
+    "t2Bop7dg33HGZx3wunnQzi2R2ntfpjuti3M",
+    "t2HVeEwovcLq9RstAbYkqngXNEsCe2vjJh9",
+    "t2HxbP5keQSx7p592zWQ5bJ5GrMmGDsV2Xa",
+    "t2TJzUg2matao3mztBRJoWnJY6ekUau6tPD",
+    "t29pMzxmo6wod25YhswcjKv3AFRNiBZHuhj",
+    "t2QBQMRiJKYjshJpE6RhbF7GLo51yE6d4wZ",
+    "t2F5RqnqguzZeiLtYHFx4yYfy6pDnut7tw5",
+    "t2CHvyZANE7XCtg8AhZnrcHCC7Ys1jJhK13",
+    "t2BRzpMdrGWZJ2upsaNQv6fSbkbTy7EitLo",
+    "t2BFixHGQMAWDY67LyTN514xRAB94iEjXp3",
+    "t2Uvz1iVPzBEWfQBH1p7NZJsFhD74tKaG8V",
+    "t2CmFDj5q6rJSRZeHf1SdrowinyMNcj438n",
+    "t2ErNvWEReTfPDBaNizjMPVssz66aVZh1hZ",
+    "t2GeJQ8wBUiHKDVzVM5ZtKfY5reCg7CnASs",
+    "t2L2eFtkKv1G6j55kLytKXTGuir4raAy3yr",
+    "t2EK2b87dpPazb7VvmEGc8iR6SJ289RywGL",
+    "t2DJ7RKeZJxdA4nZn8hRGXE8NUyTzjujph9",
+    "t2K1pXo4eByuWpKLkssyMLe8QKUbxnfFC3H",
+    "t2TB4mbSpuAcCWkH94Leb27FnRxo16AEHDg",
+    "t2Phx4gVL4YRnNsH3jM1M7jE4Fo329E66Na",
+    "t2VQZGmeNomN8c3USefeLL9nmU6M8x8CVzC",
+    "t2RicCvTVTY5y9JkreSRv3Xs8q2K67YxHLi",
+    "t2JrSLxTGc8wtPDe9hwbaeUjCrCfc4iZnDD",
+    "t2Uh9Au1PDDSw117sAbGivKREkmMxVC5tZo",
+    "t2FDwoJKLeEBMTy3oP7RLQ1Fihhvz49a3Bv",
+    "t2FY18mrgtb7QLeHA8ShnxLXuW8cNQ2n1v8",
+    "t2L15TkDYum7dnQRBqfvWdRe8Yw3jVy9z7g"
+  ]
+
+  FS_ZF_Addresses[0..50] = ["t27eWDgjFYJGVXmzrXeVjnb5J3uXDM9xH9v"] * 51
+
+  FS_MG_Addresses[0..50] = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"] * 51
+
+(i.e. ``FS_ZF_Addresses`` and ``FS_MG_Addresses`` each consist of 51 repetitions
+of the same address).
 
 
 Rationale
@@ -334,13 +267,6 @@ in ZIP 1014. [#zip-1014]_
 Generation of recipient addresses for Testnet is specified to be done by the
 same parties as on Mainnet, in order to allow practicing each party's security
 procedures.
-
-Since Testnet is ahead of Mainnet in terms of block height (by ~77000 blocks
-at the time of writing, which is the equivalent of ~67 days at the post-Blossom
-block target spacing), the activation height and the start heights of the
-funding streams could have also been set to 1046400 on Testnet. However,
-67 days is arguably too short a testing period, and the block rate on Testnet
-is less predictable than on Mainnet.
 
 It was judged to be unnecessary to have a mechanism to update funding stream
 definitions (in case of security breach or changes to direct grant recipients)

--- a/zip-0251.html
+++ b/zip-0251.html
@@ -42,7 +42,7 @@ License: MIT</pre>
                     <dd><code>0xE9FF75A6</code></dd>
                     <dt>ACTIVATION_HEIGHT (Canopy)</dt>
                     <dd>
-                        <p>Testnet: TODO</p>
+                        <p>Testnet: 1028500</p>
                         <p>Mainnet: 1046400</p>
                     </dd>
                 </dl>

--- a/zip-0251.rst
+++ b/zip-0251.rst
@@ -60,7 +60,7 @@ CONSENSUS_BRANCH_ID
 
 
 ACTIVATION_HEIGHT (Canopy)
-  Testnet: TODO
+  Testnet: 1028500
 
   Mainnet: 1046400
 


### PR DESCRIPTION
The old heights were incorrect because the different activation heights for Blossom
on Mainnet and Testnet had not been taken into account. Also, Testnet requires 3 extra
addresses for each stream, to account for the start height being before the first halving.

This also sets the Canopy Testnet activation height in ZIP 251.

Signed-off-by: Daira Hopwood <daira@jacaranda.org>