### PR TITLE
Fix invalid ZIP-0321 sample URL.

### DIFF
--- a/zip-0321.html
+++ b/zip-0321.html
@@ -92,8 +92,8 @@ License: MIT</pre>
                 <section id="valid-examples"><h4><span class="section-heading">Valid examples</span><span class="section-anchor"> <a rel="bookmark" href="#valid-examples"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <pre>zcash:ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez?amount=1&amp;memo=VGhpcyBpcyBhIHNpbXBsZSBtZW1vLg&amp;message=Thank%20you%20for%20your%20purchase</pre>
                     <p>A valid payment request for a payment of 1 ZEC to a single shielded address, with a base64url-encoded memo and a message for display by the wallet.</p>
-                    <pre>zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amp;amount=123.456&amp;memo=eyAia2V5IjogIlRoaXMgaXMgYSBKU09OLXN0cnVjdHVyZWQgbWVtby4iIH0&amp;address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amp;amount.1=0.789&amp;memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok</pre>
-                    <p>A valid payment request with one transparent and one shielded recipient address, with encoded JSON and Unicode memos.</p>
+                    <pre>zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amp;amount=123.456&amp;address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amp;amount.1=0.789&amp;memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok</pre>
+                    <p>A valid payment request with one transparent and one shielded recipient address, with an encoded Unicode memo for the shielded recipient.</p>
                 </section>
                 <section id="invalid-examples"><h4><span class="section-heading">Invalid Examples</span><span class="section-anchor"> <a rel="bookmark" href="#invalid-examples"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <pre>zcash:?amount=3491405.05201255&amp;address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amp;amount.1=5740296.87793245</pre>

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -180,10 +180,10 @@ with a base64url-encoded memo and a message for display by the wallet.
 
 ::
 
-  zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amount=123.456&memo=eyAia2V5IjogIlRoaXMgaXMgYSBKU09OLXN0cnVjdHVyZWQgbWVtby4iIH0&address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amount.1=0.789&memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok
+  zcash:?address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU&amount=123.456&address.1=ztestsapling10yy2ex5dcqkclhc7z7yrnjq2z6feyjad56ptwlfgmy77dmaqqrl9gyhprdx59qgmsnyfska2kez&amount.1=0.789&memo.1=VGhpcyBpcyBhIHVuaWNvZGUgbWVtbyDinKjwn6aE8J-PhvCfjok
 
 A valid payment request with one transparent and one shielded recipient address,
-with encoded JSON and Unicode memos.
+with an encoded Unicode memo for the shielded recipient.
 
 Invalid Examples
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This sample URI inadvertently contained a memo at the paramindex
for a transparent address.