### PR TITLE
Add a missing floor in the MeanTarget calculation

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -9803,7 +9803,7 @@ Define:
   \item $\ActualTimespanBounded(\BlockHeight \typecolon \Nat) := \bound{\MinActualTimespan\blossom{(\BlockHeight)}}{\MaxActualTimespan\blossom{(\BlockHeight)}}(\ActualTimespanDamped(\BlockHeight))$
   \item $\MeanTarget(\BlockHeight \typecolon \Nat) := \!\begin{cases}
           \PoWLimit, \hspace{16em}\text{if } \BlockHeight \leq \PoWAveragingWindow \\
-          \mean(\listcomp{\!\ToTarget(\nBits(i)\kern-0.1em) \for i \from \BlockHeight\!-\!\PoWAveragingWindow \upto \BlockHeight\!-\!1\!}),\\
+          \floor{\mean(\listcomp{\!\ToTarget(\nBits(i)\kern-0.1em) \for i \from \BlockHeight\!-\!\PoWAveragingWindow \upto \BlockHeight\!-\!1\!})},\\
                      \hspace{20.7em}\text{otherwise.}
         \end{cases}$
 \end{formulae}


### PR DESCRIPTION
zcashd implicitly truncates the MeanTarget value before and after dividing it by the AveragingWindowTimespan, but only one of these truncations is currently captured in the specification.

This change makes it clear that the calculation is:
`floor(floor(sum(....)/PoWAveragingWindow)/AveragingWindowTimespan)`
Rather than:
`floor(sum(...)/(PoWAveragingWindow * AveragingWindowTimespan))`.

For the relevant code, see:
https://github.com/zcash/zcash/blob/091f5d78162e76eabb3a59840e9e32febb3f0fae/src/pow.cpp#L54