### PR TITLE
Add "funding stream outputs" to the "no transparent outputs" rule

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -9186,7 +9186,7 @@ $\versionField \geq 4$ and $\nShieldedSpend + \nShieldedOutput > 0$.
   \saplingonwarditem{At least one of \txOutCount, \nShieldedOutput, and \nJoinSplit{} \MUST be nonzero.}
   \item A \transaction with one or more \transparent inputs from \coinbaseTransactions{} \MUST have no
         \transparent outputs (i.e.\ \txOutCount{} \MUST be $0$). Inputs from
-        \coinbaseTransactions include \foundersReward outputs.
+        \coinbaseTransactions include \foundersReward outputs \canopy{and \transparent \fundingStream outputs}.
   \item If $\versionField \geq 2$ and $\nJoinSplit > 0$, then:
         \begin{itemize}
           \item \joinSplitPubKey{} \MUST be a valid encoding (see \crossref{concretejssig}) of


### PR DESCRIPTION
The "no transparent outputs" rule also applies to funding stream transparent inputs.