### PR TITLE
Proposal to remove Sprout fields from the V5 transaction format.

### DIFF
--- a/zip-0225.html
+++ b/zip-0225.html
@@ -21,7 +21,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This proposal defines an update to the Zcash peer-to-peer transaction format to include support for data elements required to support the Orchard protocol <a id="id2" class="footnote_reference" href="#protocol-orchard">2</a>. The new transaction format defines well-bounded regions of the serialized form to serve each of the existing pools of funds, and adds and describes a new region containing Orchard-specific elements.</p>
-            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="id3" class="footnote_reference" href="#zip-0244">6</a>.</p>
+            <p>This ZIP also depends upon and defines modifications to the computation of the values <strong>TxId Digest</strong>, <strong>Signature Digest</strong>, and <strong>Authorizing Data Commitment</strong> defined by ZIP 244 <a id="id3" class="footnote_reference" href="#zip-0244">7</a>.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The new Orchard shielded pool requires serialized data elements that are distinct from any previous Zcash transaction. In addition, with the activation of ZIP 244, the serialized transaction format will no longer be consensus-critical. It makes sense at this point to define a format that can readily accommodate future extension in a systematic fashion, where elements required for support for a given pool are kept separate.</p>
@@ -111,33 +111,6 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
                             <td><code>tx_out</code></td>
                             <td><code>tx_out</code></td>
                             <td>Transparent outputs, encoded as in Bitcoin.</td>
-                        </tr>
-                        <tr>
-                            <td colspan="4"><strong>Sprout Transaction Fields</strong></td>
-                        </tr>
-                        <tr>
-                            <td><code>varies</code></td>
-                            <td><code>nJoinSplit</code></td>
-                            <td><code>compactSize</code></td>
-                            <td>The number of JoinSplit descriptions in <code>vJoinSplit</code>.</td>
-                        </tr>
-                        <tr>
-                            <td><code>1698 * nJoinSplit</code></td>
-                            <td><code>vJoinSplit</code></td>
-                            <td><code>JSDescriptionGroth16[nJoinSplit]</code></td>
-                            <td>A sequence of JoinSplit descrptions using Groth16 proofs, encoded per §7.2 ‘JoinSplit Description Encoding and Consensus’.</td>
-                        </tr>
-                        <tr>
-                            <td><code>32</code></td>
-                            <td><code>joinSplitPubKey</code></td>
-                            <td><code>byte[32]</code></td>
-                            <td>An encoding of a JoinSplitSig public validating key.</td>
-                        </tr>
-                        <tr>
-                            <td><code>64</code></td>
-                            <td><code>joinSplitSig</code></td>
-                            <td><code>byte[64]</code></td>
-                            <td>A signature on a prefix of the transaction encoding, to be verfied using joinSplitPubKey as specified in §4.11 ‘Non-malleability (Sprout)’.</td>
                         </tr>
                         <tr>
                             <td colspan="4"><strong>Sapling Transaction Fields</strong></td>
@@ -275,13 +248,12 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
                 <ul>
                     <li>The <code>valueBalanceSapling</code>, <code>anchorSapling</code>, and <code>bindingSigSapling</code> fields are present if and only if <code>nSpendsSapling + nOutputsSapling &gt; 0</code>. If <code>valueBalanceSapling</code> is not present, then <code>valueBalanceSapling</code> is defined to be 0.</li>
                     <li>The <code>valueBalanceOrchard</code>, <code>anchorOrchard</code>, and <code>bindingSigOrchard</code> fields are present if and only if <code>nActionsOrchard &gt; 0</code>. If <code>valueBalanceOrchard</code> is not present, then <code>valueBalanceOrchard</code> is defined to be 0.</li>
-                    <li>The <code>joinSplitPubKey</code> and <code>joinSplitSig</code> fields are present if and only if <code>nJoinSplit &gt; 0</code>.</li>
                     <li>The elements of <code>vSpendProofsSapling</code> and <code>vSpendAuthSigsSapling</code> have a 1:1 correspondence to the elements of <code>vSpendsSapling</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>SpendDescriptionV5</code> at the same index.</li>
                     <li>The elements of <code>vOutputProofsSapling</code> have a 1:1 correspondence to the elements of <code>vOutputsSapling</code> and MUST be ordered such that the proof at a given index corresponds to the <code>OutputDescriptionV5</code> at the same index.</li>
                     <li>The proofs aggregated in <code>proofsOrchard</code>, and the elements of <code>vSpendAuthSigsOrchard</code>, each have a 1:1 correspondence to the elements of <code>vActionsOrchard</code> and MUST be ordered such that the proof or signature at a given index corresponds to the <code>OrchardAction</code> at the same index.</li>
                     <li>For coinbase transactions, the <code>spendsEnabledOrchard</code> bit MUST be set to <code>0</code>.</li>
                 </ul>
-                <p>The encodings of <code>tx_in</code>, <code>tx_out</code>, and <code>JSDescriptionGroth16</code>, are as in a version 4 transaction (i.e. unchanged from Canopy). The encodings of <code>SpendDescriptionV5</code>, <code>OutputDescriptionV5</code> and <code>OrchardAction</code> are described below. The encoding of Sapling Spends and Outputs has changed relative to prior versions in order to better separate data that describe the effects of the transaction from the proofs of and commitments to those effects, and for symmetry with this separation in the Orchard-related parts of the transaction format.</p>
+                <p>The encodings of <code>tx_in</code>, and <code>tx_out</code> are as in a version 4 transaction (i.e. unchanged from Canopy). The encodings of <code>SpendDescriptionV5</code>, <code>OutputDescriptionV5</code> and <code>OrchardAction</code> are described below. The encoding of Sapling Spends and Outputs has changed relative to prior versions in order to better separate data that describe the effects of the transaction from the proofs of and commitments to those effects, and for symmetry with this separation in the Orchard-related parts of the transaction format.</p>
             </section>
             <section id="sapling-spend-description-spenddescriptionv5"><h3><span class="section-heading">Sapling Spend Description (<code>SpendDescriptionV5</code>)</span><span class="section-anchor"> <a rel="bookmark" href="#sapling-spend-description-spenddescriptionv5"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <table>
@@ -420,59 +392,57 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
             </section>
             <section id="modifications-to-zip-244"><h3><span class="section-heading">Modifications to ZIP 244</span><span class="section-anchor"> <a rel="bookmark" href="#modifications-to-zip-244"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <section id="txid-digest"><h4><span class="section-heading">TxId Digest</span><span class="section-anchor"> <a rel="bookmark" href="#txid-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The tree of hashes defined by ZIP 244 <a id="id7" class="footnote_reference" href="#zip-0244">6</a> is re-structured to include a new branch for Orchard hashes. The <code>orchard_digest</code> branch is the only new addition to the tree; <code>header_digest</code>, <code>transparent_digest</code>, <code>sprout_digest</code>, and <code>sapling_digest</code> are as in ZIP 244:</p>
+                    <p>The tree of hashes defined by ZIP 244 <a id="id7" class="footnote_reference" href="#zip-0244">7</a> is re-structured to include a new branch for Orchard hashes. The <code>orchard_digest</code> branch is the only new addition to the tree; <code>header_digest</code>, <code>transparent_digest</code>, <code>sprout_digest</code>, and <code>sapling_digest</code> are as in ZIP 244:</p>
                     <pre>txid_digest
 ├── header_digest
 ├── transparent_digest
-├── sprout_digest
 ├── sapling_digest
 └── orchard_digest</pre>
                     <section id="id8"><h5><span class="section-heading">txid_digest</span><span class="section-anchor"> <a rel="bookmark" href="#id8"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>The top hash of the <code>txid_digest</code> tree is modified from the ZIP 244 structure to be a BLAKE2b-256 hash of the following values</p>
                         <pre>T.1: header_digest      (32-byte hash output)
 T.2: transparent_digest (32-byte hash output)
-T.3: sprout_digest      (32-byte hash output)
-T.4: sapling_digest     (32-byte hash output)
-T.5: orchard_digest     (32-byte hash output)</pre>
+T.3: sapling_digest     (32-byte hash output)
+T.4: orchard_digest     (32-byte hash output)</pre>
                         <p>The personalization field of this hash is unmodified from ZIP 244.</p>
                     </section>
                     <section id="orchard-digest"><h5><span class="section-heading">2: <code>orchard_digest</code></span><span class="section-anchor"> <a rel="bookmark" href="#orchard-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>A BLAKE2b-256 hash of the following values</p>
-                        <pre>T.5c: anchorOrchard                       (32 bytes)
-T.5b: orchard_actions_compact_digest      (32-byte hash output)
-T.5c: orchard_actions_memos_digest        (32-byte hash output)
-T.5d: orchard_actions_noncompact_digest   (32-byte hash output)
-T.5e: valueBalanceOrchard                 (64-bit signed little-endian)</pre>
+                        <pre>T.4c: anchorOrchard                       (32 bytes)
+T.4b: orchard_actions_compact_digest      (32-byte hash output)
+T.4c: orchard_actions_memos_digest        (32-byte hash output)
+T.4d: orchard_actions_noncompact_digest   (32-byte hash output)
+T.4e: valueBalanceOrchard                 (64-bit signed little-endian)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrchardHash"</pre>
                     </section>
-                    <section id="t-5b-orchard-actions-compact-digest"><h5><span class="section-heading">T.5b: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5b-orchard-actions-compact-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="id9" class="footnote_reference" href="#zip-0307">7</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
-                        <pre>T.5b.i  : nullifier            (field encoding bytes)
-T.5b.ii : cmx                  (field encoding bytes)
-T.5b.iii: ephemeralKey         (field encoding bytes)
-T.5b.iv : encCiphertext[..52]  (First 52 bytes of field encoding)</pre>
+                    <section id="t-4b-orchard-actions-compact-digest"><h5><span class="section-heading">T.4b: orchard_actions_compact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4b-orchard-actions-compact-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                        <p>A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in an updated version of the ZIP-307 <a id="id9" class="footnote_reference" href="#zip-0307">8</a> <code>CompactBlock</code> format for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <pre>T.4b.i  : nullifier            (field encoding bytes)
+T.4b.ii : cmx                  (field encoding bytes)
+T.4b.iii: ephemeralKey         (field encoding bytes)
+T.4b.iv : encCiphertext[..52]  (First 52 bytes of field encoding)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcOutCHash"</pre>
                     </section>
-                    <section id="t-5c-orchard-actions-memos-digest"><h5><span class="section-heading">T.5c: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5c-orchard-actions-memos-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                    <section id="t-4c-orchard-actions-memos-digest"><h5><span class="section-heading">T.4c: orchard_actions_memos_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4c-orchard-actions-memos-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
-                        <pre>T.5c.i: encCiphertext[52..564] (contents of the encrypted memo field)</pre>
+                        <pre>T.4c.i: encCiphertext[52..564] (contents of the encrypted memo field)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcOutMHash"</pre>
                     </section>
-                    <section id="t-5d-orchard-actions-noncompact-digest"><h5><span class="section-heading">T.5d: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-5d-orchard-actions-noncompact-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="id10" class="footnote_reference" href="#zip-0307">7</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
-                        <pre>T.5d.i  : cv                    (field encoding bytes)
-T.5d.ii : rk                    (field encoding bytes)
-T.5d.iii: encCiphertext[564..]  (post-memo suffix of field encoding)
-T.5d.iv : outCiphertext         (field encoding bytes)</pre>
+                    <section id="t-4d-orchard-actions-noncompact-digest"><h5><span class="section-heading">T.4d: orchard_actions_noncompact_digest</span><span class="section-anchor"> <a rel="bookmark" href="#t-4d-orchard-actions-noncompact-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                        <p>A BLAKE2b-256 hash of the remaining subset of Orchard Action information <strong>not</strong> intended for inclusion in an updated version of the the ZIP 307 <a id="id10" class="footnote_reference" href="#zip-0307">8</a> <code>CompactBlock</code> format, for all Orchard Actions belonging to the transaction. For each Action, the following elements are included in the hash:</p>
+                        <pre>T.4d.i  : cv                    (field encoding bytes)
+T.4d.ii : rk                    (field encoding bytes)
+T.4d.iii: encCiphertext[564..]  (post-memo suffix of field encoding)
+T.4d.iv : outCiphertext         (field encoding bytes)</pre>
                         <p>The personalization field of this hash is set to:</p>
                         <pre>"ZTxIdOrcOutNHash"</pre>
                     </section>
                 </section>
                 <section id="signature-digest"><h4><span class="section-heading">Signature Digest</span><span class="section-anchor"> <a rel="bookmark" href="#signature-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The signature digest creation algorithm defined by ZIP 244 <a id="id11" class="footnote_reference" href="#zip-0244">6</a> is modified to include a new branch for Orchard hashes. The <code>orchard_digest</code> branch is the only new addition to the tree; <code>header_digest</code>, <code>transparent_digest</code>, <code>sprout_digest</code>, and <code>sapling_digest</code> are as in ZIP 244:</p>
+                    <p>The signature digest creation algorithm defined by ZIP 244 <a id="id11" class="footnote_reference" href="#zip-0244">7</a> is modified to include a new branch for Orchard hashes. The <code>orchard_digest</code> branch is the only new addition to the tree; <code>header_digest</code>, <code>transparent_digest</code>, <code>sprout_digest</code>, and <code>sapling_digest</code> are as in ZIP 244:</p>
                     <pre>signature_digest
 ├── header_digest
 ├── transparent_digest
@@ -483,24 +453,23 @@ T.5d.iv : outCiphertext         (field encoding bytes)</pre>
                         <p>A BLAKE2b-256 hash of the following values</p>
                         <pre>S.1: header_digest      (32-byte hash output)
 S.2: transparent_digest (32-byte hash output)
-S.3: sprout_digest      (32-byte hash output)
-S.4: sapling_digest     (32-byte hash output)
-S.5: orchard_digest     (32-byte hash output)</pre>
+S.3: sapling_digest     (32-byte hash output)
+S.4: orchard_digest     (32-byte hash output)</pre>
                         <p>The personalization field of this hash is unmodified from ZIP 244</p>
                     </section>
-                    <section id="s-5-orchard-digest"><h5><span class="section-heading">S.5: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-5-orchard-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
+                    <section id="s-4-orchard-digest"><h5><span class="section-heading">S.4: orchard_digest</span><span class="section-anchor"> <a rel="bookmark" href="#s-4-orchard-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
                         <p>Identical to that specified for the transaction identifier.</p>
                     </section>
                 </section>
                 <section id="authorizing-data-commitment"><h4><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h4>
-                    <p>The tree of hashes defined by ZIP 244 <a id="id13" class="footnote_reference" href="#zip-0244">6</a> for authorizing data commitments is re-structured to include a new branch for Orchard Actions. The <code>orchard_digest</code> branch is the only new addition to the tree; <code>transparent_digest</code>, and <code>sprout_digest</code> <code>sapling_digest</code> are as in ZIP 244:</p>
+                    <p>The tree of hashes defined by ZIP 244 <a id="id13" class="footnote_reference" href="#zip-0244">7</a> for authorizing data commitments is re-structured to include a new branch for Orchard Actions. The <code>orchard_digest</code> branch is the only new addition to the tree; <code>transparent_digest</code>, and <code>sprout_digest</code> <code>sapling_digest</code> are as in ZIP 244:</p>
                     <pre>auth_digest
 ├── transparent_scripts_digest
 ├── sprout_auth_digest
 ├── sapling_auth_digest
 └── orchard_auth_digest</pre>
                     <section id="auth-digest"><h5><span class="section-heading">auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#auth-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>
-                        <p>The tree of hashes defined by ZIP 244 <a id="id14" class="footnote_reference" href="#zip-0244">6</a> for authorizing data commitments is re-structured to include a new branch for Orchard authorizing data. The <code>orchard_auth_digest</code> branch is the only new addition to the tree; <code>transparent_auth_digest</code>, <code>sprout_auth_digest</code>, and <code>sapling_auth_digest</code> are as in ZIP 244:</p>
+                        <p>The tree of hashes defined by ZIP 244 <a id="id14" class="footnote_reference" href="#zip-0244">7</a> for authorizing data commitments is re-structured to include a new branch for Orchard authorizing data. The <code>orchard_auth_digest</code> branch is the only new addition to the tree; <code>transparent_auth_digest</code>, <code>sprout_auth_digest</code>, and <code>sapling_auth_digest</code> are as in ZIP 244:</p>
                         <pre>A.1: transparent_scripts_digest (32-byte hash output)
 A.2: sprout_auth_digest         (32-byte hash output)
 A.3: sapling_auth_digest        (32-byte hash output)
@@ -517,6 +486,70 @@ A.4c: bindingSigOrchard        (field encoding bytes)</pre>
                     </section>
                 </section>
             </section>
+        </section>
+        <section id="alternatives"><h2><span class="section-heading">Alternatives</span><span class="section-anchor"> <a rel="bookmark" href="#alternatives"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The original version of ZIP-225 included Sprout-related fields <code>nJoinSplit</code>, <code>vJoinSplit</code>, <code>joinSplitPubKey</code>, and <code>joinSplitSig</code> in the V5 transaction format. The Electric Coin Company and Zcash Foundation teams have elected to remove these fields from the V5 transaction format as part of the continuing process of deprecation of the Sprout shielded pool. As a consequence of these fields being removed:</p>
+            <pre>* This effectively prohibits migration transactions that would directly move funds from</pre>
+            <div>
+                <h1>System Message: ERROR/3 (zip-0225.rst line 432)</h1>
+                <p>Unexpected indentation.</p>
+            </div>
+            <blockquote>
+                <p>the Sprout pool to the Orchard pool. Sprout -&gt; Transparent and Sprout -&gt; Sapling migration transactions will still be supported when using the V4 transaction format.</p>
+            </blockquote>
+            <p>Removing these fields reduces the complexity of the NU5 upgrade in the following ways:</p>
+            <pre>* V5 parsing and serialization code does not need to take these fields into account.
+* ZIP 244 [#zip_0244]_ transaction identifier, signature hash, and authorizing</pre>
+            <div>
+                <h1>System Message: ERROR/3 (zip-0225.rst line 439)</h1>
+                <p>Unexpected indentation.</p>
+            </div>
+            <blockquote>
+                <p>data commitment computations are simplified by excluding consideration of these fields.</p>
+            </blockquote>
+            <p>Removal of these fields means that that in the future, removing the support for the V4 transaction format will also effectively end support for Sprout transactions on the Zcash network, though it might be possible to restore limited support for migration via a future ZIP 222 <a id="id15" class="footnote_reference" href="#zip-0222">6</a> extension or by other means not yet determined.</p>
+            <p>The original definitions for the transaction fields that have been removed are:</p>
+            <pre>+-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+</pre>
+            <div>
+                <h1>System Message: ERROR/3 (zip-0225.rst line 450)</h1>
+                <p>Inconsistent literal block quoting.</p>
+            </div>
+            <pre class="line_block"><strong>Sprout Transaction Fields</strong> |</pre>
+            <div>
+                <h1>System Message: WARNING/2 (zip-0225.rst line 451)</h1>
+                <p>Line block ends without a blank line.</p>
+            </div>
+            <table>
+                <tbody>
+                    <tr>
+                        <td><code>varies</code></td>
+                        <td><code>nJoinSplit</code></td>
+                        <td><code>compactSize</code></td>
+                        <td>The number of JoinSplit descriptions in <code>vJoinSplit</code>.</td>
+                    </tr>
+                    <tr>
+                        <td><code>1698 * nJoinSplit</code></td>
+                        <td><code>vJoinSplit</code></td>
+                        <td><code>JSDescriptionGroth16[nJoinSplit]</code></td>
+                        <td>A sequence of JoinSplit descrptions using Groth16 proofs, encoded per §7.2 ‘JoinSplit Description Encoding and Consensus’.</td>
+                    </tr>
+                    <tr>
+                        <td><code>32</code></td>
+                        <td><code>joinSplitPubKey</code></td>
+                        <td><code>byte[32]</code></td>
+                        <td>An encoding of a JoinSplitSig public validating key.</td>
+                    </tr>
+                    <tr>
+                        <td><code>64</code></td>
+                        <td><code>joinSplitSig</code></td>
+                        <td><code>byte[64]</code></td>
+                        <td>A signature on a prefix of the transaction encoding, to be verfied using joinSplitPubKey as specified in §4.11 ‘Non-malleability (Sprout)’.</td>
+                    </tr>
+                </tbody>
+            </table>
+            <ul>
+                <li>The <code>joinSplitPubKey</code> and <code>joinSplitSig</code> fields were specified to be present if and only if <code>nJoinSplit &gt; 0</code>.</li>
+            </ul>
         </section>
         <section id="reference-implementation"><h2><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>TBD</p>
@@ -562,10 +595,18 @@ A.4c: bindingSigOrchard        (field encoding bytes)</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0244" class="footnote">
+            <table id="zip-0222" class="footnote">
                 <tbody>
                     <tr>
                         <th>6</th>
+                        <td><a href="zip-0222">ZIP 222: Transparent Zcash Extensions</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0244" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>7</th>
                         <td><a href="zip-0244">ZIP 244: Transaction Identifier Non-Malleability</a></td>
                     </tr>
                 </tbody>
@@ -573,7 +614,7 @@ A.4c: bindingSigOrchard        (field encoding bytes)</pre>
             <table id="zip-0307" class="footnote">
                 <tbody>
                     <tr>
-                        <th>7</th>
+                        <th>8</th>
                         <td><a href="zip-0307">ZIP 307: Light Client Protocol for Payment Detection</a></td>
                     </tr>
                 </tbody>

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -335,7 +335,7 @@ the following elements are included in the hash::
 
    T.4d.i  : cv                    (field encoding bytes)
    T.4d.ii : rk                    (field encoding bytes)
-   T.4d.iii: encCiphertext[464..]  (post-memo suffix of field encoding)
+   T.4d.iii: encCiphertext[564..]  (post-memo suffix of field encoding)
    T.4d.iv : outCiphertext         (field encoding bytes)
 
 The personalization field of this hash is set to::
@@ -439,8 +439,8 @@ Removing these fields reduces the complexity of the NU5 upgrade in the following
   data commitment computations are simplified by excluding consideration of 
   these fields.
 
-Having removed these fields means that that in the future, removing the support for the V4
-transaction format will also effectively end support for Sprout transactions on the zcash
+Removal of these fields means that that in the future, removing the support for the V4
+transaction format will also effectively end support for Sprout transactions on the Zcash
 network, though it might be possible to restore limited support for migration via a future
 ZIP 222 [#zip-0222]_ extension or by other means not yet determined.
 

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -445,7 +445,7 @@ A possible modification to this proposal is to entirely remove the Sprout-relate
 ``nJoinSplit``, ``vJoinSplit``, ``joinSplitPubKey``, and ``joinSplitSig`` from the V5
 transaction format. While this would effectively prohibit migration transactions that
 directly move funds from the Sprout pool to the Orchard pool, Sprout -> Transparent and
-Sprout -> Sapling transactions would still be supported when using the V4 transaction
+Sprout -> Sapling migration transactions would still be supported when using the V4 transaction
 format. This proposal is appealing from the perspective that it would reduce the
 complexity of the NU5 upgrade in the following ways::
 

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -438,6 +438,26 @@ The personalization field of this hash is set to::
 
   "ZTxAuthOrchaHash"
 
+Alternatives
+============
+
+A possible modification to this proposal is to entirely remove the Sprout-related fields
+``nJoinSplit``, ``vJoinSplit``, ``joinSplitPubKey``, and ``joinSplitSig`` from the V5
+transaction format. While this would effectively prohibit migration transactions that
+directly move funds from the Sprout pool to the Orchard pool, Sprout -> Transparent and
+Sprout -> Sapling transactions would still be supported when using the V4 transaction
+format. This proposal is appealing from the perspective that it would reduce the
+complexity of the NU5 upgrade in the following ways::
+
+* V5 parsing and serialization code would not need to take these fields into account.
+* ZIP 244 [#zip_0244]_ transaction identifier, signature hash, and authorizing
+  data commitment computations could be simplified to exclude consideration of 
+  these fields.
+
+This change would mean that in the future, removing the support for the V4 transaction
+format would also effectively end support for Sprout transactions on the zcash network,
+though it might be possible to restore limited support for migration via a future ZIP 222
+[#zip_0222] extension or by other means not yet determined.
 
 Reference implementation
 ========================

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -100,19 +100,6 @@ Transaction Format
 +-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
 |``varies``                   |``tx_out``                |``tx_out``                              |Transparent outputs, encoded as in Bitcoin.                          |
 +-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
-| **Sprout Transaction Fields**                                                                                                                                         |
-+-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
-|``varies``                   |``nJoinSplit``            |``compactSize``                         |The number of JoinSplit descriptions in ``vJoinSplit``.              |
-+-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
-|``1698 * nJoinSplit``        |``vJoinSplit``            |``JSDescriptionGroth16[nJoinSplit]``    |A sequence of JoinSplit descrptions using Groth16 proofs,            |
-|                             |                          |                                        |encoded per §7.2 ‘JoinSplit Description Encoding and Consensus’.     |
-+-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
-|``32``                       |``joinSplitPubKey``       |``byte[32]``                            |An encoding of a JoinSplitSig public validating key.                 |
-+-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
-|``64``                       |``joinSplitSig``          |``byte[64]``                            |A signature on a prefix of the transaction encoding,                 |
-|                             |                          |                                        |to be verfied using joinSplitPubKey as specified in §4.11            |
-|                             |                          |                                        |‘Non-malleability (Sprout)’.                                         |
-+-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
 | **Sapling Transaction Fields**                                                                                                                                        |
 +-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
 |``varies``                   |``nSpendsSapling``        |``compactSize``                         |Number of Sapling Spend descriptions in ``vSpendsSapling``.          |
@@ -173,9 +160,6 @@ Transaction Format
   present if and only if ``nActionsOrchard > 0``. If ``valueBalanceOrchard`` is not
   present, then ``valueBalanceOrchard`` is defined to be 0.
 
-* The ``joinSplitPubKey`` and ``joinSplitSig`` fields are present if and only if
-  ``nJoinSplit > 0``.
-
 * The elements of ``vSpendProofsSapling`` and ``vSpendAuthSigsSapling`` have a 1:1
   correspondence to the elements of ``vSpendsSapling`` and MUST be ordered such that the
   proof or signature at a given index corresponds to the ``SpendDescriptionV5`` at the
@@ -192,13 +176,12 @@ Transaction Format
 
 * For coinbase transactions, the ``spendsEnabledOrchard`` bit MUST be set to ``0``.
 
-The encodings of ``tx_in``, ``tx_out``, and ``JSDescriptionGroth16``, are as in a
-version 4 transaction (i.e. unchanged from Canopy). The encodings of ``SpendDescriptionV5``,
-``OutputDescriptionV5`` and ``OrchardAction`` are described below. The encoding of Sapling
-Spends and Outputs has changed relative to prior versions in order to better separate data
-that describe the effects of the transaction from the proofs of and commitments to those
-effects, and for symmetry with this separation in the Orchard-related parts of the
-transaction format.
+The encodings of ``tx_in``, and ``tx_out`` are as in a version 4 transaction (i.e.
+unchanged from Canopy). The encodings of ``SpendDescriptionV5``, ``OutputDescriptionV5``
+and ``OrchardAction`` are described below. The encoding of Sapling Spends and Outputs has
+changed relative to prior versions in order to better separate data that describe the
+effects of the transaction from the proofs of and commitments to those effects, and for
+symmetry with this separation in the Orchard-related parts of the transaction format.
 
 Sapling Spend Description (``SpendDescriptionV5``)
 --------------------------------------------------
@@ -281,7 +264,6 @@ are as in ZIP 244::
    txid_digest
    ├── header_digest
    ├── transparent_digest
-   ├── sprout_digest
    ├── sapling_digest
    └── orchard_digest
 
@@ -293,9 +275,8 @@ to be a BLAKE2b-256 hash of the following values ::
 
    T.1: header_digest      (32-byte hash output)
    T.2: transparent_digest (32-byte hash output)
-   T.3: sprout_digest      (32-byte hash output)
-   T.4: sapling_digest     (32-byte hash output)
-   T.5: orchard_digest     (32-byte hash output)
+   T.3: sapling_digest     (32-byte hash output)
+   T.4: orchard_digest     (32-byte hash output)
 
 The personalization field of this hash is unmodified from ZIP 244.
  
@@ -304,17 +285,17 @@ The personalization field of this hash is unmodified from ZIP 244.
 
 A BLAKE2b-256 hash of the following values ::
 
-   T.5c: anchorOrchard                       (32 bytes)
-   T.5b: orchard_actions_compact_digest      (32-byte hash output)
-   T.5c: orchard_actions_memos_digest        (32-byte hash output)
-   T.5d: orchard_actions_noncompact_digest   (32-byte hash output)
-   T.5e: valueBalanceOrchard                 (64-bit signed little-endian)
+   T.4c: anchorOrchard                       (32 bytes)
+   T.4b: orchard_actions_compact_digest      (32-byte hash output)
+   T.4c: orchard_actions_memos_digest        (32-byte hash output)
+   T.4d: orchard_actions_noncompact_digest   (32-byte hash output)
+   T.4e: valueBalanceOrchard                 (64-bit signed little-endian)
 
 The personalization field of this hash is set to::
 
   "ZTxIdOrchardHash" 
 
-T.5b: orchard_actions_compact_digest
+T.4b: orchard_actions_compact_digest
 """"""""""""""""""""""""""""""""""""
 
 A BLAKE2b-256 hash of the subset of Orchard Action information intended to be included in
@@ -322,29 +303,29 @@ an updated version of the ZIP-307 [#zip-0307]_ ``CompactBlock`` format for all O
 Actions belonging to the transaction. For each Action, the following elements are included
 in the hash::
 
-   T.5b.i  : nullifier            (field encoding bytes)
-   T.5b.ii : cmx                  (field encoding bytes)
-   T.5b.iii: ephemeralKey         (field encoding bytes)
-   T.5b.iv : encCiphertext[..52]  (First 52 bytes of field encoding)
+   T.4b.i  : nullifier            (field encoding bytes)
+   T.4b.ii : cmx                  (field encoding bytes)
+   T.4b.iii: ephemeralKey         (field encoding bytes)
+   T.4b.iv : encCiphertext[..52]  (First 52 bytes of field encoding)
 
 The personalization field of this hash is set to::
 
   "ZTxIdOrcOutCHash"
 
-T.5c: orchard_actions_memos_digest
+T.4c: orchard_actions_memos_digest
 """"""""""""""""""""""""""""""""""
 
 A BLAKE2b-256 hash of the subset of Orchard shielded memo field data for all Orchard
 Actions belonging to the transaction. For each Action, the following elements are included
 in the hash::
 
-   T.5c.i: encCiphertext[52..564] (contents of the encrypted memo field)
+   T.4c.i: encCiphertext[52..564] (contents of the encrypted memo field)
 
 The personalization field of this hash is set to::
 
   "ZTxIdOrcOutMHash"
 
-T.5d: orchard_actions_noncompact_digest
+T.4d: orchard_actions_noncompact_digest
 """""""""""""""""""""""""""""""""""""""
 
 A BLAKE2b-256 hash of the remaining subset of Orchard Action information **not** intended
@@ -352,10 +333,10 @@ for inclusion in an updated version of the the ZIP 307 [#zip-0307]_ ``CompactBlo
 format, for all Orchard Actions belonging to the transaction. For each Action,
 the following elements are included in the hash::
 
-   T.5d.i  : cv                    (field encoding bytes)
-   T.5d.ii : rk                    (field encoding bytes)
-   T.5d.iii: encCiphertext[564..]  (post-memo suffix of field encoding)
-   T.5d.iv : outCiphertext         (field encoding bytes)
+   T.4d.i  : cv                    (field encoding bytes)
+   T.4d.ii : rk                    (field encoding bytes)
+   T.4d.iii: encCiphertext[464..]  (post-memo suffix of field encoding)
+   T.4d.iv : outCiphertext         (field encoding bytes)
 
 The personalization field of this hash is set to::
 
@@ -383,13 +364,12 @@ A BLAKE2b-256 hash of the following values ::
 
    S.1: header_digest      (32-byte hash output)
    S.2: transparent_digest (32-byte hash output)
-   S.3: sprout_digest      (32-byte hash output)
-   S.4: sapling_digest     (32-byte hash output)
-   S.5: orchard_digest     (32-byte hash output)
+   S.3: sapling_digest     (32-byte hash output)
+   S.4: orchard_digest     (32-byte hash output)
 
 The personalization field of this hash is unmodified from ZIP 244
 
-S.5: orchard_digest
+S.4: orchard_digest
 """""""""""""""""""
 
 Identical to that specified for the transaction identifier.
@@ -441,23 +421,48 @@ The personalization field of this hash is set to::
 Alternatives
 ============
 
-A possible modification to this proposal is to entirely remove the Sprout-related fields
-``nJoinSplit``, ``vJoinSplit``, ``joinSplitPubKey``, and ``joinSplitSig`` from the V5
-transaction format. While this would effectively prohibit migration transactions that
-directly move funds from the Sprout pool to the Orchard pool, Sprout -> Transparent and
-Sprout -> Sapling migration transactions would still be supported when using the V4 transaction
-format. This proposal is appealing from the perspective that it would reduce the
-complexity of the NU5 upgrade in the following ways::
+The original version of ZIP-225 included Sprout-related fields ``nJoinSplit``, 
+``vJoinSplit``, ``joinSplitPubKey``, and ``joinSplitSig`` in the V5
+transaction format. The Electric Coin Company and Zcash Foundation teams have
+elected to remove these fields from the V5 transaction format as part of the 
+continuing process of deprecation of the Sprout shielded pool. As a consequence
+of these fields being removed::
 
-* V5 parsing and serialization code would not need to take these fields into account.
+* This effectively prohibits migration transactions that would directly move funds from
+  the Sprout pool to the Orchard pool. Sprout -> Transparent and Sprout -> Sapling
+  migration transactions will still be supported when using the V4 transaction format. 
+
+Removing these fields reduces the complexity of the NU5 upgrade in the following ways::
+
+* V5 parsing and serialization code does not need to take these fields into account.
 * ZIP 244 [#zip_0244]_ transaction identifier, signature hash, and authorizing
-  data commitment computations could be simplified to exclude consideration of 
+  data commitment computations are simplified by excluding consideration of 
   these fields.
 
-This change would mean that in the future, removing the support for the V4 transaction
-format would also effectively end support for Sprout transactions on the zcash network,
-though it might be possible to restore limited support for migration via a future ZIP 222
-[#zip_0222] extension or by other means not yet determined.
+Having removed these fields means that that in the future, removing the support for the V4
+transaction format will also effectively end support for Sprout transactions on the zcash
+network, though it might be possible to restore limited support for migration via a future
+ZIP 222 [#zip_0222] extension or by other means not yet determined.
+
+The original definitions for the transaction fields that have been removed are::
+
++-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
+| **Sprout Transaction Fields**                                                                                                                                         |
++-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
+|``varies``                   |``nJoinSplit``            |``compactSize``                         |The number of JoinSplit descriptions in ``vJoinSplit``.              |
++-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
+|``1698 * nJoinSplit``        |``vJoinSplit``            |``JSDescriptionGroth16[nJoinSplit]``    |A sequence of JoinSplit descrptions using Groth16 proofs,            |
+|                             |                          |                                        |encoded per §7.2 ‘JoinSplit Description Encoding and Consensus’.     |
++-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
+|``32``                       |``joinSplitPubKey``       |``byte[32]``                            |An encoding of a JoinSplitSig public validating key.                 |
++-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
+|``64``                       |``joinSplitSig``          |``byte[64]``                            |A signature on a prefix of the transaction encoding,                 |
+|                             |                          |                                        |to be verfied using joinSplitPubKey as specified in §4.11            |
+|                             |                          |                                        |‘Non-malleability (Sprout)’.                                         |
++-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
+
+* The ``joinSplitPubKey`` and ``joinSplitSig`` fields were specified to be
+  present if and only if ``nJoinSplit > 0``.
 
 Reference implementation
 ========================

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -442,7 +442,7 @@ Removing these fields reduces the complexity of the NU5 upgrade in the following
 Having removed these fields means that that in the future, removing the support for the V4
 transaction format will also effectively end support for Sprout transactions on the zcash
 network, though it might be possible to restore limited support for migration via a future
-ZIP 222 [#zip_0222] extension or by other means not yet determined.
+ZIP 222 [#zip-0222]_ extension or by other means not yet determined.
 
 The original definitions for the transaction fields that have been removed are::
 
@@ -478,5 +478,6 @@ References
 .. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2021.1.17 or later. Section 4.4: Spend Descriptions <protocol/nu5.pdf#spenddesc>`_
 .. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2021.1.17 or later. Section 4.5: Output Descriptions <protocol/nu5.pdf#outputdesc>`_
 .. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2021.1.17 or later. Section 4.6: Action Descriptions <protocol/nu5.pdf#actiondesc>`_
+.. [#zip-0222] `ZIP 222: Transparent Zcash Extensions <zip-0222.rst>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.rst>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_


### PR DESCRIPTION
This modification is suggested as a possible simplification as a result of this discussion in #446: https://github.com/zcash/zips/pull/446/files#r585949598