### PR TITLE
Zip 321 address bundle extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 *.swp
 *.save
 *.save.*
+.vscode/
 
 .Makefile.uptodate
 .zipfilelist.*
@@ -29,3 +30,5 @@ protocol/saplinghtml/
 
 protocol/heartwood.pdf
 protocol/protocol.ver
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,3 @@ protocol/saplinghtml/
 
 protocol/heartwood.pdf
 protocol/protocol.ver
-
-

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-tactile
+url: "https://zips.z.cash"
+markdown: GFM

--- a/css/style.css
+++ b/css/style.css
@@ -55,7 +55,7 @@ h2 {
 }
 
 h3 {
-  font-size: 1.625rem;
+  font-size: 1.8rem;
 }
 
 h3 code {
@@ -63,11 +63,11 @@ h3 code {
 }
 
 h4 {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
 }
 
 h4 code {
-  font-size: 1.35rem;
+  font-size: 1.3rem;
 }
 
 h5, h6 {
@@ -76,11 +76,11 @@ h5, h6 {
 }
 
 h5 {
-  font-size: 1.125rem;
+  font-size: 1.25rem;
 }
 
 h6 {
-  font-size: 1rem;
+  font-size: 1.2rem;
 }
 
 blockquote {

--- a/zip-0244.html
+++ b/zip-0244.html
@@ -267,9 +267,10 @@ additional data</pre>
                 </section>
                 <section id="authorizing-data-commitment"><h4><span class="section-heading">Authorizing Data Commitment</span><span class="section-anchor"> <a rel="bookmark" href="#authorizing-data-commitment"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>A new transaction digest algorithm is defined that constructs a digest which commits to the authorizing data of a transaction from a tree of BLAKE2b-256 hashes. The overall structure of the hash is as follows:</p>
-                    <blockquote>
-                        <p>auth_digest ├── transparent_scripts_digest ├── sprout_auth_digest └── sapling_auth_digest</p>
-                    </blockquote>
+                    <pre>auth_digest
+├── transparent_scripts_digest
+├── sprout_auth_digest
+└── sapling_auth_digest</pre>
                     <p>Each node written as <code>snake_case</code> in this tree is a BLAKE2b-256 hash of authorizing data of the transaction.</p>
                     <p>The pair (Transaction Identifier, Auth Commitment) constitutes a commitment to all the data of a serialized transaction that may be included in a block.</p>
                     <section id="auth-digest"><h5><span class="section-heading">auth_digest</span><span class="section-anchor"> <a rel="bookmark" href="#auth-digest"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h5>

--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -491,7 +491,7 @@ Authorizing Data Commitment
 
 A new transaction digest algorithm is defined that constructs a digest which commits
 to the authorizing data of a transaction from a tree of BLAKE2b-256 hashes.
-The overall structure of the hash is as follows:
+The overall structure of the hash is as follows::
 
     auth_digest
     ├── transparent_scripts_digest

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -91,12 +91,14 @@ The following syntax specification uses ABNF [#RFC5234]_.
 
   zcashurn        = "zcash:" ( zcashaddress [ "?" zcashparams ] / "?" zcashparams )
   zcashaddress    = 1*( ALPHA / DIGIT )
+  zcashaddresses  = zcashaddress [ ";" zcashaddresses ]
   zcashparams     = zcashparam [ "&" zcashparams ]
   zcashparam      = [ addrparam / amountparam / memoparam / messageparam / labelparam / reqparam / otherparam ]
   NONZERO         = %x31-39
   DIGIT           = %x30-39
   paramindex      = "." NONZERO 0*3DIGIT
   addrparam       = "address" [ paramindex ] "=" zcashaddress
+  addrsparam      = "addresses" [ paramindex ] "=" zcashaddresses
   amountparam     = "amount"  [ paramindex ] "=" 1*DIGIT [ "." 1*8DIGIT ]
   labelparam      = "label"   [ paramindex ] "=" *qchar
   memoparam       = "memo"    [ paramindex ] "=" *base64url
@@ -145,17 +147,20 @@ A URI of the form ``zcash:<address>?...`` MUST be considered equivalent to a
 URI of the form ``zcash:?address=<address>&...`` where ``<address>`` is an
 instance of ``zcashaddress``.
 
-If there are any non-address parameters having a given ``paramindex``, then
-the URI MUST contain an address parameter having that ``paramindex``. There
-MUST NOT be more than one occurrence of a given parameter and ``paramindex``.
+If there are any non-address parameters having a given ``paramindex``, then the URI MUST
+contain an ``address`` parameter and/or an ``addressess`` parameter having that
+``paramindex``. There MUST NOT be more than one occurrence of a given parameter and
+``paramindex``.
 
 Implementations SHOULD check that each instance of ``zcashaddress`` is a valid
-string encoding of either:
+string encoding of one of the following **address types**:
 
 * a Zcash transparent address, using Base58Check [#base58check]_ as defined
   in [#protocol-transparentaddrencoding]_; or
 * a Zcash Sapling address, using Bech32 [#zip-0173]_ as defined in
   [#protocol-saplingpaymentaddrencoding]_.
+* a Zcash Orchard address, using Bech32 [#zip-0173]_ as defined in
+  [#protocol-orchardpaymentaddrencoding]_.
 
 New address formats may be added in future. If the context of whether the
 payment URI is intended for Testnet or Mainnet is available, then each address
@@ -166,6 +171,22 @@ this is that transfers to Sprout addresses will, at activation of the Canopy
 network upgrade, be restricted by ZIP 211 [#zip-0211]_; it cannot generally
 be expected that senders will have funds available in the Sprout pool with which
 to satisfy requests for payment to a Sprout address.
+
+An instance of ``zcashaddresses`` represents a bundle of addresses to which a payment may
+be sent. By providing a bundle of addresses, the requestor can ensure that the payer has
+been provided with an address that the payer's wallet can recognize, even if that wallet
+has not yet been updated to support newly released protocol versions.  Implementations
+SHOULD select the address from the bundle that is associated with the most recent Zcash
+protocol version that they support. Each such bundle of addresses MUST be associated with
+only a single recipient; for separate recipients, distinct payments within the request can
+be used instead. A bundle of addresses MUST NOT contain more than one address of each
+address type.
+
+If an ``addresses`` parameter appears at a given ``paramindex`` and an ``address``
+parameter appears at the same index, the value of the ``address`` parameter at that index
+MUST also be a member of the ``addresses`` bundle. It is RECOMMENDED that the value of
+such an ``address`` parameter, if present, be associated with the oldest protocol version
+that the recipient supports. 
 
 Transfer amount
 ---------------
@@ -309,4 +330,5 @@ References
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2020.1.15. Section 3.11: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#protocol-saplingbalance] `Zcash Protocol Specification, Version 2020.1.15. Section 4.12: Balance and Binding Signature (Sapling) <protocol/protocol.pdf#saplingbalance>`_
 .. [#protocol-transparentaddrencoding] `Zcash Protocol Specification, Version 2020.1.15. Section 5.6.1: Transparent Addresses <protocol/protocol.pdf#transparentaddrencoding>`_
-.. [#protocol-saplingpaymentaddrencoding] `Zcash Protocol Specification, Version 2020.1.15. Section 5.6.4: Sapling Payment Addresses <protocol/protocol.pdf#saplingpaymentaddrencoding>`_
+.. [#protocol-saplingpaymentaddrencoding] `Zcash Protocol Specification, Version 2020.1.16. Section 5.6.3.1: Sapling Payment Addresses <protocol/protocol.pdf#saplingpaymentaddrencoding>`_
+.. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2020.1.16. Section 5.6.4.1: Orchard Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -98,7 +98,7 @@ The following syntax specification uses ABNF [#RFC5234]_.
   DIGIT           = %x30-39
   paramindex      = "." NONZERO 0*3DIGIT
   addrparam       = "address" [ paramindex ] "=" zcashaddress
-  bundleparam     = "bundle" [ paramindex ] "=" zcashaddrbundle
+  bundleparam     = "bundle"  [ paramindex ] "=" zcashaddrbundle
   amountparam     = "amount"  [ paramindex ] "=" 1*DIGIT [ "." 1*8DIGIT ]
   labelparam      = "label"   [ paramindex ] "=" *qchar
   memoparam       = "memo"    [ paramindex ] "=" *base64url
@@ -192,7 +192,7 @@ Transfer amount
 ---------------
 
 If an amount is provided, it MUST be specified in decimal ZEC. If a decimal fraction
-is present then a period (`.`) MUST be used as the separating character to separate
+is present then a period ('.') MUST be used as the separating character to separate
 the whole number from the decimal fraction, and both the whole number and the 
 decimal fraction MUST be nonempty. No other separators (such as commas for 
 grouping or thousands) are permitted. Leading zeros in the whole number or trailing
@@ -219,6 +219,16 @@ label
 
 address
    Zcash address string (shielded or transparent)
+
+bundle
+   Zcash Address Bundle. An address bundle is an abstraction that 
+   provides Zcash users the ability to express a clear intent on how they want 
+   to receive a payment without the need to restrict senders either to transparent
+   or a specific Shielded Pool (Sapling or Orchard) at the moment of generating
+   a payment request URI. When presented a Bundle, a sender can send the requested
+   amount to the `best pool` (newest shielded pool) or fall back to transparent
+   for the case sender has no capability for sending to shielded. Wallets sending
+   to transparent address must ignore the memo field if available.
 
 memo
    Contents for the Zcash shielded memo field, encoded as base64url without

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -192,7 +192,7 @@ Transfer amount
 ---------------
 
 If an amount is provided, it MUST be specified in decimal ZEC. If a decimal fraction
-is present then a period ('.') MUST be used as the separating character to separate
+is present then a period (``.``) MUST be used as the separating character to separate
 the whole number from the decimal fraction, and both the whole number and the 
 decimal fraction MUST be nonempty. No other separators (such as commas for 
 grouping or thousands) are permitted. Leading zeros in the whole number or trailing
@@ -228,7 +228,7 @@ bundle
    a payment request URI. When presented a Bundle, a sender can send the requested
    amount to the `best pool` (newest shielded pool) or fall back to transparent
    for the case sender has no capability for sending to shielded. Wallets sending
-   to transparent address must ignore the memo field if available.
+   to transparent addresses MUST ignore the memo field if available.
 
 memo
    Contents for the Zcash shielded memo field, encoded as base64url without

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -91,14 +91,14 @@ The following syntax specification uses ABNF [#RFC5234]_.
 
   zcashurn        = "zcash:" ( zcashaddress [ "?" zcashparams ] / "?" zcashparams )
   zcashaddress    = 1*( ALPHA / DIGIT )
-  zcashaddresses  = zcashaddress [ ";" zcashaddresses ]
+  zcashaddrbundle = zcashaddress [ ";" zcashaddrbundle ]
   zcashparams     = zcashparam [ "&" zcashparams ]
-  zcashparam      = [ addrparam / amountparam / memoparam / messageparam / labelparam / reqparam / otherparam ]
+  zcashparam      = [ addrparam / bundleparam / amountparam / memoparam / messageparam / labelparam / reqparam / otherparam ]
   NONZERO         = %x31-39
   DIGIT           = %x30-39
   paramindex      = "." NONZERO 0*3DIGIT
   addrparam       = "address" [ paramindex ] "=" zcashaddress
-  addrsparam      = "addresses" [ paramindex ] "=" zcashaddresses
+  bundleparam     = "bundle" [ paramindex ] "=" zcashaddrbundle
   amountparam     = "amount"  [ paramindex ] "=" 1*DIGIT [ "." 1*8DIGIT ]
   labelparam      = "label"   [ paramindex ] "=" *qchar
   memoparam       = "memo"    [ paramindex ] "=" *base64url
@@ -148,7 +148,7 @@ URI of the form ``zcash:?address=<address>&...`` where ``<address>`` is an
 instance of ``zcashaddress``.
 
 If there are any non-address parameters having a given ``paramindex``, then the URI MUST
-contain an ``address`` parameter and/or an ``addressess`` parameter having that
+contain an ``address`` parameter and/or an ``bundle`` parameter having that
 ``paramindex``. There MUST NOT be more than one occurrence of a given parameter and
 ``paramindex``.
 
@@ -172,7 +172,7 @@ network upgrade, be restricted by ZIP 211 [#zip-0211]_; it cannot generally
 be expected that senders will have funds available in the Sprout pool with which
 to satisfy requests for payment to a Sprout address.
 
-An instance of ``zcashaddresses`` represents a bundle of addresses to which a payment may
+An instance of ``zcashaddrbundle`` represents a bundle of addresses to which a payment may
 be sent. By providing a bundle of addresses, the requestor can ensure that the payer has
 been provided with an address that the payer's wallet can recognize, even if that wallet
 has not yet been updated to support newly released protocol versions.  Implementations
@@ -182,11 +182,11 @@ only a single recipient; for separate recipients, distinct payments within the r
 be used instead. A bundle of addresses MUST NOT contain more than one address of each
 address type.
 
-If an ``addresses`` parameter appears at a given ``paramindex`` and an ``address``
-parameter appears at the same index, the value of the ``address`` parameter at that index
-MUST also be a member of the ``addresses`` bundle. It is RECOMMENDED that the value of
-such an ``address`` parameter, if present, be associated with the oldest protocol version
-that the recipient supports. 
+If a ``bundle`` parameter appears at a given ``paramindex`` and an ``address`` parameter
+appears at the same index, the value of the ``address`` parameter at that index MUST also
+be a member of the bundle. It is RECOMMENDED that the value of such an ``address``
+parameter, if present, be associated with the oldest protocol version that the recipient
+supports. 
 
 Transfer amount
 ---------------


### PR DESCRIPTION
# Include Support for Zcash Address Bundles.

## What is an address bundle?

A Zcash Address Bundle is a way to express a set of addresses to receive payments without specifying a single address (transparent or shielded). The rationale behind these bundles is to abstract the inherent complexity of choosing an address and address type to receive Zcash. The action of providing a bundle relieves users from knowing which address is suitable for the wallet the sender would eventually use. Also provides Zcash developers a pattern around the _Yet Another Address Type_ UX/UI problem. 

The Representation of the Bundle is yet to be determined. 

