### PR TITLE
s/enableSpendsOrchard/enableOutputsOrchard/ re: no new notes

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12106,7 +12106,7 @@ each \spendDescription (\crossref{spendencodingandconsensus}),\notnufive{ and} e
 \nufive{
   \item The flags in \flagsOrchard allow a version 5 \transaction to declare that no funds are spent
         from \Orchard \notes (by setting \enableSpendsOrchard to $0$), or that no new \Orchard \notes
-        with non-zero values are created (by setting \enableSpendsOrchard to $0$). This has two primary
+        with non-zero values are created (by setting \enableOutputsOrchard to $0$). This has two primary
         purposes. First, the \enableSpendsOrchard flag is set to $0$ in version 5 \coinbaseTransactions to
         ensure that they cannot spend from existing \Orchard outputs, maintaining a restriction present
         in \coinbaseTransactions for \transparent, \Sprout, or \Sapling funds (which would not otherwise


### PR DESCRIPTION
>The flags in `flagsOrchard` allow a version 5 transaction to declare that no funds are spent from Orchard notes (by setting `enableSpendsOrchard` to 0), or that no new Orchard notes with non-zero values are created (by setting `enableSpendsOrchard` to 0).

Should be `enableOutputsOrchard` if no new Orchard notes with non-zero values are created.