### PR TITLE
[ZIP 244]: Be explicit about delayed hashBlockCommitments activation

### DIFF
--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -608,6 +608,14 @@ a later protocol version. Such a third party SHOULD provide a value that can
 be used instead of the all-zeros terminator to permit the light client to
 perform validation of the parts of the structure it needs.
 
+In the block that activates this ZIP, ``hashBlockCommitments`` MUST be set to the
+value of ``hashLightClientRoot``, as specified in ZIP 221 [#zip-0221]_. This MUST
+be interpreted as a light client root hash.
+
+In subsequent blocks, ``hashBlockCommitments`` MUST be set to the value specified
+above.
+
+The block header byte format and version are not altered by this ZIP.
 
 ========================
 Reference implementation


### PR DESCRIPTION
In ZIP-221, we delayed activation of `hashLightClientRoot` until the block after `Heartwood` activation, to avoid calculating the `hashLightClientRoot` for the entire Zcash chain.

For similar reasons, we might want to delay the activation of `hashBlockCommitments` to the block after `NU5` activation, and use the `hashLightClientRoot` for the previous block.

If we make this change, we might also want to delay non-malleable transaction ids until the block after `NU5` activation.