### PR TITLE
[ZIP 244]: Be explicit about immediate hashBlockCommitments activation

### DIFF
--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -608,6 +608,10 @@ a later protocol version. Such a third party SHOULD provide a value that can
 be used instead of the all-zeros terminator to permit the light client to
 perform validation of the parts of the structure it needs.
 
+Unlike the ``hashLightClientRoot`` change, the change to ``hashBlockCommitments``
+happens in the block that activates this ZIP.
+
+The block header byte format and version are not altered by this ZIP.
 
 ========================
 Reference implementation


### PR DESCRIPTION
In ZIP-221, we delayed activation of `hashLightClientRoot` until the block after `Heartwood` activation, to avoid calculating the `hashLightClientRoot` for the entire Zcash chain.

But we don't need to delay the activation of `hashBlockCommitments`, because:
- the new `hashAuthDataRoot` only commits to the current block, and
- the old `hashLightClientRoot` has been incrementally calculated since the block after Canopy activation