### PR TITLE
Add action descriptions to the Note Commitments section intro

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -6441,7 +6441,7 @@ authority for other \transactions, since it is not able to create a \spendAuthSi
 \lsubsection{Note Commitments and Nullifiers}{commitmentsandnullifiers}
 
 A \transaction that contains one or more
-\joinSplitDescriptions\sapling{ or \spendDescriptions}, when entered
+\joinSplitDescriptions\sapling{ or \spendDescriptions}\nufive{ or \actionDescriptions}, when entered
 into the \blockChain, appends to the \noteCommitmentTree with all constituent
 \noteCommitments.
 


### PR DESCRIPTION
Orchard nullifiers are mentioned in this section, but not in its intro.