### PR TITLE
Use a different symbol for each V5 sapling field cardinality rule

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12205,7 +12205,7 @@ The number of \outputDescriptions in $\vOutputsSapling$.\! \\ \hline
 & \Longunderstack{$756 \mult$ \\$\!\nOutputsSapling\!$} & $\vOutputsSapling\!$ & \type{OutputDescriptionV5} \type{[$\nOutputsSapling$]} &
 A sequence of \outputDescriptions{}, encoded per \crossref{outputencodingandconsensus}.\! \\ \hline
 
-$\ddagger$ & $8$ & $\valueBalance{Sapling}\!$ & \type{int64} &
+$\dagger$ & $8$ & $\valueBalance{Sapling}\!$ & \type{int64} &
 The net value of \Sapling{} spends minus outputs.\! \\ \hline
 
 $\ddagger$ & $32$ & $\anchorField{Sapling}$ & \type{byte[32]} &
@@ -12220,7 +12220,7 @@ Authorizing signatures for each \Sapling \spendDescription.\! \\ \hline
 & \Longunderstack{$192 \mult$ \\$\!\nOutputsSapling\!$} & $\vOutputProofsSapling$ & \type{byte[192]} \type{[$\nOutputsSapling$]} &
 Encodings of the \zkSNARKProofs for each \Sapling \outputDescription.\! \\ \hline
 
-$\ddagger$ & $64$ & $\bindingSig{Sapling}$ & \type{byte[64]} &
+$\dagger$ & $64$ & $\bindingSig{Sapling}$ & \type{byte[64]} &
 A \saplingBindingSignature on the \sighashTxHash, validated per \crossref{concretebindingsig}.\! \\
 \hhline{|=====|}
 
@@ -12262,11 +12262,11 @@ An \orchardBindingSignature on the \sighashTxHash, validated per \crossref{concr
 \vspace{-0.3ex}
 \scalebox{0.87}{
 \begin{tabularx}{1.14\textwidth}{@{\!\!}l@{\hskip 1em}X@{}}
-$\ddagger$ & The fields \valueBalance{Sapling} and \bindingSig{Sapling}
+$\dagger$ & The fields \valueBalance{Sapling} and \bindingSig{Sapling}
 are present if and only if $\nSpendsSapling + \nOutputsSapling > 0$. If \valueBalance{Sapling}
-is not present, then $\vBalance{Sapling}$ is defined to be $0$. \\[-0.5ex]
+is not present, then $\vBalance{Sapling}$ is defined to be $0$. \\
 
-& The field \anchorField{Sapling} is present if and only if $\nSpendsSapling > 0$. \\
+$\ddagger$ & The field \anchorField{Sapling} is present if and only if $\nSpendsSapling > 0$. \\
 
 $\mathsection$ & The fields \flagsOrchard, \valueBalance{Orchard}, \anchorField{Orchard},
 \sizeProofsOrchard, \proofsOrchard, and \bindingSig{Orchard} are present if and only if


### PR DESCRIPTION
Currently, the V5 transaction spec uses the double dagger symbol for both:
* present if and only if `nSpendsSapling + nOutputsSapling > 0` (`valueBalanceSapling`, `bindingSigSapling`)
* present if and only if `nSpendsSapling > 0` (`anchorSapling`)

To avoid confusion, use dagger for the first rule, and double dagger for the second rule.