### PR TITLE
ZIP-244: Clarify sapling shared anchor hashing

### DIFF
--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -267,8 +267,8 @@ signature(s). For each spend, the following elements are included in the hash::
    T.3a.ii.2: anchor (field encoding bytes)
    T.3a.ii.3: rk     (field encoding bytes)
 
-In Transaction version 5, sapling spends have a shared anchor, which is hashed
-into the sapling_spends_noncompact_digest for *each* spend.
+In Transaction version 5, Sapling Spends have a shared anchor, which is hashed
+into the sapling_spends_noncompact_digest for *each* Spend.
 
 The personalization field of this hash is set to::
 

--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -267,6 +267,9 @@ signature(s). For each spend, the following elements are included in the hash::
    T.3a.ii.2: anchor (field encoding bytes)
    T.3a.ii.3: rk     (field encoding bytes)
 
+In Transaction version 5, sapling spends have a shared anchor, which is hashed
+into the sapling_spends_noncompact_digest for *each* spend.
+
 The personalization field of this hash is set to::
 
   "ZTxIdSSpendNHash"


### PR DESCRIPTION
Unlike the orchard shared anchor, the sapling v5 transaction shared anchor is hashed into *each* spend.