### PR TITLE
Allow coinbase transparent inputs in coinbase transactions

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12353,11 +12353,11 @@ Several fields are reordered and/or renamed relative to prior versions.}} %scale
         $\vBalance{Sapling}$,}\nufive{ minus $\vBalance{Orchard}$,} \MUSTNOT be greater than the value in
         \zatoshi of \minerSubsidy plus the \transactionFees paid by \transactions in this \block.
 \notheartwood{
-  \item A \coinbaseTransaction \MUSTNOT have any \transparentInputs,
+  \item A \coinbaseTransaction \MUSTNOT have any \transparentInputs with previous outputs,
         \joinSplitDescriptions\sapling{, \spendDescriptions, or \outputDescriptions}.
 }
 \notbeforeheartwood{
-  \item A \coinbaseTransaction \MUSTNOT have any \transparentInputs,
+  \item A \coinbaseTransaction \MUSTNOT have any \transparentInputs with previous outputs,
         \joinSplitDescriptions\sapling{, or \spendDescriptions}.
   \preheartwooditem{\sapling{A \coinbaseTransaction also \MUSTNOT have any \outputDescriptions.}}
 }


### PR DESCRIPTION
Coinbase inputs are included in the transparent inputs array, but they have no previous outputs.

(The recent update to the coinbase rules bans coinbase inputs in coinbase transactions, which is not what was intended.)