### PR TITLE
Add ZIP-244 block commitments as a consensus rule

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12826,8 +12826,14 @@ preceding \blocks if there are fewer than $\PoWMedianBlockSpan$). The \medianTim
   \saplingandblossomitem{$\hashLightClientRoot$ \MUST be $\LEBStoOSPOf{256}{\rt{Sapling}}$ where
         $\rt{Sapling}$ is the \merkleRoot of the \Sapling \noteCommitmentTree for the final
         \Sapling \treestate of this \block.}
-  \heartwoodonwarditem{$\hashLightClientRoot$ \MUST be set to the value of $\hashChainHistoryRoot$
+  \heartwood{
+        \item{$\hashLightClientRoot$ \MUST be set to the value of $\hashChainHistoryRoot$
         for this \block, as specified in \cite{ZIP-221}.}
+  }
+  \nufive{
+        \item{$\hashBlockCommitments$ \MUST be set to the value of $\hashBlockCommitments$
+        for this \block, as specified in \cite{ZIP-244}.}
+  }
 }
   \item \todo{Other rules inherited from \Bitcoin.}
 \end{consensusrules}


### PR DESCRIPTION
It's currently just a note, which makes it look like the heartwood rule might still apply.