### PR TITLE
ZIP 321: clarify that only URIs that parse according to the grammar are accepted

### DIFF
--- a/zip-0321.html
+++ b/zip-0321.html
@@ -63,6 +63,7 @@ License: MIT</pre>
                 <p>Here, <code>ALPHA</code>, <code>unreserved</code> and <code>pct-encoded</code> are as defined in <a id="id6" class="footnote_reference" href="#rfc3986">3</a>. "base64url" is defined as in <a id="id7" class="footnote_reference" href="#base64url">4</a> with padding omitted. (Note that this uses a different alphabet to the usual base64; the values 62 and 63 in the alphabet are encoded as <code>-</code> and <code>_</code> respectively. Implementations MUST NOT accept the characters <code>+</code>, <code>/</code>, and <code>=</code> that occur only in the usual base64.)</p>
                 <p>Productions of the form <code>1*x</code> indicate one or more successive instances of the production <code>x</code>. Productions of the form <code>&lt;n&gt;*&lt;m&gt;x</code> indicate at least <cite>&lt;n&gt;</cite> and at most <cite>&lt;m&gt;</cite> instances of production <code>x</code>.</p>
                 <p>Note that this grammar does not allow percent encoding outside the productions that use <code>qchar</code>, i.e. the values of label, message, <code>reqparam</code>, and <code>otherparam</code> parameters.</p>
+                <p>Purported ZIP 321 URIs that cannot be parsed according to the above grammar MUST NOT be accepted.</p>
             </section>
             <section id="uri-semantics"><h3><span class="section-heading">URI Semantics</span><span class="section-anchor"> <a rel="bookmark" href="#uri-semantics"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A ZIP-321 URI represents a request for the construction of a transaction having one or more <em>payments</em>. In the case that only a single payment is being requested, the recipient address SHOULD be included in the <code>hier-part</code> component of the RFC 3986 URI; otherwise, multiple recipient addresses can be specified using <code>addrparam</code> parameters with different indices.</p>
@@ -126,6 +127,8 @@ zcash:?amount.1=1.234&amp;amount.1=2.345&amp;address.1=tmEZhbWHTpdKMw5it8YDspUXS
 zcash:tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?%61mount=1
 zcash:%74mEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?amount=1</pre>
                     <p>Invalid; percent encoding is only allowed in <code>qchar</code> productions, which do not include addresses, amounts, or parameter names.</p>
+                    <pre>zcash://tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU</pre>
+                    <p>Invalid; the grammar does not allow <code>//</code>. ZIP 321 URIs are not "hierarchical URIs" in the sense defined in <a id="id14" class="footnote_reference" href="#rfc3986">3</a> section 1.2.3, and do not have an "authority component".</p>
                 </section>
             </section>
             <section id="forward-compatibility"><h3><span class="section-heading">Forward compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#forward-compatibility"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>

--- a/zip-0321.html
+++ b/zip-0321.html
@@ -127,7 +127,7 @@ zcash:?amount.1=1.234&amp;amount.1=2.345&amp;address.1=tmEZhbWHTpdKMw5it8YDspUXS
 zcash:tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?%61mount=1
 zcash:%74mEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?amount=1</pre>
                     <p>Invalid; percent encoding is only allowed in <code>qchar</code> productions, which do not include addresses, amounts, or parameter names.</p>
-                    <pre>zcash://tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU</pre>
+                    <pre>zcash://tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?amount=1</pre>
                     <p>Invalid; the grammar does not allow <code>//</code>. ZIP 321 URIs are not "hierarchical URIs" in the sense defined in <a id="id14" class="footnote_reference" href="#rfc3986">3</a> section 1.2.3, and do not have an "authority component".</p>
                 </section>
             </section>

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -122,6 +122,10 @@ Note that this grammar does not allow percent encoding outside the productions
 that use ``qchar``, i.e. the values of label, message, ``reqparam``, and
 ``otherparam`` parameters.
 
+Purported ZIP 321 URIs that cannot be parsed according to the above grammar
+MUST NOT be accepted.
+
+
 URI Semantics
 -------------
 
@@ -268,6 +272,15 @@ Also invalid; duplicate ``amount=`` or ``amount.1=`` fields
 
 Invalid; percent encoding is only allowed in ``qchar`` productions, which do
 not include addresses, amounts, or parameter names.
+
+::
+
+  zcash://tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU
+
+Invalid; the grammar does not allow ``//``. ZIP 321 URIs are not
+"hierarchical URIs" in the sense defined in [#RFC3986]_ section 1.2.3,
+and do not have an "authority component".
+
 
 Forward compatibility
 ---------------------

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -275,7 +275,7 @@ not include addresses, amounts, or parameter names.
 
 ::
 
-  zcash://tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU
+  zcash://tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?amount=1
 
 Invalid; the grammar does not allow ``//``. ZIP 321 URIs are not
 "hierarchical URIs" in the sense defined in [#RFC3986]_ section 1.2.3,


### PR DESCRIPTION
Signed-off-by: Daira Hopwood <daira@jacaranda.org>