### PR TITLE
ZIP-221: Fix block height description

### DIFF
--- a/zip-0221.html
+++ b/zip-0221.html
@@ -18,8 +18,8 @@ Category: Consensus
 Created: 2019-03-30
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="id1" class="footnote_reference" href="#rfc2119">1</a></p>
-            <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="id2" class="footnote_reference" href="#zip-0200">8</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a href="#rfc2119" id="id1" class="footnote_reference">1</a></p>
+            <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a href="#zip-0200" id="id2" class="footnote_reference">8</a></p>
             <dl>
                 <dt><em>Light client</em></dt>
                 <dd>A client that is not a full participant in the network of Zcash peers. It can send and receive payments, but does not store or validate a copy of the block chain.</dd>
@@ -40,7 +40,7 @@ License: MIT</pre>
             </dl>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This ZIP specifies modifications to the Zcash block header semantics and consensus rules in order to support the probabilistic verification FlyClient protocol <a id="id3" class="footnote_reference" href="#flyclient">2</a>. The <code>hashFinalSaplingRoot</code> commitment in the block header is replaced with a commitment to the root of a Merkle Mountain Range (MMR), that in turn commits to various features of the chain's history, including the Sapling commitment tree.</p>
+            <p>This ZIP specifies modifications to the Zcash block header semantics and consensus rules in order to support the probabilistic verification FlyClient protocol <a href="#flyclient" id="id3" class="footnote_reference">2</a>. The <code>hashFinalSaplingRoot</code> commitment in the block header is replaced with a commitment to the root of a Merkle Mountain Range (MMR), that in turn commits to various features of the chain's history, including the Sapling commitment tree.</p>
         </section>
         <section id="background"><h2><span class="section-heading">Background</span><span class="section-anchor"> <a rel="bookmark" href="#background"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>An MMR is a Merkle tree which allows for efficient appends, proofs, and verifications. Informally, appending data to an MMR consists of creating a new leaf and then iteratively merging neighboring subtrees with the same size. This takes at most
@@ -48,13 +48,13 @@ License: MIT</pre>
              operations and only requires knowledge of the previous subtree roots, of which there are fewer than
                 <span class="math">\(\log(n)\)</span>
             .</p>
-            <p>(example adapted from <a id="id4" class="footnote_reference" href="#mimblewimble">6</a>) To illustrate this, consider a list of 11 leaves. We first construct the biggest perfect binary subtrees possible by joining any balanced sibling trees that are the same size. We do this starting from the left to the right, adding a parent as soon as 2 children exist. This leaves us with three subtrees ("mountains") of altitudes 3, 1, and 0:</p>
-            <pre data-language="text">   /\
+            <p>(example adapted from <a href="#mimblewimble" id="id4" class="footnote_reference">6</a>) To illustrate this, consider a list of 11 leaves. We first construct the biggest perfect binary subtrees possible by joining any balanced sibling trees that are the same size. We do this starting from the left to the right, adding a parent as soon as 2 children exist. This leaves us with three subtrees ("mountains") of altitudes 3, 1, and 0:</p>
+            <pre data-language="text"><span></span>   /\
   /  \
  /\  /\
 /\/\/\/\ /\ /</pre>
             <p>Note that the first leftmost peak is always the highest. We can number this structure in the order by which nodes would be created, if the leaves were inserted from left to right:</p>
-            <pre data-language="text">Altitude
+            <pre data-language="text"><span></span>Altitude
 
     3              14
                  /    \
@@ -130,7 +130,7 @@ License: MIT</pre>
                 <li>Repeat 1. until we have a single peak.</li>
             </ol>
             <p>Note that the extra nodes generated during the bagging process do not follow the above rules for jumping between nodes.</p>
-            <pre data-language="text">Altitude
+            <pre data-language="text"><span></span>Altitude
 
     5                     20g
                          /  \
@@ -151,7 +151,7 @@ License: MIT</pre>
             <p>MMR trees allow for efficient incremental set update operations (push, pop, prune). In addition, MMR update operations and Merkle proofs for recent additions to the leaf set are more efficient than other incremental Merkle tree implementations (e.g. Bitcoin's padded leafset, sparse Merkle trees, and Zcash's incremental note commitment trees).</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>MMR proofs are used in the FlyClient protocol <a id="id5" class="footnote_reference" href="#flyclient">2</a>, to reduce the proof size needed for light clients to verify:</p>
+            <p>MMR proofs are used in the FlyClient protocol <a href="#flyclient" id="id5" class="footnote_reference">2</a>, to reduce the proof size needed for light clients to verify:</p>
             <ul>
                 <li>the validity of a block chain received from a full node, and</li>
                 <li>the inclusion of a block
@@ -171,7 +171,7 @@ License: MIT</pre>
             <p>(
                 <span class="math">\(x\)</span>
              is the activation height of the preceding network upgrade.)</p>
-            <p>FlyClient reduces the number of block headers needed for light client verification of a valid chain, from linear (as in the current reference protocol) to logarithmic in block chain length. This verification is correct with high probability. It also allows creation of subtree proofs, so light clients need only check blocks later than the most recently verified block index. Following that, verification of a transaction inclusion within that block follows the usual reference protocol <a id="id6" class="footnote_reference" href="#zip-0307">13</a>.</p>
+            <p>FlyClient reduces the number of block headers needed for light client verification of a valid chain, from linear (as in the current reference protocol) to logarithmic in block chain length. This verification is correct with high probability. It also allows creation of subtree proofs, so light clients need only check blocks later than the most recently verified block index. Following that, verification of a transaction inclusion within that block follows the usual reference protocol <a href="#zip-0307" id="id6" class="footnote_reference">13</a>.</p>
             <p>A smaller proof size could enable the verification of Zcash SPV Proofs in block-chain protocols such as Ethereum, enabling efficient cross-chain communication and pegs. It also reduces bandwidth and storage requirements for resource-limited clients like mobile or IoT devices.</p>
         </section>
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -196,7 +196,7 @@ License: MIT</pre>
                 <span class="math">\(x\)</span>
              is defined as above. We extend the standard MMR to allow metadata to propagate upwards through the tree by either summing the metadata of both children, or inheriting the metadata of a specific child as necessary. This allows us to create efficient proofs of selected properties of a range of blocks without transmitting the entire range of blocks or headers.</p>
             <section id="tree-node-specification"><h3><span class="section-heading">Tree Node specification</span><span class="section-anchor"> <a rel="bookmark" href="#tree-node-specification"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Unless otherwise noted, all hashes use BLAKE2b-256 with the personalization field set to <code>'ZcashHistory' || CONSENSUS_BRANCH_ID</code>. <code>CONSENSUS_BRANCH_ID</code> is the 4-byte little-endian encoding of the consensus branch ID for the epoch of the block containing the commitment. <a id="id7" class="footnote_reference" href="#zip-0200">8</a> Which is to say, each node in the tree commits to the consensus branch that produced it.</p>
+                <p>Unless otherwise noted, all hashes use BLAKE2b-256 with the personalization field set to <code>'ZcashHistory' || CONSENSUS_BRANCH_ID</code>. <code>CONSENSUS_BRANCH_ID</code> is the 4-byte little-endian encoding of the consensus branch ID for the epoch of the block containing the commitment. <a href="#zip-0200" id="id7" class="footnote_reference">8</a> Which is to say, each node in the tree commits to the consensus branch that produced it.</p>
                 <p>Each MMR node is defined as follows:</p>
                 <ol type="1">
                     <li><code>hashSubtreeCommitment</code>
@@ -287,7 +287,7 @@ License: MIT</pre>
                             <dt>Leaf node</dt>
                             <dd>The protocol-defined work of the block:
                                 <span class="math">\(\mathsf{floor}(2^{256} / (\mathsf{ToTarget}(\mathsf{nBits}) + 1))\)</span>
-                            . <a id="id8" class="footnote_reference" href="#protocol-workdef">3</a></dd>
+                            . <a href="#protocol-workdef" id="id8" class="footnote_reference">3</a></dd>
                             <dt>Internal or root node</dt>
                             <dd>
                                 <p>The sum of the <code>nSubTreeTotalWork</code> fields of both children.</p>
@@ -305,7 +305,7 @@ License: MIT</pre>
                     <li><code>nEarliestHeight</code>
                         <dl>
                             <dt>Leaf node</dt>
-                            <dd>The header's height.</dd>
+                            <dd>The block height encoded in the block's coinbase transaction.</dd>
                             <dt>Internal or root node</dt>
                             <dd>Inherited from the left child.</dd>
                         </dl>
@@ -314,7 +314,7 @@ License: MIT</pre>
                     <li><code>nLatestHeight</code>
                         <dl>
                             <dt>Leaf node</dt>
-                            <dd>The header's height.</dd>
+                            <dd>The block height encoded in the block's coinbase transaction.</dd>
                             <dt>Internal or root node</dt>
                             <dd>Inherited from the right child.</dd>
                         </dl>
@@ -357,13 +357,13 @@ License: MIT</pre>
                         <p>Serialized as <code>CompactSize uint</code>.</p>
                     </li>
                 </ol>
-                <p>The fields marked "[NU5 onward]" are omitted before NU5 activation <a id="id9" class="footnote_reference" href="#zip-0252">11</a>.</p>
+                <p>The fields marked "[NU5 onward]" are omitted before NU5 activation <a href="#zip-0252" id="id9" class="footnote_reference">11</a>.</p>
                 <p>Each node, when serialized, is between 147 and 171 bytes long (between 212 and 244 bytes after NU5 activation). The canonical serialized representation of a node is used whenever creating child commitments for future nodes. Other than the metadata commitments, the MMR tree's construction is standard.</p>
                 <p>Once the MMR has been generated, we produce <code>hashChainHistoryRoot</code>, which we define as the BLAKE2b-256 digest of the serialization of the root node.</p>
             </section>
             <section id="tree-nodes-and-hashing-pseudocode"><h3><span class="section-heading">Tree nodes and hashing (pseudocode)</span><span class="section-anchor"> <a rel="bookmark" href="#tree-nodes-and-hashing-pseudocode"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Note that this pseudocode reflects the specification prior to NU5 activation.</p>
-                <pre data-language="python"><span class="k">def</span> <span class="nf">H</span><span class="p">(</span><span class="n">msg</span><span class="p">:</span> <span class="nb">bytes</span><span class="p">,</span> <span class="n">consensusBranchId</span><span class="p">:</span> <span class="nb">bytes</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bytes</span><span class="p">:</span>
+                <pre data-language="python"><span></span><span class="k">def</span> <span class="nf">H</span><span class="p">(</span><span class="n">msg</span><span class="p">:</span> <span class="nb">bytes</span><span class="p">,</span> <span class="n">consensusBranchId</span><span class="p">:</span> <span class="nb">bytes</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="nb">bytes</span><span class="p">:</span>
     <span class="k">return</span> <span class="n">blake2b256</span><span class="p">(</span><span class="n">msg</span><span class="p">,</span> <span class="n">personalization</span><span class="o">=</span><span class="sa">b</span><span class="s1">&#39;ZcashHistory&#39;</span> <span class="o">+</span> <span class="n">consensusBranchId</span><span class="p">)</span>
 
 <span class="k">class</span> <span class="nc">ZcashMMRNode</span><span class="p">():</span>
@@ -390,8 +390,8 @@ License: MIT</pre>
     <span class="k">def</span> <span class="nf">from_block</span><span class="p">(</span><span class="n">Z</span><span class="p">,</span> <span class="n">block</span><span class="p">:</span> <span class="n">ZcashBlock</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">ZcashMMRNode</span><span class="p">:</span>
         <span class="sd">&#39;&#39;&#39;Create a leaf node from a block&#39;&#39;&#39;</span>
         <span class="k">return</span> <span class="n">Z</span><span class="p">(</span>
-            <span class="n">left_child</span><span class="o">=</span><span class="bp">None</span><span class="p">,</span>
-            <span class="n">right_child</span><span class="o">=</span><span class="bp">None</span><span class="p">,</span>
+            <span class="n">left_child</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
+            <span class="n">right_child</span><span class="o">=</span><span class="kc">None</span><span class="p">,</span>
             <span class="n">hashSubtreeCommitment</span><span class="o">=</span><span class="n">block</span><span class="o">.</span><span class="n">header_hash</span><span class="p">,</span>
             <span class="n">nEarliestTimestamp</span><span class="o">=</span><span class="n">block</span><span class="o">.</span><span class="n">timestamp</span><span class="p">,</span>
             <span class="n">nLatestTimestamp</span><span class="o">=</span><span class="n">block</span><span class="o">.</span><span class="n">timestamp</span><span class="p">,</span>
@@ -450,8 +450,8 @@ License: MIT</pre>
                     <span class="math">\(B_n\)</span>
                 , we append a new MMR leaf node corresponding to block
                     <span class="math">\(B_{n-1}\)</span>
-                . The <code>append</code> operation is detailed below in pseudocode (adapted from <a id="id10" class="footnote_reference" href="#flyclient">2</a>):</p>
-                <pre data-language="python"><span class="k">def</span> <span class="nf">get_peaks</span><span class="p">(</span><span class="n">node</span><span class="p">:</span> <span class="n">ZcashMMRNode</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">List</span><span class="p">[</span><span class="n">ZcashMMRNode</span><span class="p">]:</span>
+                . The <code>append</code> operation is detailed below in pseudocode (adapted from <a href="#flyclient" id="id10" class="footnote_reference">2</a>):</p>
+                <pre data-language="python"><span></span><span class="k">def</span> <span class="nf">get_peaks</span><span class="p">(</span><span class="n">node</span><span class="p">:</span> <span class="n">ZcashMMRNode</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">List</span><span class="p">[</span><span class="n">ZcashMMRNode</span><span class="p">]:</span>
     <span class="n">peaks</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="n">ZcashMMRNode</span><span class="p">]</span> <span class="o">=</span> <span class="p">[]</span>
 
     <span class="c1"># Get number of leaves.</span>
@@ -509,7 +509,7 @@ License: MIT</pre>
                  where
                     <span class="math">\(k\)</span>
                  is the number of leaves in the right subtree of the MMR root.</p>
-                <pre data-language="python"><span class="k">def</span> <span class="nf">delete</span><span class="p">(</span><span class="n">root</span><span class="p">:</span> <span class="n">ZcashMMRNode</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">ZcashMMRNode</span><span class="p">:</span>
+                <pre data-language="python"><span></span><span class="k">def</span> <span class="nf">delete</span><span class="p">(</span><span class="n">root</span><span class="p">:</span> <span class="n">ZcashMMRNode</span><span class="p">)</span> <span class="o">-&gt;</span> <span class="n">ZcashMMRNode</span><span class="p">:</span>
     <span class="sd">&#39;&#39;&#39;</span>
 <span class="sd">    Delete the rightmost leaf node from an existing MMR</span>
 <span class="sd">    Return the new tree root</span>
@@ -538,9 +538,9 @@ License: MIT</pre>
     <span class="k">return</span> <span class="n">new_root</span></pre>
             </section>
             <section id="block-header-semantics-and-consensus-rules"><h3><span class="section-heading">Block header semantics and consensus rules</span><span class="section-anchor"> <a rel="bookmark" href="#block-header-semantics-and-consensus-rules"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The following specification is accurate before NU5 activation. See <a id="id11" class="footnote_reference" href="#zip-0244">9</a> for header field changes in NU5.</p>
+                <p>The following specification is accurate before NU5 activation. See <a href="#zip-0244" id="id11" class="footnote_reference">9</a> for header field changes in NU5.</p>
                 <p>The <code>hashFinalSaplingRoot</code> block header field (which was named <code>hashReserved</code> prior to the Sapling network upgrade) is renamed to <code>hashLightClientRoot</code>, to reflect its usage by light clients.</p>
-                <p>Prior to activation of the network upgrade that deploys this ZIP, this existing consensus rule on block headers (adjusted for the renamed field) is enforced: <a id="id12" class="footnote_reference" href="#protocol-blockheader">4</a></p>
+                <p>Prior to activation of the network upgrade that deploys this ZIP, this existing consensus rule on block headers (adjusted for the renamed field) is enforced: <a href="#protocol-blockheader" id="id12" class="footnote_reference">4</a></p>
                 <blockquote>
                     <p>[Sapling onward] <code>hashLightClientRoot</code> MUST be
                         <span class="math">\(\mathsf{LEBS2OSP}_{256}(\mathsf{rt})\)</span>
@@ -610,7 +610,7 @@ License: MIT</pre>
             </section>
             <section id="header-format-change"><h3><span class="section-heading">Header Format Change</span><span class="section-anchor"> <a rel="bookmark" href="#header-format-change"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The primary goal of the original authors was to minimize header changes; in particular, they preferred not to introduce changes that could affect mining hardware or embedded software. Altering the block header format would require changes throughout the ecosystem, so we decided against adding <code>hashChainHistoryRoot</code> to the header as a new field.</p>
-                <p>ZIP 301 states that "[Miner client software] SHOULD alert the user upon receiving jobs containing block header versions they do not know about or support, and MUST ignore such jobs." <a id="id13" class="footnote_reference" href="#zip-0301">12</a> As the only formally defined block header version is 4, any header version change requires changes to miner client software in order for miners to handle new jobs from mining pools. We therefore do not alter the block version for this semantic change. This does not make block headers ambiguous to interpret, because blocks commit to their block height inside their coinbase transaction, <a id="id14" class="footnote_reference" href="#bip-0034">7</a> and they are never handled in a standalone context (unlike transactions, which exist in the mempool outside of blocks).</p>
+                <p>ZIP 301 states that "[Miner client software] SHOULD alert the user upon receiving jobs containing block header versions they do not know about or support, and MUST ignore such jobs." <a href="#zip-0301" id="id13" class="footnote_reference">12</a> As the only formally defined block header version is 4, any header version change requires changes to miner client software in order for miners to handle new jobs from mining pools. We therefore do not alter the block version for this semantic change. This does not make block headers ambiguous to interpret, because blocks commit to their block height inside their coinbase transaction, <a href="#bip-0034" id="id14" class="footnote_reference">7</a> and they are never handled in a standalone context (unlike transactions, which exist in the mempool outside of blocks).</p>
                 <p>Replacing <code>hashFinalSaplingRoot</code> with <code>hashChainHistoryRoot</code> does introduce the theoretical possibility of an attack where a miner constructs a Sapling commitment tree update that results in the same 32-byte value as the MMR root. We don't consider this a realistic attack, both because the adversary would need to find a preimage over 32 layers of Pedersen hash, and because light clients already need to update their code to include the consensus branch ID for the Heartwood network upgrade, and can simultaneously make changes to not rely on the value of this header field being the Sapling tree root.</p>
                 <p>We also considered putting <code>hashChainHistoryRoot</code> in the <code>hashPrevBlock</code> field as it commits to the entire chain history, but quickly realized it would require massive refactoring of the existing code base and would negatively impact performance. Reorgs in particular are fragile, performance-critical, and rely on backwards iteration over the chain history. If a chain were to be designed from scratch there may be some efficient implementation that would join these commitments, but it is clearly not appropriate for Zcash as it exists.</p>
                 <p>The calculation of <code>hashChainHistoryRoot</code> is not well-defined for the genesis block, since then
@@ -626,11 +626,11 @@ License: MIT</pre>
             <p>Generally, header commitments have no impact on privacy. However, FlyClient has additional security and privacy implications. Because FlyClient is a motivating factor for this ZIP, it seems prudent to include a brief overview. A more in-depth security analysis of FlyClient should be performed before designing a FlyClient-based light client ecosystem for Zcash.</p>
             <p>FlyClient, like all light clients, requires a connection to a light client server. That server may collect information about client requests, and may use that information to attempt to deanonymize clients. However, because FlyClient proofs are non-interactive and publicly verifiable, they could be shared among many light clients after the initial server interaction.</p>
             <p>FlyClient proofs are probabilistic. When properly constructed, there is negligible probability that a dishonest chain commitment will be accepted by the verifier. The security analysis assumes adversary mining power is bounded by a known fraction of combined mining power of honest nodes, and cannot drop or tamper with messages between client and full nodes. It also assumes the client is connected to at least one full node and knows the genesis block.</p>
-            <p>In addition, <a id="id15" class="footnote_reference" href="#flyclient">2</a> only analyses these security properties in chain models with slowly adjusting difficulty, such as Bitcoin. That paper leaves their analysis in chains with rapidly adjusting difficulty –such as Zcash or Ethereum– as an open problem, and states that the FlyClient protocol provides only heuristic security guarantees in that case. However, as mentioned in <a href="#flyclient-requirements-and-recommendations">FlyClient Requirements and Recommendations</a>, additional commitments allowing light clients to reason about application of the difficulty adjustment algorithm were added in discussion with an author of the FlyClient paper. The use of these fields has not been analysed in the academic security literature. It would be possible to update them in a future network upgrade if further security analysis were to find any deficiencies.</p>
+            <p>In addition, <a href="#flyclient" id="id15" class="footnote_reference">2</a> only analyses these security properties in chain models with slowly adjusting difficulty, such as Bitcoin. That paper leaves their analysis in chains with rapidly adjusting difficulty –such as Zcash or Ethereum– as an open problem, and states that the FlyClient protocol provides only heuristic security guarantees in that case. However, as mentioned in <a href="#flyclient-requirements-and-recommendations">FlyClient Requirements and Recommendations</a>, additional commitments allowing light clients to reason about application of the difficulty adjustment algorithm were added in discussion with an author of the FlyClient paper. The use of these fields has not been analysed in the academic security literature. It would be possible to update them in a future network upgrade if further security analysis were to find any deficiencies.</p>
         </section>
         <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>On the Zcash Mainnet and Testnet, this proposal will be deployed with the Heartwood network upgrade. <a id="id16" class="footnote_reference" href="#zip-0250">10</a></p>
-            <p>Additional fields are added on activation of the NU5 network upgrade <a id="id17" class="footnote_reference" href="#zip-0252">11</a>, to support the new Orchard shielded protocol.</p>
+            <p>On the Zcash Mainnet and Testnet, this proposal will be deployed with the Heartwood network upgrade. <a href="#zip-0250" id="id16" class="footnote_reference">10</a></p>
+            <p>Additional fields are added on activation of the NU5 network upgrade <a href="#zip-0252" id="id17" class="footnote_reference">11</a>, to support the new Orchard shielded protocol.</p>
         </section>
         <section id="additional-reading"><h2><span class="section-heading">Additional Reading</span><span class="section-anchor"> <a rel="bookmark" href="#additional-reading"><img width="24" height="24" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>

--- a/zip-0221.rst
+++ b/zip-0221.rst
@@ -300,7 +300,7 @@ Each MMR node is defined as follows:
 9. ``nEarliestHeight``
 
    Leaf node
-     The header's height.
+     The block height encoded in the block's coinbase transaction.
 
    Internal or root node
      Inherited from the left child.
@@ -310,7 +310,7 @@ Each MMR node is defined as follows:
 10. ``nLatestHeight``
 
     Leaf node
-      The header's height.
+     The block height encoded in the block's coinbase transaction.
 
     Internal or root node
       Inherited from the right child.


### PR DESCRIPTION
The block height is encoded in each block's coinbase transaction.

Unfortunately, my version of `rst2html5` generates HTML attributes in a different order from the rest of the repository. So there might be a redundant change next time someone else rebuilds.