### PR TITLE
Fix Orchard Action byte size

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12264,7 +12264,7 @@ A \saplingBindingSignature on the \sighashTxHash, validated per \crossref{concre
 & \Varies &\setnufive $\nActionsOrchard\!$ & \type{compactSize} &
 The number of \actionDescriptions in $\vActionsOrchard$.\! \\ \hline
 
-& \Longunderstack{$884 \mult$ \\$\!\nActionsOrchard\!$} & $\vActionsOrchard$ & \type{ActionDescription} \type{[$\nActionsOrchard$]} &
+& \Longunderstack{$820 \mult$ \\$\!\nActionsOrchard\!$} & $\vActionsOrchard$ & \type{ActionDescription} \type{[$\nActionsOrchard$]} &
 A sequence of \actionDescriptions{}, encoded per \crossref{actionencodingandconsensus}.\! \\ \hline
 
 $\mathsection$ & $1$ & $\flagsOrchard$ & \type{byte} &


### PR DESCRIPTION
Since the signature is now separate, the size is 64 bytes smaller.