### PR TITLE
Explicitly apply MAX_MONEY to Orchard

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12476,7 +12476,7 @@ Several fields are reordered and/or renamed relative to prior versions.}} %scale
   \overwinteronwarditem{\nExpiryHeight{} \MUST be less than or equal to 499999999.}
   \overwinteronwarditem{If a \transaction is not a \coinbaseTransaction and its \nExpiryHeight{} field
         is nonzero, then it \MUSTNOT be mined at a \blockHeight greater than its \nExpiryHeight.}
-  \saplingonwarditem{\valueBalance{} \MUST be in the range $\range{-\MAXMONEY}{\MAXMONEY}$.}
+  \saplingonwarditem{\valueBalance{Sapling}\nufive{ and \valueBalance{Orchard}} \MUST be in the range $\range{-\MAXMONEY}{\MAXMONEY}$.}
   \heartwoodonwarditem{All \SaplingAndOrchard outputs in \coinbaseTransactions \MUST decrypt to a
         \notePlaintext, i.e.\ the procedure in \crossref{decryptovk} does not return $\bot$,
         using a sequence of $32$ zero bytes as the \outgoingViewingKey.}


### PR DESCRIPTION
Previously, this rule applied to `[Sapling onward] valueBalance`, which is unclear.