### PR TITLE
Specify that version 1-4 transaction IDs use SHA-256d

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -7966,7 +7966,8 @@ associated bit sequence. (In the NIST specification ``first'' is conflated with
 ``leftmost''.)
 
 \introlist
-\defining{\shadHash}, defined as a double application of \shaHash, is used to hash \blockHeaders:
+\defining{\shadHash}, defined as a double application of \shaHash, is used to hash \blockHeaders,
+and version 1-4 \transactionIDs:
 
 \begin{formulae}
   \item $\SHAFulld \typecolon \byteseqs \rightarrow \byteseq{32}$

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -7967,7 +7967,7 @@ associated bit sequence. (In the NIST specification ``first'' is conflated with
 
 \introlist
 \defining{\shadHash}, defined as a double application of \shaHash, is used to hash \blockHeaders,
-and version 1-4 \transactionIDs:
+and used to produce version 1-4 \transactionIDs:
 
 \begin{formulae}
   \item $\SHAFulld \typecolon \byteseqs \rightarrow \byteseq{32}$

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -7967,7 +7967,7 @@ associated bit sequence. (In the NIST specification ``first'' is conflated with
 
 \introlist
 \defining{\shadHash}, defined as a double application of \shaHash, is used to hash \blockHeaders,
-and used to produce version 1-4 \transactionIDs:
+and used to produce version 1-4 \transactionIDs from their serialized byte encodings:
 
 \begin{formulae}
   \item $\SHAFulld \typecolon \byteseqs \rightarrow \byteseq{32}$


### PR DESCRIPTION
As far as I can tell, the derivation of  version 1-4 transaction IDs isn't specified anywhere.

~This is a partial specification: it specifies the hash function, but not the serialization.~