### PR TITLE
Make heightBytes encoding match NU5 coinbase nExpiryHeight

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12515,7 +12515,7 @@ in \cite{ZIP-239}.
         the range $\range{1}{16}$, the encoding is a single byte of value $\hexint{50} + \BlockHeight$.
         Otherwise, let $\heightBytes$ be the signed little-endian representation of $\BlockHeight$,
         using the minimum nonzero number of bytes such that the most significant byte is $< \hexint{80}$.
-        The length of $\heightBytes$ \MUST be in the range $\range{1}{8}$. Then the encoding is the
+        The length of $\heightBytes$ \MUST be in the range $\range{1}{5}$. Then the encoding is the
         length of $\heightBytes$ encoded as one byte, followed by $\heightBytes$ itself. This matches
         the encoding used by \Bitcoin in the implementation of \cite{BIP-34} (but the description here
         is to be considered normative).


### PR DESCRIPTION
Since nExpiryHeight is limited to `2^32 - 1`, heightBytes is limited to 5 bytes.
(heightBytes is effectively the non-negative half of a signed encoding.)

We could also use a 4 byte limit to match the minimum required height of `2^31 - 1`.

This change is optional and is only relevant in the far future.

But I think it might be helpful to remove confusion between the encoding of coinbase script height and expiry height.