### PR TITLE
Only check remaining transparent value for non-coinbase transactions

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1007,7 +1007,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\transparentOutput}{\term{transparent output}}
 \newcommand{\transparentOutputs}{\terms{transparent output}}
 \newcommand{\xTransparentOutputs}{\termxs{transparent output}}
-\newcommand{\transparentTxValuePool}{\termandindex{transparent transaction value pool}{transaction value pool (transparent)}}
+\newcommand{\transparentTxValuePool}{\termandindex{non-coinbase transparent transaction value pool}{transaction value pool (non-coinbase transparent)}}
 % There is no Sprout transaction value pool, since JoinSplits are balanced individually.
 \newcommand{\SaplingTxValuePool}{\termandindex{\textbf{Sapling} transaction value pool}{transaction value pool (Sapling)}}
 \newcommand{\OrchardTxValuePool}{\termandindex{\textbf{Orchard} transaction value pool}{transaction value pool (Orchard)}}
@@ -3342,7 +3342,7 @@ use each of them, see \cite{ZIP-239} and \cite{ZIP-244}.}
 \vspace{2ex}
 \defining{\xTransparentInputs} to a \transaction insert value into a \defining{\transparentTxValuePool}
 associated with the \transaction, and \defining{\transparentOutputs} remove value from this pool.
-As in \Bitcoin, the remaining value in the pool is available to miners as a fee.
+As in \Bitcoin, the remaining value in non-coinbase transaction pools is available to miners as a fee.
 
 \vspace{-1ex}
 \consensusrule{


### PR DESCRIPTION
When read in context, it's impossible to apply this rule to coinbase transactions.
But we should make that clear in the spec.

There are a few different ways to apply this change, feel free to do whatever works for your index style and rule style.