### PR TITLE
fix contradictory terminology, with introduction of segment

### DIFF
--- a/zip-0200.rst
+++ b/zip-0200.rst
@@ -25,14 +25,15 @@ Consensus rule set
   A set of validation rules that determine which block chains are considered valid.
 
 Consensus rule change
-  A change in the consensus rule set of the network, such that nodes that do not recognize the new rules will
-  follow a different block chain.
+  A change in the consensus rule set.
+  This implies that a new block constructed with the new rule set will be on a different chain,
+  from a new block constructed with the old rule set.
 
-Consensus branch
-  A block chain with a common consensus rule set, where the first block in the chain is either the genesis
-  block, or the child of a parent block created under an older set of consensus rules (i.e. the parent block
-  is a member of a different consensus branch). By definition, every block belongs to at most one consensus
-  branch.
+Consensus segment
+  A block chain segment built with a single consensus rule set.
+  The first block in the segment is either the genesis block, or the child of a parent block created under 
+  the previous consensus rule set (i.e. the parent block is a member of a different consensus segment). 
+  By definition, every block belongs to at most one consensus segment.
 
 Network upgrade
   An intentional consensus rule change undertaken by the community in order to improve the network.
@@ -50,7 +51,7 @@ Motivation
 ==========
 
 Zcash is a *consensual currency*: nobody is ever going to force someone to use a specific software
-implementation or a specific consensus branch of Zcash. [#consensual-currency]_ As such, different
+implementation or a specific consensus segment of Zcash. [#consensual-currency]_ As such, different
 sub-communities will always have the freedom to choose different variants or branches which offer different
 design trade-offs.
 
@@ -86,7 +87,7 @@ The following constants are defined for every network upgrade:
 CONSENSUS_BRANCH_ID
   A globally-unique non-zero 32-bit identifier.
 
-  Implementations MAY use a value of zero in consensus branch ID fields to indicate the absence of any
+  Implementations MAY use a value of zero in consensus segment ID fields to indicate the absence of any
   upgrade (i.e. that the Sprout consensus rules apply).
 
 ACTIVATION_HEIGHT
@@ -108,8 +109,8 @@ ACTIVATION_HEIGHT
     re-integrate into the network prior to activation of the network upgrade.
 
 The relationship between ``CONSENSUS_BRANCH_ID`` and ``ACTIVATION_HEIGHT`` is many-to-one: it is possible
-for many distinct consensus branches to descend from the same parent block (and thus have the same
-``ACTIVATION_HEIGHT``), but a specific consensus branch can only have one parent block. Concretely, this
+for many distinct consensus segments to descend from the same parent block (and thus have the same
+``ACTIVATION_HEIGHT``), but a specific consensus segment can only have one parent block. Concretely, this
 means that if the ``ACTIVATION_HEIGHT`` of a network upgrade is changed for any reason (e.g. security
 vulnerabilities or consensus bugs are discovered), the ``CONSENSUS_BRANCH_ID`` MUST also be changed.
 
@@ -143,7 +144,7 @@ network behavior or surrounding code that depends on it) MUST be gated by a bloc
 Block validation
 ````````````````
 Incoming blocks known to have a particular height (due to their parent chain being entirely known) MUST be
-validated under the consensus rules corresponding to the expected consensus branch ID for that height.
+validated under the consensus rules corresponding to the expected consensus segment ID for that height.
 
 Incoming blocks with unknown heights (because at least one block header in their parent chain is unknown)
 MAY be cached, so that they can be reconsidered in the future after all their parents have been received.
@@ -158,8 +159,8 @@ Post-activation upgrading
 `````````````````````````
 If a user does not upgrade their node to a compatible software version before ``ACTIVATION_HEIGHT`` is
 reached, and the node continues running (which could normally only occur if the End-of-Service halt were
-bypassed), then the node will follow any pre-upgrade consensus branch that persists. In this case it may
-download blocks that are incompatible with the post-upgrade consensus branch. If the user subsequently
+bypassed), then the node will follow any pre-upgrade consensus segment that persists. In this case it may
+download blocks that are incompatible with the post-upgrade consensus segment. If the user subsequently
 upgrades their node to a compatible software version, the node will consider these blocks to be invalid,
 and if there are a significant number of invalid blocks it SHOULD shut down and alert the user of the issue.
 
@@ -167,10 +168,10 @@ Memory pool
 -----------
 
 While the current chain tip height is below ``ACTIVATION_HEIGHT``, nodes SHOULD NOT accept transactions that
-will only be valid on the post-upgrade consensus branch.
+will only be valid on the post-upgrade consensus segment.
 
 When the current chain tip height reaches ``ACTIVATION_HEIGHT``, the node's local transaction memory pool
-SHOULD be cleared of transactions that will never be valid on the post-upgrade consensus branch.
+SHOULD be cleared of transactions that will never be valid on the post-upgrade consensus segment.
 
 Two-way replay protection
 -------------------------
@@ -178,7 +179,7 @@ Two-way replay protection
 Before the Overwinter network upgrade, two-way replay protection is ensured by enforcing post-upgrade that the
 most significant bit of the transaction version is set to 1. [#zip-0202]_ From the perspective of old nodes,
 the transactions will have a negative version number, which is invalid under the old consensus rules.
-Enforcing this rule trivially makes old transactions invalid on the Overwinter consensus branch.
+Enforcing this rule trivially makes old transactions invalid on the Overwinter consensus segment.
 
 After the Overwinter network upgrade, two-way replay protection is ensured by transaction signatures
 committing to a specific ``CONSENSUS_BRANCH_ID``. [#zip-0143]_
@@ -187,8 +188,8 @@ Wipe-out protection
 -------------------
 
 Nodes running upgrade-aware software versions will enforce the upgraded consensus rules from
-``ACTIVATION_HEIGHT``. The chain from that height will not reorganize to a pre-upgrade consensus branch if
-any block in that consensus branch would violate the new consensus rules.
+``ACTIVATION_HEIGHT``. The chain from that height will not reorganize to a pre-upgrade consensus segment if
+any block in that consensus segment would violate the new consensus rules.
 
 Care must be taken, however, to account for possible edge cases where the old and new consensus rules do not
 differ. For example, if the non-upgraded chain only contained empty blocks from ``ACTIVATION_HEIGHT``, and the
@@ -211,7 +212,7 @@ Backward compatibility
 This proposal intentionally creates what is known as a "bilateral consensus rule change". Use of this
 mechanism requires that all network participants upgrade their software to a compatible version within the
 upgrade window. Older software will treat post-upgrade blocks as invalid, and will follow any pre-upgrade
-consensus branch that persists.
+consensus segment that persists.
 
 
 Reference Implementation


### PR DESCRIPTION
The existing terminology is contradictory, as defined `consensus branches` would contain ancestors since block chains were defined to start from the genesis block.