### PR TITLE
Update Zebra NU5 testnet release and connection behaviour

### DIFF
--- a/zip-0252.html
+++ b/zip-0252.html
@@ -108,7 +108,7 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;</pre>
             <p>Several versions of Zebra have implemented versions of the NU5 consensus rules on Testnet:</p>
             <ul>
                 <li><cite>zebrad</cite> v1.0.0-alpha.18 implemented partial support for NU5 on Testnet, validating a strict subset of the NU5 consensus rules. This version had an activation height of 1599200, as described in section <a href="#nu5-deployment">NU5 deployment</a> above.</li>
-                <li><cite>zebrad</cite> v1.0.0-beta.7 will fully validate what is expected to be the final revision of the NU5 consensus rules. As part of these consensus rule changes, <cite>zebrad</cite> v1.0.0-beta.7 will automatically re-download the entire chain from genesis, then follow an alternate chain starting at height 1599200. It will advertise protocol version 170050.</li>
+                <li><cite>zebrad</cite> v1.0.0-beta.8 will fully validate what is expected to be the final revision of the NU5 consensus rules. As part of these consensus rule changes, <cite>zebrad</cite> v1.0.0-beta.8 will automatically re-download the entire chain from genesis, then follow an alternate chain starting at height 1599200. It will advertise protocol version 170050.</li>
             </ul>
             <p>Support for NU5 on Mainnet will be implemented in <cite>zebrad</cite> version [TODO], which will advertise protocol version 170100.</p>
             <section id="backward-compatibility-in-zebra"><h3><span class="section-heading">Backward compatibility in Zebra</span><span class="section-anchor"> <a rel="bookmark" href="#backward-compatibility-in-zebra"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -119,8 +119,7 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;</pre>
                 </ul>
             </section>
             <section id="nu5-deployment-for-zebra"><h3><span class="section-heading">NU5 deployment for Zebra</span><span class="section-anchor"> <a rel="bookmark" href="#nu5-deployment-for-zebra"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>For each network, at the corresponding NU5 activation height, nodes compatible with NU5 activation on that network will close any new connections with pre-NU5 peers.</p>
-                <p>Since Zebra maintains a reasonably strict internal request-response protocol, pre-NU5 nodes will gradually be disconnected after activation. (Nodes are temporarily disconnected if they send gossip or chain sync hints outside the strict request-response sequence that Zebra expects.)</p>
+                <p>For each network, at the corresponding NU5 activation height, nodes compatible with NU5 activation on that network will close any existing connections with pre-NU5 peers, and reject new connections from pre-NU5 peers.</p>
             </section>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zip-0252.rst
+++ b/zip-0252.rst
@@ -191,9 +191,9 @@ rules on Testnet:
   validating a strict subset of the NU5 consensus rules. This version had an
   activation height of 1599200, as described in section `NU5 deployment`_
   above.
-- `zebrad` v1.0.0-beta.7 will fully validate what is expected to be the final
+- `zebrad` v1.0.0-beta.8 will fully validate what is expected to be the final
   revision of the NU5 consensus rules. As part of these consensus rule changes,
-  `zebrad` v1.0.0-beta.7 will automatically re-download the entire chain from
+  `zebrad` v1.0.0-beta.8 will automatically re-download the entire chain from
   genesis, then follow an alternate chain starting at height 1599200. It will
   advertise protocol version 170050.
 
@@ -214,13 +214,8 @@ NU5 deployment for Zebra
 ------------------------
 
 For each network, at the corresponding NU5 activation height, nodes compatible
-with NU5 activation on that network will close any new connections with pre-NU5
-peers.
-
-Since Zebra maintains a reasonably strict internal request-response protocol,
-pre-NU5 nodes will gradually be disconnected after activation. (Nodes are
-temporarily disconnected if they send gossip or chain sync hints outside the
-strict request-response sequence that Zebra expects.)
+with NU5 activation on that network will close existing connections with pre-NU5
+peers, and reject new connections from pre-NU5 peers.
 
 
 References


### PR DESCRIPTION
We decided to do another Zebra release before NU5 testnet re-activation.

We also changed Zebra's peer protocol version connection filter around network upgrade activation a few months ago.