### PR TITLE
Add value of sizeProofsOrchard to protocol spec §7.1 and ZIP 225

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12527,7 +12527,7 @@ $\mathsection$ & $32$ & $\anchorField{Orchard}$ & \type{byte[32]} &
 A \merkleRoot of the \Orchard \noteCommitmentTree at some \blockHeight in the past, $\LEBStoOSP{256}\big(\rt{Orchard}\big)$.\! \\ \hline
 
 $\mathsection$ & \Varies & $\sizeProofsOrchard$ & \type{compactSize} &
-The length of the aggregated \zkSNARKProof $\ProofAction$.\! \\ \hline
+The length of the aggregated \zkSNARKProof $\ProofAction$. Value is $2720 + 2272 \cdot \nActionsOrchard$.\! \\ \hline
 
 $\mathsection$ & \!$\sizeProofsOrchard$\! & $\proofsOrchard$ & \type{byte[$\sizeProofsOrchard$]}\!\! &
 The aggregated \zkSNARKProof $\ProofAction$ (see \crossref{halo2}).\! \\ \hline

--- a/zip-0225.html
+++ b/zip-0225.html
@@ -234,7 +234,9 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
                             <td><code>varies</code></td>
                             <td><code>sizeProofsOrchard</code></td>
                             <td><code>compactSize</code></td>
-                            <td>Length in bytes of <code>proofsOrchard</code>.</td>
+                            <td>Length in bytes of <code>proofsOrchard</code>. Value is
+                                <span class="math">\(2720 + 2272 \cdot \mathtt{nActionsOrchard}\)</span>
+                            .</td>
                         </tr>
                         <tr>
                             <td><code>sizeProofsOrchard</code></td>

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -152,7 +152,8 @@ Transaction Format
 |``32``                       |``anchorOrchard``         |``byte[32]``                            |A root of the Orchard note commitment tree at some block             |
 |                             |                          |                                        |height in the past.                                                  |
 +-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
-|``varies``                   |``sizeProofsOrchard``     |``compactSize``                         |Length in bytes of ``proofsOrchard``.                                |
+|``varies``                   |``sizeProofsOrchard``     |``compactSize``                         |Length in bytes of ``proofsOrchard``. Value is                       |
+|                             |                          |                                        |:math:`2720 + 2272 \cdot \mathtt{nActionsOrchard}`.                  |
 +-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+
 |``sizeProofsOrchard``        |``proofsOrchard``         |``byte[sizeProofsOrchard]``             |Encoding of aggregated zk-SNARK proofs for Orchard Actions.          |
 +-----------------------------+--------------------------+----------------------------------------+---------------------------------------------------------------------+


### PR DESCRIPTION
ZIP 225 is re-rendered; the protocol spec PDF is not (as this should be batched with any other upcoming changes).