### PR TITLE
Fix pre-heartwood rule preventing Sapling shielded coinbase 

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12645,7 +12645,7 @@ in \cite{ZIP-239}.
         \zatoshi of \blockSubsidy plus the \transactionFees paid by \transactions in this \block.
   \item A \coinbaseTransaction \MUSTNOT have any \joinSplitDescriptions.
   \item \sapling{A \coinbaseTransaction \MUSTNOT have any \spendDescriptions.}
-  \preheartwooditem{\sapling{A \coinbaseTransaction \MUST have any \outputDescriptions.}}
+  \preheartwooditem{\sapling{A \coinbaseTransaction \MUSTNOT have any \outputDescriptions.}}
   \nufiveonwarditem{In a version 5 \coinbaseTransaction, the \enableSpendsOrchard{} flag \MUST be $0$.}
   \nufiveonwarditem{In a version 5 \transaction, the reserved bits $\barerange{2}{7}$ of the
         \flagsOrchard{} field \MUST be zero.}


### PR DESCRIPTION
In context, this seems like a typo where MUST was used instead of MUSTNOT:

<img width="743" alt="Screen Shot 2022-10-25 at 10 28 04" src="https://user-images.githubusercontent.com/8951843/197654808-ba6236ce-9353-4e26-8db3-92d4c85a63e0.png">
