### PR TITLE
Amend ZIP1014 to provide a Discretionary Budget for MGRC

### DIFF
--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -267,8 +267,8 @@ Grants, but subject to the following additional constraints:
    MUST be approved by the Major Grant Review Committee. Expenses related to the 
    administration of Major Grants include, without limitation the following:
    
-   * Paying third party vendor for services related to domain name registration, 
-     website design, website hosting and administration for the Major Grant 
+   * Paying third party vendor for services related to domain name registration,  or
+     the design, website hosting and administration of websites for the Major Grant 
      Review Committee.
    * Paying independent consultant to develop requests for proposals that align 
      with the Major Grants program.

--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -270,12 +270,12 @@ Grants, but subject to the following additional constraints:
    * Paying third party vendor for services related to domain name registration,  or
      the design, website hosting and administration of websites for the Major Grant 
      Review Committee.
-   * Paying independent consultant to develop requests for proposals that align 
+   * Paying independent consultants to develop requests for proposals that align 
      with the Major Grants program.
-   * Paying independent consultant for expert review of grant applications.
+   * Paying independent consultants for expert review of grant applications.
    * Paying for sales and marketing services to promote the Major Grants 
      program.
-   * Paying third party consultant to undertake activities that support the 
+   * Paying third party consultants to undertake activities that support the 
      purpose of the Major Grants program. 
    * Reimbursement to members of the Major Grant Review Committee for reasonable 
      travel expenses, including transportation, hotel and meals allowance.

--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -209,13 +209,16 @@ Zcash ecosystem, to perform major ongoing development (or other work) for the
 public good of the Zcash ecosystem, to the extent that such teams are available
 and effective.
 
-The funds SHALL be received and administered by ZF. ZF MUST disburse them as
-"Major Grants", but subject to the following additional constraints:
+The funds SHALL be received and administered by ZF. ZF MUST disburse them for
+"Major Grants" and expenses reasonably related to the administration of Major 
+Grants, but subject to the following additional constraints:
 
 1. These funds MUST only be used to issue Major Grants to external parties
-   that are independent of ZF. They MUST NOT be used by ZF for its internal
-   operations and direct expenses. Additionally, BP, ECC, and ZF are ineligible
-   to receive Major Grants.
+   that are independent of ZF, and to pay for expenses reasonably related to 
+   the administration of Major Grants. They MUST NOT be used by ZF for its 
+   internal operations and direct expenses not related to administration of 
+   Major Grants. Additionally, BP, ECC, and ZF are ineligible to receive 
+   Major Grants.
 
 2. Major Grants SHOULD support well-specified work proposed by the grantee,
    at reasonable market-rate costs. They can be of any duration or ongoing
@@ -255,6 +258,33 @@ The funds SHALL be received and administered by ZF. ZF MUST disburse them as
    an immediate family relationship with any of the above. The ZF SHALL continue
    to operate the Community Advisory Panel and SHOULD work toward making it more
    representative and independent (more on that below).
+   
+8. From 1st January 2022, a portion of the MG Slice shall be allocated to a 
+   Discretionary Budget, which may be disbursed for expenses reasonably related 
+   to the administration of Major Grants. The amount of funds allocated to the 
+   Discretionary Budget SHALL be decided by the ZF's Community Advisory Panel or 
+   successor process. Any disbursement of funds from the Discretionary Budget 
+   MUST be approved by the Major Grant Review Committee. Expenses related to the 
+   administration of Major Grants include, without limitation the following:
+   
+   * Paying third party vendor for services related to domain name registration, 
+     website design, website hosting and administration for the Major Grant 
+     Review Committee.
+   * Paying independent consultant to develop requests for proposals that align 
+     with the Major Grants program.
+   * Paying independent consultant for expert review of grant applications.
+   * Paying for sales and marketing services to promote the Major Grants 
+     program.
+   * Paying third party consultant to undertake activities that support the 
+     purpose of the Major Grants program. 
+   * Reimbursement to members of the Major Grant Review Committee for reasonable 
+     travel expenses, including transportation, hotel and meals allowance.
+     
+   The Major Grant Review Committee's decisions relating to the allocation and 
+   disbursement of funds from the Discretionary Budget will be final, requiring 
+   no approval from the ZF Board, but are subject to veto if the Foundation 
+   judges them to violate U.S. law or the ZF's reporting requirements and other 
+   (current or future) obligations under U.S. IRS 501(c)(3).
 
 ZF SHALL recognize the MG slice of the Dev Fund as a Restricted Fund
 donation under the above constraints (suitably formalized), and keep separate

--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -267,7 +267,7 @@ Grants, but subject to the following additional constraints:
    MUST be approved by the Major Grant Review Committee. Expenses related to the 
    administration of Major Grants include, without limitation the following:
    
-   * Paying third party vendor for services related to domain name registration,  or
+   * Paying third party vendors for services related to domain name registration, or
      the design, website hosting and administration of websites for the Major Grant 
      Review Committee.
    * Paying independent consultants to develop requests for proposals that align 


### PR DESCRIPTION
In 2021 Jason McGee proposed that ZIP 1014 be amended to provide the Major Grants Review Committee (aka the Zcash Community Grants Committee) with a Discretionary Budget. The proposal was [approved by the Zcash Community Advisory Panel (ZCAP) in December 2021 ](https://vote.heliosvoting.org/helios/elections/2d0787fc-61de-11ec-8619-8ee85a8a1b8a/view). 

The pull request amends ZIP 1014 to reflect the Zcash community's decision to provide the Major Grants Review Committee with a Discretionary Budget, funded out of the MG Slice of the Dev Fund. 

The initial denomination (ZEC), annual budget (3% of the MG slice), cap ($1,000,000 USD) and floor ($250,000) were established in the same ZCAP poll that approved the proposal. Zcash Foundation will run a similar poll to allow ZCAP to change these parameters if requested to do so by the Major Grants Review Committee.