### PR TITLE
[ZIP 216] Add "Retroactive applicability" section and clarify that the zero point is not valid for pk_d

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -3327,7 +3327,7 @@ An \Orchard \note is a tuple $(\Diversifier, \DiversifiedTransmitPublic,
   \item $\Diversifier \typecolon \DiversifierType$
         is the \diversifier of the recipient's \shieldedPaymentAddress;
         \vspace{-0.5ex}
-  \item $\DiversifiedTransmitPublic \typecolon \KAPublic{Orchard}$
+  \item $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{Orchard}$
         is the \diversifiedTransmissionKey of the recipient's \shieldedPaymentAddress;
   \item $\Value \typecolon \ValueType$ is an integer
         representing the value of the \note in \zatoshi;
@@ -3345,7 +3345,7 @@ An \Orchard \note is a tuple $(\Diversifier, \DiversifiedTransmitPublic,
 \introlist
 Let $\NoteType{Orchard}$ be the type of an \Orchard \note, i.e.
 \begin{formulae}
-  \item $\NoteType{Orchard} := \DiversifierType \times \KAPublic{Orchard} \times \ValueType
+  \item $\NoteType{Orchard} := \DiversifierType \times \KAPublicPrimeOrder{Orchard} \times \ValueType
            \times \NoteUniqueRandTypeOrchard \times \NoteNullifierRandType \times \NoteCommitTrapdoor{Orchard}$.
 \end{formulae}
 } %nufive
@@ -5385,7 +5385,7 @@ uniquely from $\DiversifierType$. Then calculate the \diversifier $\Diversifier$
 
 \vspace{-1ex}
 The resulting \diversifiedPaymentAddress is
-$(\Diversifier \typecolon \DiversifierType, \DiversifiedTransmitPublic \typecolon \KAPublic{Orchard})$.
+$(\Diversifier \typecolon \DiversifierType, \DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{Orchard})$.
 
 The \diversifiedPaymentAddress with \diversifierIndex $0$ is called the \defining{\defaultDiversifiedPaymentAddress}.
 
@@ -5997,7 +5997,7 @@ performs the following steps:
 
 \begin{algorithm}
         \vspace{-0.5ex}
-  \item Check that $\DiversifiedTransmitPublic$ is of type $\KAPublic{Orchard}$.
+  \item Check that $\DiversifiedTransmitPublic$ is of type $\KAPublicPrimeOrder{Orchard}$.
   \item Calculate $\DiversifiedTransmitBase = \DiversifyHash{Orchard}(\Diversifier)$.
   \item Choose a uniformly random \commitmentTrapdoor $\ValueCommitRand \leftarrowR \ValueCommitGenTrapdoor{Orchard}()$.
   \item Choose uniformly random $\NoteSeedBytes \leftarrowR \NoteSeedBytesType$.
@@ -9873,6 +9873,8 @@ Let $\GroupP$ be as defined in \crossref{pallasandvesta}.
 
 Define $\KAPublic{Orchard} := \GroupPstar$.
 
+Define $\KAPublicPrimeOrder{Orchard} := \GroupPstar$.
+
 Define $\KASharedSecret{Orchard} := \GroupPstar$.
 
 Define $\KAPrivate{Orchard} := \GFstar{\ParamP{r}}$.
@@ -12349,10 +12351,10 @@ a user might only check part of the address. See \cite{ZIP-316} for full details
 Let $\KA{Orchard}$ be as defined in \crossref{concreteorchardkeyagreement}.
 
 An \Orchard{} \defining{\shieldedPaymentAddress} consists of $\Diversifier \typecolon \DiversifierType$
-and $\DiversifiedTransmitPublic \typecolon \KAPublic{Orchard}$.
+and $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{Orchard}$.
 
 $\DiversifiedTransmitPublic$ is an encoding of a $\KA{Orchard}$ \publicKey of type
-$\KAPublic{Orchard}$, for use with the encryption scheme defined in \crossref{saplingandorchardinband}.
+$\KAPublicPrimeOrder{Orchard}$, for use with the encryption scheme defined in \crossref{saplingandorchardinband}.
 $\Diversifier$~is a sequence of $11$ bytes. These components are derived as described in
 \crossref{orchardkeycomponents}.
 
@@ -15100,6 +15102,11 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
     \item Document in \crossref{concretereddsa}, \crossref{spenddesc}, and \crossref{txnconsensus}
           that the canonicity restriction on the encoding of $\RedDSASigR{}$ in $\RedDSA$
           signature validation is retrospectively valid on \Mainnet and \Testnet before \NUFive.
+    \item So that \SaplingAndOrchard are consistent, \crossref{concreteorchardkeyagreement}
+          now also defines $\KAPublicPrimeOrder{Orchard}$, which is used instead of
+          $\KAPublic{Orchard}$ as the type of an \Orchard $\DiversifiedTransmitPublic$.
+          This has no effect on conformance since both $\KAPublicPrimeOrder{Orchard}$ and
+          $\KAPublic{Orchard}$ are defined as $\GroupPstar$.
 } %nufive
     \item Added dark mode rendering (\url{https://zips.z.cash/protocol/protocol-dark.pdf}).
 \end{itemize}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -5560,7 +5560,8 @@ where
         i.e.\ $\SpendAuthSigValidate{Sapling}{\AuthSignRandomizedPublic}(\SigHash, \spendAuthSig) = 1$.
 
         \nufiveonward{As specified in \crossref{concretereddsa}, the validation of the $\RedDSAReprR{}$
-        component of the signature changes to prohibit \nonCanonicalPoint encodings.}
+        component of the signature changes to prohibit \nonCanonicalPoint encodings. This change is also
+        retrospectively valid on \Mainnet and \Testnet before \NUFive.}
 \end{consensusrules}
 
 \vspace{-1.5ex}
@@ -10195,11 +10196,12 @@ Define $\RedDSAValidate{} \typecolon (\vk \typecolon \RedDSAPublic) \times (M \t
 \begin{pnotes}
         \vspace{-0.25ex}
   \item The validation algorithm \emph{does not} check that $\RedDSASigR{}$ is a point of order
-at least $\ParamG{r}$.
+        at least $\ParamG{r}$.
 \nufive{
         \vspace{-0.5ex}
-  \item After activation of \cite{ZIP-216}, validation returns $0$ if $\RedDSAReprR{}$ is a
-        \nonCanonicalPoint compressed point encoding.
+  \item After the activation of \cite{ZIP-216} with \NUFive, validation returns $0$ if $\RedDSAReprR{}$
+        is a \nonCanonicalPoint compressed point encoding. This change is also retrospectively valid
+        on \Mainnet and \Testnet before \NUFive.
 }
         \vspace{-0.5ex}
   \item The value $\RedDSAReprR{}$ used as part of the input to $\RedDSAHashToScalar$ \MUST be exactly
@@ -12958,7 +12960,8 @@ in \cite{ZIP-239}.
                 $\BindingPublic{Sapling}$ of $\SigHash$ ---
                 i.e.\ $\BindingSigValidate{Sapling}{\BindingPublic{Sapling}}(\SigHash, \bindingSig{Sapling}) = 1$.
                 \nufiveonward{As specified in \crossref{concretereddsa}, the validation of the $\RedDSAReprR{}$
-                component of the signature changes to prohibit \nonCanonicalPoint encodings.}
+                component of the signature changes to prohibit \nonCanonicalPoint encodings. This change
+                is also retrospectively valid on \Mainnet and \Testnet before \NUFive.}
         \end{itemize}}
         \vspace{-1ex}
   \saplingonwarditem{If $\effectiveVersion = 4$ and there are no \spendDescriptions or \outputDescriptions,
@@ -15093,6 +15096,11 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           returns $\bot$ if $\DiversifiedTransmitPublic \not\in \SubgroupJstar$ would catch
           all such cases.
 } %sapling
+\nufive{
+    \item Document in \crossref{concretereddsa}, \crossref{spenddesc}, and \crossref{txnconsensus}
+          that the canonicity restriction on the encoding of $\RedDSASigR{}$ in $\RedDSA$
+          signature validation is retrospectively valid on \Mainnet and \Testnet before \NUFive.
+} %nufive
     \item Added dark mode rendering (\url{https://zips.z.cash/protocol/protocol-dark.pdf}).
 \end{itemize}
 

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -7995,7 +7995,7 @@ The \outgoingViewingKey holder will attempt to decrypt the \noteCiphertext as fo
         and $\DiversifiedTransmitPublic = \abstG{}\Of{\DiversifiedTransmitPublicRepr}$
         \vspace{-0.2ex}
   \item if $\EphemeralPrivate \geq \ParamG{r}$ or $\DiversifiedTransmitPublic = \bot$, return $\bot$
-  \nufiveonwarditem{if $\reprP\big(\DiversifiedTransmitPublic\big) \neq \DiversifiedTransmitPublicRepr$, return $\bot$}
+  \item if $\reprP\big(\DiversifiedTransmitPublic\big) \neq \DiversifiedTransmitPublicRepr$, return $\bot$
         \vspace{-0.2ex}
   \item let $\DHSecret{} = \KAAgree{}(\EphemeralPrivate, \DiversifiedTransmitPublic)$
         \vspace{-0.2ex}
@@ -8071,7 +8071,7 @@ from $\TransmitPlaintext{}$
         $\reprG{}\big(\KADerivePublic{Sapling}(\EphemeralPrivate, \DiversifiedTransmitBase)\kern-0.12em\big)$\rlap{.}\nufive{\; For
         consistency this is also what is specified for \Orchard.}\vspace{-0.6ex}
   \item For \Sapling \outgoingCiphertexts, $\DiversifiedTransmitPublicRepr$ could also be \nonCanonicalPoint.
-        After \NUFive activation, the above algorithm explicitly returns $\bot$ if
+        The above algorithm explicitly returns $\bot$ if
         $\reprP\big(\DiversifiedTransmitPublic\big) \neq \DiversifiedTransmitPublicRepr$. However,
         this is technically redundant with the later check that returns $\bot$ if
         $\DiversifiedTransmitPublic \not\in \smash{\SubgroupJstar}$, because only \smallOrderAdjective \jubjubCurve
@@ -15087,6 +15087,11 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           \MUST be considered invalid when imported.
           Notes have been added in \crossref{saplingpaymentaddrencoding} and
           \crossref{saplinginviewingkeyencoding} calling out these changes.
+    \item In \crossref{decryptovk}, retrospectively enforce the canonicity check on
+          $\DiversifiedTransmitPublic$. This has no effect on consensus because only small-order
+          \jubjubCurve points have \nonCanonicalPoint encodings, and so the check that
+          returns $\bot$ if $\DiversifiedTransmitPublic \not\in \SubgroupJstar$ would catch
+          all such cases.
 } %sapling
     \item Added dark mode rendering (\url{https://zips.z.cash/protocol/protocol-dark.pdf}).
 \end{itemize}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1214,6 +1214,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\unifiedIncomingViewingKeys}{\terms{unified incoming viewing key}}
 \newcommand{\unifiedFullViewingKey}{\term{unified full viewing key}}
 \newcommand{\unifiedFullViewingKeys}{\terms{unified full viewing key}}
+\newcommand{\IVKEncoding}{\termandindex{IVK Encoding}{IVK Encoding (in a Unified Incoming Viewing Key)}}
 \newcommand{\Bech}{\term{Bech32}}
 \newcommand{\Bechm}{\term{Bech32m}}
 \newcommand{\BechOptm}{\termandindex{Bech32[m]}{Bech32m}}
@@ -1554,7 +1555,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\PaymentAddressSecondByte}{\hexint{9A}}
 \newcommand{\InViewingKey}{\mathsf{ivk}}
 \newcommand{\InViewingKeyLength}[1]{\ell^\mathsf{#1\vphantom{p}}_{\InViewingKey}\!}
-\newcommand{\InViewingKeyTypeSapling}{\binaryrange{\InViewingKeyLength{Sapling}}}
+\newcommand{\InViewingKeyTypeSapling}{\range{1}{2^{\InViewingKeyLength{Sapling}}\!-\!1}}
 \newcommand{\InViewingKeyTypeOrchard}{\range{1}{\ParamP{q}-1}}
 \newcommand{\InViewingKeyRepr}{{\InViewingKey\Repr}}
 \newcommand{\InViewingKeyLeadByte}{\hexint{A8}}
@@ -1762,7 +1763,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 
 \newcommand{\KA}[1]{\mathsf{KA}^\mathsf{#1\kern-0.1em}}
 \newcommand{\KAPublic}[1]{\KA{#1}\mathsf{.Public}}
-\newcommand{\KAPublicPrimeSubgroup}[1]{\KA{#1}\mathsf{.PublicPrimeSubgroup}}
+\newcommand{\KAPublicPrimeOrder}[1]{\KA{#1}\mathsf{.PublicPrimeOrder}}
 \newcommand{\KAPrivate}[1]{\KA{#1}\mathsf{.Private}}
 \newcommand{\KASharedSecret}[1]{\KA{#1}\mathsf{.SharedSecret}}
 \newcommand{\KAFormatPrivate}[1]{\KA{#1}\mathsf{.FormatPrivate}}
@@ -3301,7 +3302,7 @@ A \Sapling \note is a tuple $(\Diversifier, \DiversifiedTransmitPublic,
 \begin{itemize}
   \item $\Diversifier \typecolon \DiversifierType$
         is the \diversifier of the recipient's \shieldedPaymentAddress;
-  \item $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeSubgroup{Sapling}$
+  \item $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{Sapling}$
         is the \diversifiedTransmissionKey of the recipient's \shieldedPaymentAddress;
   \item $\Value \typecolon \range{0}{\MAXMONEY}$ is an integer
         representing the value of the \note in \zatoshi;
@@ -3312,7 +3313,7 @@ A \Sapling \note is a tuple $(\Diversifier, \DiversifiedTransmitPublic,
 \introlist
 Let $\NoteType{Sapling}$ be the type of a \Sapling \note, i.e.
 \begin{formulae}
-  \item $\NoteType{Sapling} := \DiversifierType \times \KAPublicPrimeSubgroup{Sapling} \times \range{0}{\MAXMONEY}
+  \item $\NoteType{Sapling} := \DiversifierType \times \KAPublicPrimeOrder{Sapling} \times \range{0}{\MAXMONEY}
            \times \NoteCommitTrapdoor{Sapling}$.
 \end{formulae}
 } %sapling
@@ -4262,7 +4263,7 @@ a shared secret, each using their \defining{\privateKey} and the other party's \
 
 A \keyAgreementScheme $\KA{}$ defines a type of \publicKeys $\KAPublic{}$, a type
 of \privateKeys $\KAPrivate{}$, and a type of shared secrets $\KASharedSecret{}$.
-\sapling{Optionally, it also defines a type $\KAPublicPrimeSubgroup{} \subseteq \KAPublic{}$.}
+\sapling{Optionally, it also defines a type $\KAPublicPrimeOrder{} \subseteq \KAPublic{}$.}
 
 \sapling{Optional:} Let $\KAFormatPrivate{} \typecolon \PRFOutputSprout \rightarrow \KAPrivate{}$
 be a function to convert a bit string of length $\PRFOutputLengthSprout$ to a $\KA{}$ \privateKey.
@@ -5180,7 +5181,7 @@ Then calculate the \defining{\diversifiedTransmissionKey} $\DiversifiedTransmitP
 
 \vspace{-1ex}
 The resulting \diversifiedPaymentAddress is
-$(\Diversifier \typecolon \DiversifierType, \DiversifiedTransmitPublic \typecolon \KAPublicPrimeSubgroup{Sapling})$.
+$(\Diversifier \typecolon \DiversifierType, \DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{Sapling})$.
 
 \vspace{1ex}
 For each \spendingKey, there is also a \defining{\defaultDiversifiedPaymentAddress}
@@ -5888,9 +5889,9 @@ performs the following steps:
 
 \vspace{-0.5ex}
 \begin{algorithm}
-  \item Check that $\DiversifiedTransmitPublic$ is of type $\KAPublicPrimeSubgroup{Sapling}$, i.e.\ it
-        \MUST be a valid \ctEdwardsCurve point on the \jubjubCurve (as defined in \crossref{jubjub}), and
-        $\scalarmult{\ParamJ{r}}{\DiversifiedTransmitPublic} = \ZeroJ$.
+  \item Check that $\DiversifiedTransmitPublic$ is of type $\KAPublicPrimeOrder{Sapling}$, i.e.\ it
+        \MUST be a valid \ctEdwardsCurve point on the \jubjubCurve (as defined in \crossref{jubjub}),
+        $\scalarmult{\ParamJ{r}}{\DiversifiedTransmitPublic} = \ZeroJ$, and $\DiversifiedTransmitPublic \neq \ZeroJ$.
         \vspace{-0.25ex}
   \item Calculate $\DiversifiedTransmitBase = \DiversifyHash{Sapling}(\Diversifier)$
         and check that $\DiversifiedTransmitBase \neq \bot$.
@@ -7769,9 +7770,9 @@ For both encryption and decryption,
 \extralabel{saplingencrypt}{\lsubsubsection{Encryption (\SaplingAndOrchardText)}{saplingandorchardencrypt}}
 
 \vspace{-1ex}
-Let $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeSubgroup{}$ be the
+Let $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{}$ be the
 \diversifiedTransmissionKey for the intended recipient address of a new \SaplingOrOrchard \note,
-and let $\DiversifiedTransmitBase \typecolon \KAPublicPrimeSubgroup{}$ be the corresponding
+and let $\DiversifiedTransmitBase \typecolon \KAPublicPrimeOrder{}$ be the corresponding
 \diversifiedBase computed as $\DiversifyHash{}(\Diversifier)$.
 
 Since \Sapling \note encryption is used only in the context of \crossref{saplingsend}\nufive{, and similarly
@@ -9815,7 +9816,7 @@ Let $\GroupJ$, $\SubgroupJ$, $\SubgroupJstar$, and the cofactor $\ParamJ{h}$ be 
 
 Define $\KAPublic{Sapling} := \GroupJ$.
 
-Define $\KAPublicPrimeSubgroup{Sapling} := \SubgroupJ$.
+Define $\KAPublicPrimeOrder{Sapling} := \SubgroupJstar$.
 
 Define $\KASharedSecret{Sapling} := \SubgroupJ$.
 
@@ -12125,10 +12126,10 @@ Let $\LEBStoOSP{} \typecolon (\ell \typecolon \Nat) \times \bitseq{\ell} \righta
 be as defined in \crossref{endian}.
 
 A \Sapling{} \defining{\shieldedPaymentAddress} consists of $\Diversifier \typecolon \DiversifierType$
-and $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeSubgroup{Sapling}$.
+and $\DiversifiedTransmitPublic \typecolon \KAPublicPrimeOrder{Sapling}$.
 
 $\DiversifiedTransmitPublic$ is an encoding of a $\KA{Sapling}$ \publicKey of type
-$\KAPublicPrimeSubgroup{Sapling}$, for use with the encryption scheme defined in
+$\KAPublicPrimeOrder{Sapling}$, for use with the encryption scheme defined in
 \crossref{saplinginband}. $\Diversifier$~is a \diversifier.
 These components are derived as described in \crossref{saplingkeycomponents}.
 
@@ -12149,12 +12150,20 @@ The \rawEncoding of a \Sapling \shieldedPaymentAddress consists of:
 \end{itemize}
 
 When decoding the representation of $\DiversifiedTransmitPublic$, the address \MUST be
-considered invalid if $\abstJ$ returns $\bot$.
+considered invalid if $\abstJ$ returns $\bot$, or the encoding of $\DiversifiedTransmitPublic$
+is a \nonCanonicalPoint encoding as defined in \crossref{abstractgroup}, or the resulting
+$\DiversifiedTransmitPublic$ is not in $\SubgroupJstar$.
 
-\nufive{\cite{ZIP-216} specifies that the address \MUST also be considered invalid if the
-resulting $\DiversifiedTransmitPublic$ is not in the \primeOrderSubgroup $\SubgroupJ$, or
-if it is a \nonCanonicalPoint encoding as defined in \crossref{abstractgroup}. This \MAY be
-enforced in advance of activation of \NUFive.}
+\begin{nnotes}
+  \item There are no \nonCanonicalPoint encodings of \jubjubCurve points in $\SubgroupJstar$.
+  \item The restriction on $\DiversifiedTransmitPublic$ reflects its current type
+        $\KAPublicPrimeOrder{Sapling} = \SubgroupJstar$. In versions of this specification
+        prior to \historyref{2025.6.0}, $\DiversifiedTransmitPublic$ had type
+        $\KA{Sapling}\mathsf{.PublicPrimeSubgroup} = \SubgroupJ$, i.e. including $\ZeroJ$.
+        Implementations of consumers for this encoding may need to be updated to exclude
+        $\ZeroJ$, and should be checked for consistency with the current version of
+        \cite{ZIP-216}.
+\end{nnotes}
 
 \vspace{1ex}
 For addresses on \Mainnet, the \defining{\humanReadablePart} (as defined in \cite{ZIP-173}) is \ascii{zs}.
@@ -12199,6 +12208,13 @@ considered invalid if $\InViewingKey$ is not in this range.
 
 For \incomingViewingKeys on \Mainnet, the \humanReadablePart is \ascii{zivks}.
 For \incomingViewingKeys on \Testnet, the \humanReadablePart is \ascii{zivktestsapling}.
+
+\begin{nnotes}
+  \item In versions of this specification prior to \historyref{2025.6.0}, the range
+        of $\InViewingKey$ was defined as $\binaryrange{\InViewingKeyLength{Sapling}}$,
+        i.e.\ including $0$. Implementations of consumers for this encoding may need
+        to be updated to exclude $0$.
+\end{nnotes}
 } %sapling
 
 
@@ -15055,12 +15071,23 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \lsection{Change History}{changehistory}
 
 
-\historyentry{Unreleased}{}
+\historyentry{2025.6.0}{}
 
 \begin{itemize}
 \nusix{
     \item Clarify \crossref{transactions}, taking into account the \NUSix consensus changes from \cite{ZIP-236}.
 } %nusix
+\sapling{
+    \item Tighten the type of $\InViewingKey$ in \Sapling to $\InViewingKeyTypeSapling$,
+          and the type of $\DiversifiedTransmitPublic$ in \Sapling to $\KAPublicPrimeOrder{Sapling}$,
+          in order to make the exclusion of the zero point for $\DiversifiedTransmitPublic$
+          more obvious \cite{Zips-Issue664}. This also has the effect that a \Sapling
+          \incomingViewingKey \crossref{saplinginviewingkeyencoding} or a \Sapling \IVKEncoding
+          in a \unifiedIncomingViewingKey \cite{ZIP-316} that encodes the zero $\InViewingKey$
+          \MUST be considered invalid when imported.
+          Notes have been added in \crossref{saplingpaymentaddrencoding} and
+          \crossref{saplinginviewingkeyencoding} calling out these changes.
+} %sapling
     \item Added dark mode rendering (\url{https://zips.z.cash/protocol/protocol-dark.pdf}).
 \end{itemize}
 
@@ -15932,7 +15959,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
             \item The specification did not require $\DiversifiedTransmitPublic$ to be
                   in the subgroup $\SubgroupJ$, while the implementation in \zcashd did.
                   This check is not needed for security; however, since \Jubjub public keys
-                  are normally of type $\KAPublicPrimeSubgroup{Sapling}$, we change the
+                  are normally of type $\KAPublicPrimeOrder{Sapling}$, we change the
                   specification to match \zcashd.
           \end{itemize}
     \item Correct the procedure for generating \dummy \Sapling \notes in \crossref{saplingdummynotes}.
@@ -16013,12 +16040,12 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \historyentry{2020.1.13}{2020-08-11}
 \begin{itemize}
 \sapling{
-    \item Rename the type of \Sapling \transmissionKeys from $\KA{Sapling}\mathsf{.PublicPrimeOrder}$
-          to $\KAPublicPrimeSubgroup{Sapling}$. This type is defined as $\SubgroupJ$, which reflects
+    \item Rename the type of \Sapling \transmissionKeys from $\KAPublicPrimeOrder{Sapling}$ to
+          $\KA{Sapling}\mathsf{.PublicPrimeSubgroup}$. This type is defined as $\SubgroupJ$, which reflects
           the implementation in \zcashd (subject to the next point below); it was never enforced that a
           \transmissionKey ($\DiversifiedTransmitPublic$) cannot be $\ZeroJ$.
-    \item Add a non-normative note saying that \zcashd does not fully conform to the requirement
-          to treat \transmissionKeys not in $\KAPublicPrimeSubgroup{Sapling}$ as invalid when importing
+    \item Add a non-normative note saying that \zcashd does not fully conform to the requirement to treat
+          \transmissionKeys not in $\KA{Sapling}\mathsf{.PublicPrimeSubgroup}$ as invalid when importing
           \shieldedPaymentAddresses.
 } %sapling
 \canopy{

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -12469,9 +12469,9 @@ The \rawEncoding of an \Orchard \fullViewingKey consists of:
 \vspace{-1.5ex}
 When decoding this representation, the key \MUST be considered invalid if $\AuthSignPublic$,
 $\NullifierKey$, or $\CommitIvkRand$ are not canonically encoded elements of their respective
-fields, or if $\AuthSignPublic$ is not a valid \Pallas $x$-coordinate, or if either the
-external or internal \incomingViewingKeys derived as specified in \crossref{orchardkeycomponents}
-are $0$ or $\bot$.
+fields, or if $\AuthSignPublic$ is not a valid affine $x$-coordinate of a \pallasCurve point
+in $\GroupPstar$, or if either the external or internal \incomingViewingKeys derived as specified
+in \crossref{orchardkeycomponents} are $0$ or $\bot$.
 
 There is no \BechOptm encoding defined for an individual \Orchard \fullViewingKey;
 instead use a \unifiedFullViewingKey as defined in \cite{ZIP-316}.
@@ -15107,6 +15107,11 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           $\KAPublic{Orchard}$ as the type of an \Orchard $\DiversifiedTransmitPublic$.
           This has no effect on conformance since both $\KAPublicPrimeOrder{Orchard}$ and
           $\KAPublic{Orchard}$ are defined as $\GroupPstar$.
+    \item In \crossref{orchardfullviewingkeyencoding}, clarify the requirement on
+          $\AuthSignPublic$ by rewording ``valid \Pallas $x$-coordinate`` to
+          ``valid affine $x$-coordinate of a \pallasCurve point in $\GroupPstar$``.
+          Implementations might use $(0, 0)$ to represent $\ZeroP$, but $0$ is not a
+          valid $x$-coordinate in the sense required here.
 } %nufive
     \item Added dark mode rendering (\url{https://zips.z.cash/protocol/protocol-dark.pdf}).
 \end{itemize}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -5221,9 +5221,10 @@ if this happens, discard the key and repeat with a different $\SpendingKey$.
         \vspace{-0.5ex}
   \item Similarly, address generators \MAY encode information in the \diversifier
         that can be recovered by the recipient of a payment to determine which
-        \diversifiedPaymentAddress was used. It is \RECOMMENDED that such \diversifiers
-        be randomly chosen unique values used to index into a database, rather than
-        directly encoding the needed data.
+        \diversifiedPaymentAddress was used. It is \RECOMMENDED, instead of
+        directly encoding information in the \diversifier, to encode it in the
+        \diversifierIndex specified in \cite{ZIP-32}. This ensures that the information
+        is only accessible to a holder of the \diversifierKey $\DiversifierKey$.
 \end{pnotes}
 
 \vspace{-1ex}
@@ -12214,6 +12215,11 @@ For \incomingViewingKeys on \Mainnet, the \humanReadablePart is \ascii{zivks}.
 For \incomingViewingKeys on \Testnet, the \humanReadablePart is \ascii{zivktestsapling}.
 
 \begin{nnotes}
+  \item The \diversifierKey is not present in this encoding, so it does not provide
+        sufficient information to decrypt the \diversifier to obtain a \diversifierIndex.
+        This encoding is therefore deprecated: the preferred way to encode a \Sapling
+        \incomingViewingKey is as a component of a \unifiedIncomingViewingKey using the
+        \IVKEncoding specified in \cite{ZIP-316}, which does include the \diversifierKey.
   \item In versions of this specification prior to \historyref{2025.6.0}, the range
         of $\InViewingKey$ was defined as $\binaryrange{\InViewingKeyLength{Sapling}}$,
         i.e.\ including $0$. Implementations of consumers for this encoding may need
@@ -15083,6 +15089,12 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
     \item Clarify \crossref{transactions}, taking into account the \NUSix consensus changes from \cite{ZIP-236}.
 } %nusix
 \sapling{
+    \item Adjust the recommendation in \crossref{saplingkeycomponents} not to encode
+          information in the \diversifier, to recommend instead using a \cite{ZIP-32}
+          \diversifierIndex.
+    \item Deprecate the encoding of a \Sapling $\InViewingKey$ in \crossref{saplinginviewingkeyencoding},
+          in favour of using a \unifiedIncomingViewingKey with a \Sapling component that
+          includes the \diversifierKey $\DiversifierKey$.
     \item Tighten the type of $\InViewingKey$ in \Sapling to $\InViewingKeyTypeSapling$,
           and the type of $\DiversifiedTransmitPublic$ in \Sapling to $\KAPublicPrimeOrder{Sapling}$,
           in order to make the exclusion of the zero point for $\DiversifiedTransmitPublic$

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -16047,6 +16047,16 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
     \item Add a non-normative note saying that \zcashd does not fully conform to the requirement to treat
           \transmissionKeys not in $\KA{Sapling}\mathsf{.PublicPrimeSubgroup}$ as invalid when importing
           \shieldedPaymentAddresses.
+    \item \textbf{Retrospective note:}
+          Changing $\KAPublicPrimeOrder{Sapling}$ to $\KA{Sapling}\mathsf{.PublicPrimeSubgroup}$
+          was a mistake and has since been reverted in specification version \historyref{2025.6.0}.
+          As discussed in notes added in \historyref{2023.4.0} at \crossref{decryptovk},
+          \librustzcash was changed in \cite{librustzcash-109} to enforce that $\DiversifiedTransmitPublic$
+          is not $\ZeroJ$. \zcashd also used a different implementation for a consensus check on \shielded
+          coinbase outputs. The missing check on $\DiversifiedTransmitPublic$ for the latter was corrected
+          in \cite{zcashd-6459}, and simplified when it was observed to be retrospectively valid in
+          \cite{zcashd-6725}. However \cite{ZIP-216} was only corrected later \cite{Zips-Issue664}, at the
+          same time as the publication of \historyref{2025.6.0}.
 } %sapling
 \canopy{
     \item Set $\CanopyActivationHeight$ for \Testnet.

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -15105,7 +15105,8 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           Notes have been added in \crossref{saplingpaymentaddrencoding} and
           \crossref{saplinginviewingkeyencoding} calling out these changes.
     \item In \crossref{decryptovk}, retrospectively enforce the canonicity check on
-          $\DiversifiedTransmitPublic$. This has no effect on consensus because only small-order
+          $\DiversifiedTransmitPublic$. This has no effect on consensus relative to the
+          previous version, because only small-order
           \jubjubCurve points have \nonCanonicalPoint encodings, and so the check that
           returns $\bot$ if $\DiversifiedTransmitPublic \not\in \SubgroupJstar$ would catch
           all such cases.

--- a/protocol/zcash.bib
+++ b/protocol/zcash.bib
@@ -1592,9 +1592,17 @@ Last revised February~5, 2018.}
 @misc{Zcash-Issue2113,
    presort={Zcash-Issue2113},
    author={Simon Liu},
-   title={GitHub repository `\hairspace zcash/zcash'\hairspace: Issue 2113},
+   title={GitHub repository `\hairspace zcash/zcash'\hairspace: Issue 2113 -- Upgrade testnet to fix bug in test and update fr addresses},
    url={https://github.com/zcash/zcash/issues/2113},
    urldate={2017-02-20}
+}
+
+@misc{Zips-Issue664,
+   presort={Zips-Issue664},
+   author={{Daira\nbh{}Emma} Hopwood},
+   title={GitHub repository `\hairspace zcash/zips'\hairspace: Issue 664 -- [protocol spec] [ZIP 216] Sapling pk\_d should not allow the zero point},
+   url={https://github.com/zcash/zips/issues/664},
+   urldate={2025-09-07}
 }
 
 @book{IEEE2000,

--- a/zips/zip-0216.rst
+++ b/zips/zip-0216.rst
@@ -207,8 +207,8 @@ the protocol specification [#protocol-2023.4.0]_:
 
 The protocol specification was further updated in version 2025.6.0 [#protocol-2025.6.0]_,
 to tighten the type of $\mathsf{ivk}$ in Sapling to
-$\{ 1\,..\, 2^{\ell^{\mathsf{Sapling}}_{\mathsf{ivk}}}\!-1 \}$ and the type of
-$\mathsf{pk_d}$ in Sapling to $\mathsf{KA^{Sapling}.PublicPrimeOrder}$, in order to make
+$\{ 1\,..\, 2^{\ell^{\mathsf{Sapling}}_{\mathsf{ivk}}}\!-1 \}$ and the type of $\mathsf{pk_d}$
+in both Sapling and Orchard to $\mathsf{KA^{protocol}.PublicPrimeOrder}$, in order to make
 the exclusion of the zero point more obvious [#zips-issue664]_. This also has the effect
 that a Sapling incoming viewing key [#protocol-saplinginviewingkeyencoding]_ or a Sapling
 IVK Encoding in a Unified Incoming Viewing Key [#zip-0316]_ that encodes the zero

--- a/zips/zip-0216.rst
+++ b/zips/zip-0216.rst
@@ -31,7 +31,7 @@ Abstract
 ========
 
 This ZIP fixes an oversight in the implementation of the Sapling consensus rules, by
-rejecting all non-canonical representations of Jubjub points.
+rejecting all non‑canonical representations of Jubjub points.
 
 
 Motivation
@@ -62,12 +62,12 @@ There are two points on the Jubjub curve with $u$-coordinate zero:
 - $(0, 1)$, which is the identity;
 - $(0, -1)$, which is a point of order two.
 
-Each of these has a single non-canonical encoding in which the value of the sign bit is
+Each of these has a single non‑canonical encoding in which the value of the sign bit is
 $1$.
 
-This creates a consensus issue because (unlike other non-canonical point encodings that
+This creates a consensus issue because (unlike other non‑canonical point encodings that
 are rejected) either of the above encodings can be decoded, and then re-encoded to a
-*different* encoding. For example, if a non-canonical encoding appeared in a transaction
+*different* encoding. For example, if a non‑canonical encoding appeared in a transaction
 field, then node implementations that store points internally as abstract curve points,
 and used those to derive transaction IDs, would derive different IDs than nodes which
 store transactions as bytes (such as `zcashd`).
@@ -75,7 +75,7 @@ store transactions as bytes (such as `zcashd`).
 This issue is not known to cause any security vulnerability, beyond the risk of
 consensus incompatibility. In fact, for some of the fields that would otherwise be
 affected, the issue does not occur because there are already consensus rules that
-prohibit small-order points, and this incidentally prohibits non-canonical encodings.
+prohibit small‑order points, and this incidentally prohibits non‑canonical encodings.
 
 Adjustments to the protocol specification were made in versions 2020.1.8, 2020.1.9,
 2020.1.15, 2021.1.17, and 2023.4.0 to match the `zcashd` implementation. Further
@@ -89,19 +89,19 @@ Specification
 Let $\mathsf{abst}_{\mathbb{J}}$, $\mathsf{repr}_{\mathbb{J}}$, and
 $q_{\mathbb{J}}$ be as defined in [#protocol-jubjub]_.
 
-Define a non-canonical compressed encoding of a Jubjub point to be a sequence of
+Define a non‑canonical compressed encoding of a Jubjub point to be a sequence of
 $256$ bits, $b$, such that $\mathsf{abst}_{\mathbb{J}}(b) \neq \bot$
 and $\mathsf{repr_{\mathbb{J}}}\big(\mathsf{abst}_{\mathbb{J}}(b)\big) \neq b$.
 
-Non-normative note: There are two such bit sequences,
+Non‑normative note: There are two such bit sequences,
 $\mathsf{I2LEOSP}_{\ell_{\mathbb{J}}}(2^{255} + 1)$ and
 $\mathsf{I2LEOSP}_{\ell_{\mathbb{J}}}(2^{255} + q_{\mathbb{J}} - 1)$.
-The Sapling protocol uses little-endian ordering when converting between bit and
+The Sapling protocol uses little‑endian ordering when converting between bit and
 byte sequences, so the first of these sequences corresponds to a $\mathtt{0x01}$
 byte, followed by $30$ zero bytes, and then a $\mathtt{0x80}$ byte.
 
 Once this ZIP activates, the following places within the Sapling consensus protocol
-where Jubjub points occur MUST reject non-canonical Jubjub point encodings.
+where Jubjub points occur MUST reject non‑canonical Jubjub point encodings.
 
 In Sapling Spend descriptions [#protocol-spenddesc]_:
 
@@ -139,7 +139,7 @@ An implementation MAY redundantly enforce that the computed value of $\mathsf{pk
 is not $\mathcal{O}_{\mathbb{J}}$.
 
 There are some additional fields in the consensus protocol that encode Jubjub points,
-but where non-canonical encodings MUST already be rejected as a side-effect of
+but where non‑canonical encodings MUST already be rejected as a side effect of
 existing consensus rules.
 
 In Sapling Spend descriptions:
@@ -152,18 +152,18 @@ In Sapling Output descriptions [#protocol-outputdesc]_:
   - $\mathtt{cv}$
   - $\mathtt{ephemeralKey}$.
 
-These fields cannot by consensus contain small-order points. All of the points
-with non-canonical encodings are small-order.
+These fields cannot by consensus contain small‑order points. All of the points
+with non‑canonical encodings are small‑order.
 
-Implementations MAY choose to reject non-canonical encodings of the above four
+Implementations MAY choose to reject non‑canonical encodings of the above four
 fields early in decoding of a transaction. This eliminates the risk that parts
 of the transaction could be re-serialized from their internal representation to a
 different byte sequence than in the original transaction, e.g. when calculating
 transaction IDs.
 
 In addition, Sapling addresses and full viewing keys MUST be considered invalid when
-imported if they contain non-canonical Jubjub point encodings, or encodings of points
-that are not in the prime-order subgroup $\mathbb{J}^{(r)}$. These requirements
+imported if they contain non‑canonical Jubjub point encodings, or encodings of points
+that are not in the prime‑order subgroup $\mathbb{J}^{(r)}$. These requirements
 \MAY be enforced in advance of NU5 activation. This affects the fields listed below.
 
 In Sapling payment addresses [#protocol-saplingpaymentaddrencoding]_:
@@ -189,7 +189,7 @@ to encode the zero point. The history is explained in a note added in version 20
 the protocol specification [#protocol-2023.4.0]_:
 
   A previous version of this specification did not have the requirement for the decoded point
-  $\mathsf{pk_d}$ of a Sapling note to be in the set of prime-order points $\mathbb{J}^{(r)*}$
+  $\mathsf{pk_d}$ of a Sapling note to be in the set of prime‑order points $\mathbb{J}^{(r)*}$
   (i.e. "if ... $\mathsf{pk_d} \not\in \mathbb{J}^{(r)*}$, return $\bot\!$").
   That did not match the implementation in `zcashd`. In fact the history is a little more
   complicated. The current specification matches the implementation in `librustzcash` as of
@@ -228,33 +228,33 @@ Retroactive applicability
 -------------------------
 
 As originally specified, this ZIP required that the new validity rules be applied only
-after NU5 activation. This was necessary because a transaction containing a non-canonical
+after NU5 activation. This was necessary because a transaction containing a non‑canonical
 Jubjub point encoding could have been included in any block before NU5 activation.
 
 However, now that NU5 is a settled upgrade on the Zcash Mainnet and Testnet chains
 [#protocol-blockchain]_ [#protocol-networks]_, it can be observed that there were no such
-non-canonical encodings in publically visible transaction fields before the Mainnet and
+non‑canonical encodings in publically visible transaction fields before the Mainnet and
 Testnet NU5 activations. Therefore, a full validator MAY enforce the above specification
 retroactively.
 
-It remains possible that there could be non-canonical $\mathsf{pk\star_d}$ encodings in
+It remains possible that there could be non‑canonical $\mathsf{pk\star_d}$ encodings in
 plaintexts obtained by decrypting the $\mathsf{C^{out}}$ field of a Sapling transmitted
 note ciphertext. Such encodings MUST be rejected by the decryption procedure in
 [#protocol-decryptovk]_ as currently specified. In version 2025.6.0 of the protocol
 specification [#protocol-2025.6.0]_ this procedure has been changed to reject them
 unconditionally, not only after NU5 activation. (This has no effect on consensus relative
-to the previous version, because only small-order Jubjub curve points have non-canonical
+to the previous version, because only small‑order Jubjub curve points have non‑canonical
 encodings, and so the check that returns $\bot$ if $\mathsf{pk_d} ∉ \mathbb{J}^{(r)*}$
 would catch all such cases.)
 
-Rejecting non-canonical $\mathsf{pk\star_d}$ encodings cannot lead to loss of funds
+Rejecting non‑canonical $\mathsf{pk\star_d}$ encodings cannot lead to loss of funds
 sent to a Sapling address that has been correctly generated as specified in
 [#protocol-saplingkeycomponents]_, because such an address cannot have $\mathsf{ivk} = 0$,
-which is the only case in which $\mathsf{pk\star_d}$ could be non-canonical.
+which is the only case in which $\mathsf{pk\star_d}$ could be non‑canonical.
 They are rejected in wallet rescanning by current `zcashd` and by `librustzcash`-based
 light wallets.
 
-Note: There are no such non-canonical $\mathsf{pk\star_d}$ encodings in the
+Note: There are no such non‑canonical $\mathsf{pk\star_d}$ encodings in the
 $\mathsf{C^{out}}$ components of shielded coinbase outputs (which are required by
 consensus to be decryptable by an all-zero $\mathsf{ovk}$ [#protocol-txnconsensus]_).
 
@@ -262,19 +262,19 @@ consensus to be decryptable by an all-zero $\mathsf{ovk}$ [#protocol-txnconsensu
 Rationale
 =========
 
-Zcash previously had a similar issue with non-canonical representations of points in
+Zcash previously had a similar issue with non‑canonical representations of points in
 Ed25519 public keys and signatures. In that case, given the prevalence of Ed25519
 signatures in the wider ecosystem, the decision was made in ZIP 215 [#zip-0215]_ (which
-activated with the Canopy network upgrade [#zip-0251]_) to allow non-canonical
+activated with the Canopy network upgrade [#zip-0251]_) to allow non‑canonical
 representations of points.
 
-In Sapling, we are motivated instead to reject these non-canonical points:
+In Sapling, we are motivated instead to reject these non‑canonical points:
 
 - The chance of the identity occurring anywhere within the Sapling components of
   transactions from implementations following the standard protocol is cryptographically
   negligible.
 - This re-enables the aforementioned simpler security analysis of the Sapling protocol.
-- The Jubjub curve has a vastly-smaller scope of usage in the general cryptographic
+- The Jubjub curve has a vastly smaller scope of usage in the general cryptographic
   ecosystem than Curve25519 and Ed25519.
 
 The necessary checks are very simple and do not require cryptographic operations,
@@ -287,9 +287,9 @@ coordinates as elements of the correct field
 ($\!\mathbb{F}_{r_\mathbb{S}} = \mathbb{F}_{q_\mathbb{J}}$),
 and so no issue of encoding canonicity arises.
 
-Encodings of elliptic curve points on Curve25519, BN-254 $\mathbb{G}_1$,
-BN-254 $\mathbb{G}_2$, BLS12-381 $\mathbb{G}_1$, and
-BLS12-381 $\mathbb{G}_2$ are not affected.
+Encodings of elliptic curve points on Curve25519, BN‑254 $\mathbb{G}_1$,
+BN‑254 $\mathbb{G}_2$, BLS12‑381 $\mathbb{G}_1$, and
+BLS12‑381 $\mathbb{G}_2$ are not affected.
 
 Encodings of elliptic curve points on the Pallas and Vesta curves [#protocol-pallasandvesta]_
 used by the Orchard shielded protocol are also not affected.

--- a/zips/zip-0216.rst
+++ b/zips/zip-0216.rst
@@ -20,6 +20,12 @@ when, and only when, they appear in all capitals.
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
 
+The terms "settled" and "full validator" in this document are to be interpreted as
+described in [#protocol-blockchain]_.
+
+The terms "Mainnet" and "Testnet" in this document are to be interpreted as described
+in [#protocol-networks]_.
+
 
 Abstract
 ========
@@ -72,8 +78,9 @@ affected, the issue does not occur because there are already consensus rules tha
 prohibit small-order points, and this incidentally prohibits non-canonical encodings.
 
 Adjustments to the protocol specification were made in versions 2020.1.8, 2020.1.9,
-2020.1.15, and 2021.1.17 to match the `zcashd` implementation. (The fact that this
-required 4 specification revisions to get right, conclusively demonstrates the problem.)
+2020.1.15, 2021.1.17, and 2023.4.0 to match the `zcashd` implementation. The fact that
+this required five specification revisions to get right, conclusively demonstrates the
+problem.
 
 
 Specification
@@ -107,13 +114,29 @@ In transactions [#protocol-txnencoding]_:
     $\mathtt{bindingSigSapling}$ RedDSA signature.
 
 In the plaintext obtained by decrypting the $\mathsf{C^{out}}$ field of a
-Sapling transmitted note ciphertext [#protocol-decryptovk]_:
+Sapling transmitted note ciphertext (encrypted in [#protocol-saplingandorchardencrypt]_
+and decrypted in [#protocol-decryptovk]_):
 
-  - $\mathsf{pk}\star_{\mathsf{d}}$.
+  - $\mathsf{pk\star_d}$.
 
-(This affects decryption of $\mathsf{C^{out}}$ in all cases, but is
-consensus-critical only in the case of a shielded coinbase output.
-[#protocol-txnencoding]_)
+$\mathsf{pk\star_d}$ also MUST be considered invalid if it encodes the zero point
+$\mathcal{O}_{\mathbb{J}}$.
+
+These requirements on $\mathsf{pk\star_d}$ affect the decryption of
+$\mathsf{C^{out}}$ in all cases, but are consensus-critical only in the case
+of decrypting $\mathsf{C^{out}}$ for a Sapling shielded coinbase output.
+[#protocol-txnconsensus]_ [#zip-0213]_
+
+Note: When a Sapling transmitted note ciphertext is decrypted using an incoming
+viewing key [#protocol-decryptivk]_, $\mathsf{pk_d}$ is computed as
+$\mathsf{KA^{Sapling}.DerivePublic}(\mathsf{ivk}, \mathsf{g_d}) =$ $[\mathsf{ivk}]\,\mathsf{g_d}$.
+Since $\mathsf{g_d}$ is an output of
+$\mathsf{DiversifyHash^{Sapling}} \;{\small ⦂}\; \mathbb{B}^{[\ell_d]} \rightarrow \mathbb{J}^{(r)*} \cup \{\bot\}$,
+it cannot be $\mathcal{O}_{\mathbb{J}}$. $\mathsf{ivk}$ cannot be $0$ for a validly
+constructed Sapling incoming viewing key [#protocol-saplingkeycomponents]_, and
+so the computed value of $\mathsf{pk_d}$ cannot be $\mathcal{O}_{\mathbb{J}}$.
+An implementation MAY redundantly enforce that the computed value of $\mathsf{pk_d}$
+is not $\mathcal{O}_{\mathbb{J}}$.
 
 There are some additional fields in the consensus protocol that encode Jubjub points,
 but where non-canonical encodings MUST already be rejected as a side-effect of
@@ -122,7 +145,7 @@ existing consensus rules.
 In Sapling Spend descriptions:
 
   - $\mathtt{cv}$
-  - $\mathtt{rk}$
+  - $\mathtt{rk}$.
 
 In Sapling Output descriptions [#protocol-outputdesc]_:
 
@@ -141,22 +164,74 @@ transaction IDs.
 In addition, Sapling addresses and full viewing keys MUST be considered invalid when
 imported if they contain non-canonical Jubjub point encodings, or encodings of points
 that are not in the prime-order subgroup $\mathbb{J}^{(r)}$. These requirements
-\MAY be enforced in advance of NU5 activation.
+\MAY be enforced in advance of NU5 activation. This affects the fields listed below.
 
-In Sapling addresses [#protocol-saplingpaymentaddrencoding]_:
+In Sapling payment addresses [#protocol-saplingpaymentaddrencoding]_:
 
   - the encoding of $\mathsf{pk_d}$.
 
 In Sapling full viewing keys [#protocol-saplingfullviewingkeyencoding]_ and extended
 full viewing keys [#zip-0032-extfvk]_:
 
-  - the encoding of $\mathsf{ak}$.
+  - the encoding of $\mathsf{ak}$
+  - the encoding of $\mathsf{nk}$.
 
-($\mathsf{ak}$ also MUST NOT encode the zero point $\mathcal{O}_{\mathbb{J}}$.)
+$\mathsf{pk_d}$ and $\mathsf{ak}$ also MUST be considered invalid if they encode the
+zero point $\mathcal{O}_{\mathbb{J}}$.
 
-The above is intended to be a complete list of the places where compressed encodings
-of Jubjub points occur in the Zcash consensus protocol and in plaintext, address, or
-key formats.
+The fields mentioned in this Specification are intended to be a complete list of the
+places where compressed encodings of Jubjub points occur in the Zcash consensus protocol
+and in plaintext, address, or key formats.
+
+Note: Some versions of the Zcash protocol specification mistakenly allowed $\mathsf{pk_d}$
+in a Sapling payment address, or $\mathsf{pk\star_d}$ in a decrypted $\mathsf{C^{out}}$,
+to encode the zero point. The history is explained in a note added in version 2023.4.0 of
+the protocol specification [#protocol-2023.4.0]_:
+
+  A previous version of this specification did not have the requirement for the decoded point
+  $\mathsf{pk_d}$ of a Sapling note to be in the set of prime-order points $\mathbb{J}^{(r)*}$
+  (i.e. "if ... $\mathsf{pk_d} \not\in \mathbb{J}^{(r)*}$, return $\bot\!$").
+  That did not match the implementation in `zcashd`. In fact the history is a little more
+  complicated. The current specification matches the implementation in `librustzcash` as of
+  [#librustzcash-pr109]_, which has been used in `zcashd` since v2.1.2. However, there was
+  another implementation of Sapling note decryption used in `zcashd` for consensus checks,
+  specifically the check that a shielded coinbase output decrypts successfully with the
+  zero $\mathsf{ovk}$. This was corrected to enforce the same restriction on the decrypted
+  $\mathsf{pk_d}$ in `zcashd` v5.5.0, originally set to activate in a soft fork at block
+  height 2121200 on both Mainnet and Testnet [#zcashd-pr6459]_. (On Testnet this height was
+  in the past as of the `zcashd` v5.5.0 release, and so the change would have been immediately
+  enforced on upgrade.) Since the soft fork was observed to be retrospectively valid after
+  that height, the implementation was simplified in [#zcashd-pr6725]_ to use the
+  `librustzcash` implementation in all cases, which reflects the specification above.
+  `zebra` always used the `librustzcash` implementation.
+
+Retroactive applicability
+-------------------------
+
+As originally specified, this ZIP required that the new validity rules be applied only
+after NU5 activation. This was necessary because a transaction containing a non-canonical
+Jubjub point encoding could have been included in any block before NU5 activation.
+
+However, now that NU5 is a settled upgrade on the Zcash Mainnet and Testnet chains
+[#protocol-blockchain]_ [#protocol-networks]_, it can be observed that there were no such
+non-canonical encodings in publically visible transaction fields before the Mainnet and
+Testnet NU5 activations. Therefore, a full validator MAY enforce the above specification
+retroactively.
+
+It remains possible that there could be non-canonical $\mathsf{pk\star_d}$ encodings in
+plaintexts obtained by decrypting the $\mathsf{C^{out}}$ field of a Sapling transmitted
+note ciphertext. Such encodings MUST be rejected by the decryption
+procedure in [#protocol-decryptovk]_ after NU5 activation. An implementation MAY also
+reject them before NU5 activation. Doing so cannot lead to loss of funds
+sent to a Sapling address that has been correctly generated as specified in
+[#protocol-saplingkeycomponents]_, because such an address cannot have $\mathsf{ivk} = 0$,
+which is the only case in which $\mathsf{pk\star_d}$ could be non-canonical.
+They are rejected in wallet rescanning by current `zcashd` and by `librustzcash`-based
+light wallets.
+
+Note: There are no such non-canonical $\mathsf{pk\star_d}$ encodings in the
+$\mathsf{C^{out}}$ components of shielded coinbase outputs (which are required by
+consensus to be decryptable by an all-zero $\mathsf{ovk}$ [#protocol-txnconsensus]_).
 
 
 Rationale
@@ -191,8 +266,8 @@ Encodings of elliptic curve points on Curve25519, BN-254 $\mathbb{G}_1$,
 BN-254 $\mathbb{G}_2$, BLS12-381 $\mathbb{G}_1$, and
 BLS12-381 $\mathbb{G}_2$ are not affected.
 
-Encodings of elliptic curve points on the Pallas and Vesta curves in the NU5 proposal
-[#protocol-pallasandvesta]_ are also not affected.
+Encodings of elliptic curve points on the Pallas and Vesta curves [#protocol-pallasandvesta]_
+used by the Orchard shielded protocol are also not affected.
 
 
 Security and Privacy Considerations
@@ -200,32 +275,50 @@ Security and Privacy Considerations
 
 This ZIP eliminates a potential source of consensus divergence between differing full node
 implementations. At the time of writing (February 2021), no such divergence exists for any
-production implementation of Zcash, but the alpha-stage `zebrad` node implementation would
-be susceptible to this issue.
+production implementation of Zcash, but an early alpha version of the `zebrad` node
+implementation would have been susceptible to this issue.
 
 
 Deployment
 ==========
 
-This ZIP is proposed to activate with Network Upgrade 5. Requirements on points encoded in
-payment addresses and full viewing keys MAY be enforced in advance of NU5 activation.
+This ZIP activated with Network Upgrade 5. Requirements on points encoded in payment
+addresses and full viewing keys MAY be enforced in advance of NU5 activation.
+
+`zcashd` PRs #6399 [#zcashd-pr6399]_, #6459 [#zcashd-pr6459]_, and #6725 [#zcashd-pr6725]_
+retroactively enforce canonical encoding of Jubjub points for the entire chain history,
+as described in the `Retroactive applicability`_ section.
 
 
 References
 ==========
 
 .. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
-.. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later [NU5 proposal] <protocol/protocol.pdf>`_
-.. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
-.. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
-.. [#protocol-decryptovk] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.19.3 Decryption using a Full Viewing Key (Sapling and Orchard) <protocol/protocol.pdf#decryptovk>`_
-.. [#protocol-jubjub] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 5.4.9.3: Jubjub <protocol/protocol.pdf#jubjub>`_
-.. [#protocol-pallasandvesta] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 5.4.9.6: Pallas and Vesta <protocol/protocol.pdf#pallasandvesta>`_
-.. [#protocol-saplingpaymentaddrencoding] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 5.6.3.1: Sapling Payment Addresses <protocol/protocol.pdf#saplingpaymentaddrencoding>`_
-.. [#protocol-saplingfullviewingkeyencoding] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 5.6.3.3: Sapling Full Viewing Keys <protocol/protocol.pdf#saplingfullviewingkeyencoding>`_
-.. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
+.. [#protocol] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal] or later <protocol/protocol.pdf>`_
+.. [#protocol-blockchain] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 3.3: The Block Chain <protocol/protocol.pdf#blockchain>`_
+.. [#protocol-networks] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
+.. [#protocol-saplingkeycomponents] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 4.2.2: Sapling Key Components <protocol/protocol.pdf#saplingkeycomponents>`_
+.. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
+.. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_
+.. [#protocol-saplingandorchardencrypt] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 4.20.1 Encryption (Sapling and Orchard) <protocol/protocol.pdf#saplingandorchardencrypt>`_
+.. [#protocol-decryptivk] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 4.20.2 Decryption using a Incoming Viewing Key (Sapling and Orchard) <protocol/protocol.pdf#decryptivk>`_
+.. [#protocol-decryptovk] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 4.20.3 Decryption using a Full Viewing Key (Sapling and Orchard) <protocol/protocol.pdf#decryptovk>`_
+.. [#protocol-jubjub] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.4.9.3: Jubjub <protocol/protocol.pdf#jubjub>`_
+.. [#protocol-pallasandvesta] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.4.9.6: Pallas and Vesta <protocol/protocol.pdf#pallasandvesta>`_
+.. [#protocol-saplingpaymentaddrencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.6.3.1: Sapling Payment Addresses <protocol/protocol.pdf#saplingpaymentaddrencoding>`_
+.. [#protocol-saplinginviewingkeyencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.6.3.2: Sapling Incoming Viewing Keys <protocol/protocol.pdf#saplinginviewingkeyencoding>`_
+.. [#protocol-saplingfullviewingkeyencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.6.3.3: Sapling Full Viewing Keys <protocol/protocol.pdf#saplingfullviewingkeyencoding>`_
+.. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
+.. [#protocol-txnconsensus] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.1.2: Transaction Consensus Rules <protocol/protocol.pdf#txnconsensus>`_
+.. [#protocol-2023.4.0] `Zcash Protocol Specification, Version 2023.4.0. Section 10: Change History — 2023.4.0 <protocol/protocol.pdf#2023.4.0>`_
 .. [#zip-0032-extfvk] `ZIP 32: Shielded Hierarchical Deterministic Wallets. Sapling extended full viewing keys <zip-0032.rst#sapling-extended-full-viewing-keys>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
+.. [#zip-0213] `ZIP 213: Shielded Coinbase <zip-0213.rst>`_
 .. [#zip-0215] `ZIP 215: Explicitly Defining and Modifying Ed25519 Validation Rules <zip-0215.rst>`_
 .. [#zip-0251] `ZIP 251: Deployment of the Canopy Network Upgrade <zip-0251.rst>`_
 .. [#jubjub-crate] `jubjub Rust crate <https://github.com/zkcrypto/jubjub>`_
+.. [#zcashd-pr6399] `zcash/zcash PR 6399: Retroactively enable ZIP 216 before NU5 activation <https://github.com/zcash/zcash/pull/6399>`_
+.. [#zcashd-pr6459] `zcash/zcash PR 6459: Migrate to zcash_primitives 0.10 <https://github.com/zcash/zcash/pull/6459>`_
+.. [#zcashd-pr6725] `zcash/zcash PR 6725: Retroactively use Rust to decrypt shielded coinbase before soft fork <https://github.com/zcash/zcash/pull/6725>`_
+.. [#librustzcash-pr109] `zcash/librustzcash PR 109: PaymentAddress encapsulation <https://github.com/zcash/librustzcash/pull/109/files#diff-92d6b429f317a74bd65b2ad87d4f841e9fa9e334edab4199cdaba91172cd2d10R147-R151>`_
+.. [#zips-issue664] `zcash/zips issue 664: Sapling pk\_d should not allow the zero point <https://github.com/zcash/zips/issues/664>`_

--- a/zips/zip-0216.rst
+++ b/zips/zip-0216.rst
@@ -78,9 +78,9 @@ affected, the issue does not occur because there are already consensus rules tha
 prohibit small-order points, and this incidentally prohibits non-canonical encodings.
 
 Adjustments to the protocol specification were made in versions 2020.1.8, 2020.1.9,
-2020.1.15, 2021.1.17, and 2023.4.0 to match the `zcashd` implementation. The fact that
-this required five specification revisions to get right, conclusively demonstrates the
-problem.
+2020.1.15, 2021.1.17, and 2023.4.0 to match the `zcashd` implementation. Further
+changes were also made in version 2025.6.0. The fact that this required six
+specification revisions to get right, conclusively demonstrates the problem.
 
 
 Specification
@@ -205,6 +205,25 @@ the protocol specification [#protocol-2023.4.0]_:
   `librustzcash` implementation in all cases, which reflects the specification above.
   `zebra` always used the `librustzcash` implementation.
 
+The protocol specification was further updated in version 2025.6.0 [#protocol-2025.6.0]_,
+to tighten the type of $\mathsf{ivk}$ in Sapling to
+$\{ 1\,..\, 2^{\ell^{\mathsf{Sapling}}_{\mathsf{ivk}}}\!-1 \}$ and the type of
+$\mathsf{pk_d}$ in Sapling to $\mathsf{KA^{Sapling}.PublicPrimeOrder}$, in order to make
+the exclusion of the zero point more obvious [#zips-issue664]_. This also has the effect
+that a Sapling incoming viewing key [#protocol-saplinginviewingkeyencoding]_ or a Sapling
+IVK Encoding in a Unified Incoming Viewing Key [#zip-0316]_ that encodes the zero
+$\mathsf{ivk}$ MUST be considered invalid when imported. Another note was also added
+explicitly covering the encoding of $\mathsf{pk_d}$ in Sapling payment addresses
+[#protocol-saplingpaymentaddrencoding]_:
+
+  The restriction on $\mathsf{pk_d}$ reflects its current type
+  $\mathsf{KA^{Sapling}.PublicPrimeOrder} = \mathbb{J}^{(r)*}$. In versions of this
+  specification prior to 2025.6.0, $\mathsf{pk_d}$ had type
+  $\mathsf{KA^{Sapling}.PublicPrimeSubgroup} = \mathbb{J}^{(r)}$, i.e. including
+  $\mathcal{O}_{\mathbb{J}}$. Implementations of consumers for this encoding may need
+  to be updated to exclude $\mathcal{O}_{\mathbb{J}}$, and should be checked for
+  consistency with the current version of [ZIP-216].
+
 Retroactive applicability
 -------------------------
 
@@ -311,11 +330,13 @@ References
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#protocol-txnconsensus] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.1.2: Transaction Consensus Rules <protocol/protocol.pdf#txnconsensus>`_
 .. [#protocol-2023.4.0] `Zcash Protocol Specification, Version 2023.4.0. Section 10: Change History — 2023.4.0 <protocol/protocol.pdf#2023.4.0>`_
+.. [#protocol-2025.6.0] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 10: Change History — 2025.6.0 <protocol/protocol.pdf#2025.6.0>`_
 .. [#zip-0032-extfvk] `ZIP 32: Shielded Hierarchical Deterministic Wallets. Sapling extended full viewing keys <zip-0032.rst#sapling-extended-full-viewing-keys>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0213] `ZIP 213: Shielded Coinbase <zip-0213.rst>`_
 .. [#zip-0215] `ZIP 215: Explicitly Defining and Modifying Ed25519 Validation Rules <zip-0215.rst>`_
 .. [#zip-0251] `ZIP 251: Deployment of the Canopy Network Upgrade <zip-0251.rst>`_
+.. [#zip-0316] `ZIP 316: Unified Addresses and Unified Viewing Keys <zip-0316.rst>`_
 .. [#jubjub-crate] `jubjub Rust crate <https://github.com/zkcrypto/jubjub>`_
 .. [#zcashd-pr6000] `zcash/zcash PR 6000: Enable ZIP 216 for blocks prior to NU5 activation <https://github.com/zcash/zcash/pull/6000>`_
 .. [#zcashd-pr6399] `zcash/zcash PR 6399: Retroactively enable ZIP 216 before NU5 activation <https://github.com/zcash/zcash/pull/6399>`_

--- a/zips/zip-0216.rst
+++ b/zips/zip-0216.rst
@@ -239,9 +239,15 @@ retroactively.
 
 It remains possible that there could be non-canonical $\mathsf{pk\star_d}$ encodings in
 plaintexts obtained by decrypting the $\mathsf{C^{out}}$ field of a Sapling transmitted
-note ciphertext. Such encodings MUST be rejected by the decryption
-procedure in [#protocol-decryptovk]_ after NU5 activation. An implementation MAY also
-reject them before NU5 activation. Doing so cannot lead to loss of funds
+note ciphertext. Such encodings MUST be rejected by the decryption procedure in
+[#protocol-decryptovk]_ as currently specified. In version 2025.6.0 of the protocol
+specification [#protocol-2025.6.0]_ this procedure has been changed to reject them
+unconditionally, not only after NU5 activation. (This has no effect on consensus relative
+to the previous version, because only small-order Jubjub curve points have non-canonical
+encodings, and so the check that returns $\bot$ if $\mathsf{pk_d} ∉ \mathbb{J}^{(r)*}$
+would catch all such cases.)
+
+Rejecting non-canonical $\mathsf{pk\star_d}$ encodings cannot lead to loss of funds
 sent to a Sapling address that has been correctly generated as specified in
 [#protocol-saplingkeycomponents]_, because such an address cannot have $\mathsf{ivk} = 0$,
 which is the only case in which $\mathsf{pk\star_d}$ could be non-canonical.

--- a/zips/zip-0216.rst
+++ b/zips/zip-0216.rst
@@ -274,8 +274,8 @@ Security and Privacy Considerations
 ===================================
 
 This ZIP eliminates a potential source of consensus divergence between differing full node
-implementations. At the time of writing (February 2021), no such divergence exists for any
-production implementation of Zcash, but an early alpha version of the `zebrad` node
+implementations. From February 2023 onward, no known divergence of this type exists for
+any production implementation of Zcash, but an early alpha version of the `zebrad` node
 implementation would have been susceptible to this issue.
 
 
@@ -285,9 +285,9 @@ Deployment
 This ZIP activated with Network Upgrade 5. Requirements on points encoded in payment
 addresses and full viewing keys MAY be enforced in advance of NU5 activation.
 
-`zcashd` PRs #6399 [#zcashd-pr6399]_, #6459 [#zcashd-pr6459]_, and #6725 [#zcashd-pr6725]_
-retroactively enforce canonical encoding of Jubjub points for the entire chain history,
-as described in the `Retroactive applicability`_ section.
+`zcashd` PRs #6000 [#zcashd-pr6000]_, #6399 [#zcashd-pr6399]_, #6459 [#zcashd-pr6459]_,
+and #6725 [#zcashd-pr6725]_ retroactively enforce canonical encoding of Jubjub points
+for the entire chain history, as described in the `Retroactive applicability`_ section.
 
 
 References
@@ -317,6 +317,7 @@ References
 .. [#zip-0215] `ZIP 215: Explicitly Defining and Modifying Ed25519 Validation Rules <zip-0215.rst>`_
 .. [#zip-0251] `ZIP 251: Deployment of the Canopy Network Upgrade <zip-0251.rst>`_
 .. [#jubjub-crate] `jubjub Rust crate <https://github.com/zkcrypto/jubjub>`_
+.. [#zcashd-pr6000] `zcash/zcash PR 6000: Enable ZIP 216 for blocks prior to NU5 activation <https://github.com/zcash/zcash/pull/6000>`_
 .. [#zcashd-pr6399] `zcash/zcash PR 6399: Retroactively enable ZIP 216 before NU5 activation <https://github.com/zcash/zcash/pull/6399>`_
 .. [#zcashd-pr6459] `zcash/zcash PR 6459: Migrate to zcash_primitives 0.10 <https://github.com/zcash/zcash/pull/6459>`_
 .. [#zcashd-pr6725] `zcash/zcash PR 6725: Retroactively use Rust to decrypt shielded coinbase before soft fork <https://github.com/zcash/zcash/pull/6725>`_

--- a/zips/zip-0316.rst
+++ b/zips/zip-0316.rst
@@ -476,7 +476,8 @@ $\mathtt{addr}$ field:
 
 * A Sapling IVK Encoding, also with Typecode $\mathtt{0x02},$
   is an encoding of $(\mathsf{dk}, \mathsf{ivk})$ given by
-  $\mathsf{dk}\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).$
+  $\mathsf{dk}\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).$ Note that
+  a zero $\mathsf{ivk}$ is not valid [#protocol-2025.6.0]_.
 
 * There is no defined way to represent a Viewing Key for a Transparent
   P2SH Address in a UFVK or UIVK (because P2SH Addresses cannot, in general,
@@ -1312,6 +1313,7 @@ References
 .. [#protocol-orchardpaymentaddrencoding] `Zcash Protocol Specification, Version 2023.4.0. Section 5.6.4.2: Orchard Raw Payment Addresses <protocol/protocol.pdf#orchardpaymentaddrencoding>`_
 .. [#protocol-orchardinviewingkeyencoding] `Zcash Protocol Specification, Version 2023.4.0. Section 5.6.4.3: Orchard Raw Incoming Viewing Keys <protocol/protocol.pdf#orchardinviewingkeyencoding>`_
 .. [#protocol-orchardfullviewingkeyencoding] `Zcash Protocol Specification, Version 2023.4.0. Section 5.6.4.4: Orchard Raw Full Viewing Keys <protocol/protocol.pdf#orchardfullviewingkeyencoding>`_
+.. [#protocol-2025.6.0] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 10: Change History — 2025.6.0 <protocol/protocol.pdf#2025.6.0>`_
 .. [#zip-0000] `ZIP 0: ZIP Process <zip-0000.rst>`_
 .. [#zip-0032-sapling-helper-functions] `ZIP 32: Shielded Hierarchical Deterministic Wallets — Sapling helper functions <zip-0032#sapling-helper-functions>`_
 .. [#zip-0032-sapling-extfvk] `ZIP 32: Shielded Hierarchical Deterministic Wallets — Sapling extended full viewing keys <zip-0032#sapling-extended-full-viewing-keys>`_


### PR DESCRIPTION
fixes #664, fixes #671

This PR also finally fixes [a specification mistake](https://github.com/zcash/zips/commit/1d71f6cb3133f6a047c2e06728b1d5298344716d) made 5 years ago, explained [here](https://github.com/zcash/zcash/issues/3827#issuecomment-1402461041).