### PR TITLE
ZIP 401: Allow an approximation of memory size, and update constants to avoid penalizing Orchard

### DIFF
--- a/zip-0401.html
+++ b/zip-0401.html
@@ -3,6 +3,7 @@
 <head>
     <title>ZIP 401: Addressing Mempool Denial-of-Service</title>
     <meta charset="utf-8" />
+    <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="css/style.css"></head>
 <body>
     <section>
@@ -17,11 +18,11 @@ License: MIT</pre>
             <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This proposal specifies a change to the behaviour of <code>zcashd</code> nodes intended to mitigate denial-of-service from transaction flooding.</p>
+            <p>This proposal specifies a change to the behaviour of <cite>zcashd</cite> nodes intended to mitigate denial-of-service from transaction flooding.</p>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Adoption of this proposal would increase robustness of Zcash nodes against denial-of-service attack, in particular attacks that attempt to exhaust node memory.</p>
-            <p>Bitcoin Core added size limitation for the mempool in version 0.12 <a id="footnote-reference-2" class="footnote_reference" href="#bitcoincore-pr6722">6</a>, defaulting to 300 MB. This was after Zcash forked from Bitcoin Core.</p>
+            <p>Bitcoin Core added size limitation for the mempool in version 0.12 <a id="footnote-reference-2" class="footnote_reference" href="#bitcoincore-pr6722">8</a>, defaulting to 300 MB. This was after Zcash forked from Bitcoin Core.</p>
         </section>
         <section id="requirements"><h2><span class="section-heading">Requirements</span><span class="section-anchor"> <a rel="bookmark" href="#requirements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The memory usage of a node’s mempool should be bounded.</p>
@@ -34,12 +35,13 @@ License: MIT</pre>
             <p>This proposal is focused primarily on memory exhaustion attacks. It does not attempt to use fees to make denial-of-service economically prohibitive, since that is unlikely to be feasible while maintaining low fees for legitimate users. It does not preclude changes in fee policy.</p>
         </section>
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This specification describes the intended behaviour of <code>zcashd</code> nodes. Other node implementations MAY implement the same or similar behaviour, but this is not a requirement of the network protocol. Thus, RFC 2119 conformance keywords below are to be interpreted only as placing requirements on the <code>zcashd</code> implementation (and potentially other implementations that have adopted this specification in full).</p>
+            <p>This specification describes the intended behaviour of <cite>zcashd</cite> nodes. Other node implementations MAY implement the same or similar behaviour, but this is not a requirement of the network protocol. Thus, RFC 2119 conformance keywords below are to be interpreted only as placing requirements on the <cite>zcashd</cite> implementation (and potentially other implementations that have adopted this specification in full).</p>
             <p>The mempool of a node holds a set of transactions. Each transaction has a <em>cost</em>, which is an integer defined as:</p>
             <blockquote>
-                <p>max(serialized transaction size in bytes, 4000)</p>
+                <p>max(memory size in bytes, 10000)</p>
             </blockquote>
-            <p>Each transaction also has an <em>eviction weight</em>, which is <em>cost</em> + <em>low_fee_penalty</em>, where <em>low_fee_penalty</em> is 16000 if the transaction pays a fee less than the conventional fee, otherwise 0. The conventional fee is currently defined in <a id="footnote-reference-4" class="footnote_reference" href="#zip-0317">5</a>.</p>
+            <p>The memory size is an estimate of the size that a transaction occupies in the memory of a node. It MAY be approximated as the serialized transaction size in bytes.</p>
+            <p>Each transaction also has an <em>eviction weight</em>, which is <em>cost</em> + <em>low_fee_penalty</em>, where <em>low_fee_penalty</em> is 40000 if the transaction pays a fee less than the conventional fee, otherwise 0. The conventional fee is currently defined in ZIP 317 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0317">5</a>.</p>
             <p>Each node also MUST hold a FIFO queue RecentlyEvicted of pairs (txid, time), where the time indicates when the transaction with the given txid was evicted. The txid (rather than the wtxid as defined in <a id="footnote-reference-5" class="footnote_reference" href="#zip-0239">3</a>) is used even for version 5 transactions after activation of NU5 <a id="footnote-reference-6" class="footnote_reference" href="#zip-0252">4</a>.</p>
             <p>The RecentlyEvicted queue SHOULD be empty on node startup. The size of RecentlyEvicted SHOULD never exceed <code>eviction_memory_entries</code> entries, which is the constant 40000.</p>
             <p>There MUST be a configuration option <code>mempooltxcostlimit</code>, which SHOULD default to 80000000.</p>
@@ -59,22 +61,29 @@ License: MIT</pre>
         </section>
         <section id="rationale"><h2><span class="section-heading">Rationale</span><span class="section-anchor"> <a rel="bookmark" href="#rationale"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The accounting for transaction size should include some overhead per transaction, to reflect the cost to the network of processing them (proof and signature verification; networking overheads; size of in-memory data structures). The implication of not including overhead is that a denial-of-service attacker would be likely to use minimum-size transactions so that more of them would fit in a block, increasing the unaccounted-for overhead. A possible counterargument would be that the complexity of accounting for this overhead is unwarranted given that the format of a transaction already imposes a minimum size. However, the proposed cost function is almost as simple as using transaction size directly.</p>
-            <p>The threshold 4000 for the cost function is chosen so that the size in bytes of a typical fully shielded Sapling transaction (with, say, 2 shielded outputs and up to 5 shielded inputs) will fall below the threshold. This has the effect of ensuring that such transactions are not evicted preferentially to typical transparent transactions because of their size.</p>
-            <p>The proposed eviction policy differs significantly from that of Bitcoin Core <a id="footnote-reference-7" class="footnote_reference" href="#bitcoincore-pr6722">6</a>, which is primarily fee-based. This reflects differing philosophies about the motivation for fees and the level of fee that legitimate users can reasonably be expected to pay. The proposed eviction weight function does involve a penalty for transactions with a fee lower than the standard (0.0001 ZEC) value, but since there is no further benefit to increasing the fee above the standard value, it creates no pressure toward escalating fees. For transactions up to 4000 bytes, this penalty makes a transaction that pays less than the standard fee value five times as likely to be chosen for eviction (because 4000 + 16000 = 20000 = 4000 * 5).</p>
-            <p>The fee penalty is not included in the cost that determines whether the mempool is considered full. This ensures that a DoS attacker does not have an incentive to pay less than the standard fee in order to cause the mempool to be considered full sooner.</p>
-            <p>The default value of 80000000 for <code>mempooltxcostlimit</code> represents no more than 40 blocks’ worth of transactions in the worst case, which is the default expiration height after the Blossom network upgrade <a id="footnote-reference-8" class="footnote_reference" href="#zip-0208">2</a>. It would serve no purpose to make it larger.</p>
+            <p>There is some ambiguity in the specification of a transaction's "memory size", allowing implementations to use different approximations. Currently, <cite>zcashd</cite> uses a size computed by the <code>RecursiveDynamicUsage</code> function, and <cite>zebrad</cite> uses the serialized size. This has been changed from a previous version of this ZIP that specified use of the serialized size, to reflect how the implementation in <cite>zcashd</cite> has worked since it was first deployed <a id="footnote-reference-7" class="footnote_reference" href="#size-ambiguity">7</a>.</p>
+            <p>The threshold 10000 for the cost function is chosen so that the size in bytes of a minimal fully shielded Orchard transaction with 2 shielded actions (having a serialized size of 9165 bytes) will fall below the threshold. This has the effect of ensuring that such transactions are not evicted preferentially to typical transparent or Sapling transactions because of their size. This constant has been updated <a id="footnote-reference-8" class="footnote_reference" href="#constants-update">6</a> from 4000 to 10000 in parallel with the changes for deployment of ZIP 317 <a id="footnote-reference-9" class="footnote_reference" href="#zip-0317">5</a>; the previous value had been chosen based on the typical size of fully shielded Sapling transactions.</p>
+            <p>The proposed eviction policy differs significantly from that of Bitcoin Core <a id="footnote-reference-10" class="footnote_reference" href="#bitcoincore-pr6722">8</a>, which is primarily fee-based. This reflects differing philosophies about the motivation for fees and the level of fee that legitimate users can reasonably be expected to pay. The proposed eviction weight function does involve a penalty for transactions with a fee lower than the ZIP 317 <a id="footnote-reference-11" class="footnote_reference" href="#zip-0317">5</a> conventional fee, but since there is no further benefit (as far as mempool limiting is concerned) to increasing the fee above the conventional fee value, it creates no pressure toward escalating fees. For transactions with a memory size up to 10000 bytes, this penalty makes a transaction that pays less than the conventional fee five times as likely to be chosen for eviction (because
+                <span class="math">\(10000 + 40000 = 50000 = 10000 \times 5\)</span>
+            ).</p>
+            <p>The fee penalty is not included in the cost that determines whether the mempool is considered full. This ensures that a DoS attacker does not have an incentive to pay less than the conventional fee in order to cause the mempool to be considered full sooner.</p>
+            <p>The default value of 80000000 for <code>mempooltxcostlimit</code> represents no more than 40 blocks’ worth of transactions in the worst case, which is the default expiration height after the Blossom network upgrade <a id="footnote-reference-12" class="footnote_reference" href="#zip-0208">2</a>. It would serve no purpose to make it larger.</p>
             <p>The <code>mempooltxcostlimit</code> is a per-node configurable parameter in order to provide flexibility for node operators to change it either in response to attempted denial-of-service attacks, or if needed to handle spikes in transaction demand. It may also be useful for nodes running in memory-constrained environments to reduce this parameter.</p>
-            <p>The limit of <code>eviction_memory_entries</code> = 40000 entries in RecentlyEvicted bounds the memory needed for this data structure. Since a txid is 32 bytes and a timestamp 8 bytes, 40000 entries can be stored in ~1.6 MB, which is small compared to other node memory usage (in particular, small compared to the maximum memory usage of the mempool itself under the default <code>mempooltxcostlimit</code>). <code>eviction_memory_entries</code> entries should be sufficient to mitigate any performance loss caused by re-accepting transactions that were previously evicted. In particular, since a transaction has a minimum cost of 4000, and the default <code>mempooltxcostlimit</code> is 80000000, at most 20000 transactions can be in the mempool of a node using the default parameters. While the number of transactions “in flight” or across the mempools of all nodes in the network could exceed this number, we believe that is unlikely to be a problem in practice.</p>
+            <p>The limit of <code>eviction_memory_entries</code> = 40000 entries in RecentlyEvicted bounds the memory needed for this data structure. Since a txid is 32 bytes and a timestamp 8 bytes, 40000 entries can be stored in ~1.6 MB, which is small compared to other node memory usage (in particular, small compared to the maximum memory usage of the mempool itself under the default <code>mempooltxcostlimit</code>). <code>eviction_memory_entries</code> entries should be sufficient to mitigate any performance loss caused by re-accepting transactions that were previously evicted. In particular, since a transaction has a minimum cost of 10000, and the default <code>mempooltxcostlimit</code> is 80000000, at most 8000 transactions can be in the mempool of a node using the default parameters. While the number of transactions “in flight” or across the mempools of all nodes in the network could exceed this number, we believe that is unlikely to be a problem in practice.</p>
             <p>Note that the RecentlyEvicted queue is intended as a performance optimization under certain conditions, rather than as a DoS-mitigation measure in itself.</p>
             <p>The default expiry of 40 blocks after Blossom activation represents an expected time of 50 minutes. Therefore (even if some blocks are slow), most legitimate transactions are expected to expire within 60 minutes. Note however that an attacker’s transactions cannot be relied on to expire.</p>
         </section>
         <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This specification is proposed to be implemented in <code>zcashd</code> v2.1.0. It is independent of the Blossom network upgrade.</p>
+            <p>This specification was implemented in <cite>zcashd</cite> v2.1.0-1. It is independent of the Blossom network upgrade.</p>
+            <p>The fee threshold for applying the <em>low_fee_penalty</em> was reduced from 10000 to 1000 zatoshis as part of the deployment of ZIP 313 in <cite>zcashd</cite> v4.2.0.</p>
+            <p>The fee threshold for applying the <em>low_fee_penalty</em> changed again in <cite>zcashd</cite> v5.5.0 and <cite>zebrad</cite> v1.0.0-rc.7 to match the ZIP 317 conventional fee. At the same time, the minimum cost threshold and the <em>low_fee_penalty</em> constant was increased as proposed in <a id="footnote-reference-13" class="footnote_reference" href="#constants-update">6</a>.</p>
         </section>
         <section id="reference-implementation"><h2><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
-                <li><a href="https://github.com/zcash/zcash/pull/4145">PR 4145: Implementation</a></li>
-                <li><a href="https://github.com/zcash/zcash/pull/4166">PR 4166: macOS compilation fix</a></li>
+                <li><a href="https://github.com/zcash/zcash/pull/4145">zcashd PR 4145: DoS protection: Weighted random drop of txs if mempool full</a></li>
+                <li><a href="https://github.com/zcash/zcash/pull/4166">zcashd PR 4166: Use same type when calling max (macOS compilation fix)</a></li>
+                <li><a href="https://github.com/zcash/zcash/pull/4916">zcashd PR 4916: Reduce default fee to 1000 zatoshis</a></li>
+                <li><a href="https://github.com/zcash/zcash/pull/6564">zcashd PR 6564: Change ZIP 401 mempool limiting to use conventional fee and new constants</a></li>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -118,10 +127,26 @@ License: MIT</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="bitcoincore-pr6722" class="footnote">
+            <table id="constants-update" class="footnote">
                 <tbody>
                     <tr>
                         <th>6</th>
+                        <td><a href="https://github.com/zcash/zips/issues/565">zcash/zips issue #565 - ZIP 401: Increase the minimum eviction cost to avoid penalizing Orchard</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="size-ambiguity" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>7</th>
+                        <td><a href="https://github.com/zcash/zips/issues/673">zcash/zips issue #673 - ZIP 401 uses serialized size to calculate cost but the zcashd implementation uses RecursiveDynamicUsage</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="bitcoincore-pr6722" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
                         <td><a href="https://github.com/bitcoin/bitcoin/pull/6722">Bitcoin Core PR 6722: Limit mempool by throwing away the cheapest txn and setting min relay fee to it</a></td>
                     </tr>
                 </tbody>

--- a/zip-0401.rst
+++ b/zip-0401.rst
@@ -141,7 +141,7 @@ cost function is almost as simple as using transaction size directly.
 
 There is some ambiguity in the specification of a transaction's "memory size",
 allowing implementations to use different approximations. Currently, `zcashd`
-uses a size computed by the ``RecursiveDynamicUsage`` function, and `zebra` uses
+uses a size computed by the ``RecursiveDynamicUsage`` function, and `zebrad` uses
 the serialized size. This has been changed from a previous version of this ZIP
 that specified use of the serialized size, to reflect how the implementation in
 `zcashd` has worked since it was first deployed [#size-ambiguity]_.
@@ -214,10 +214,10 @@ the Blossom network upgrade.
 The fee threshold for applying the *low_fee_penalty* was reduced from 10000 to
 1000 zatoshis as part of the deployment of ZIP 313 in `zcashd` v4.2.0.
 
-The fee threshold for applying the *low_fee_penalty* is planned to change again
-in `zcashd` v5.5.0 to match the ZIP 317 conventional fee. At the same time, the
-minimum cost threshold and the *low_fee_penalty* constant will be increased as
-proposed in [#constants-update]_.
+The fee threshold for applying the *low_fee_penalty* changed again in `zcashd`
+v5.5.0 and `zebrad` v1.0.0-rc.7 to match the ZIP 317 conventional fee. At the
+same time, the minimum cost threshold and the *low_fee_penalty* constant was
+increased as proposed in [#constants-update]_.
 
 
 Reference implementation

--- a/zip-0401.rst
+++ b/zip-0401.rst
@@ -79,16 +79,16 @@ potentially other implementations that have adopted this specification in full).
 The mempool of a node holds a set of transactions. Each transaction has a *cost*,
 which is an integer defined as:
 
-  max(memory size in bytes, 4000)
+  max(memory size in bytes, 10000)
 
 The memory size is an estimate of the size that a transaction occupies in the
 memory of a node. It MAY be approximated as the serialized transaction size in
 bytes.
 
 Each transaction also has an *eviction weight*, which is *cost* + *low_fee_penalty*,
-where *low_fee_penalty* is 16000 if the transaction pays a fee less than the
+where *low_fee_penalty* is 40000 if the transaction pays a fee less than the
 conventional fee, otherwise 0. The conventional fee is currently defined in
-[#zip-0317]_.
+ZIP 317 [#zip-0317]_.
 
 Each node also MUST hold a FIFO queue RecentlyEvicted of pairs (txid, time), where
 the time indicates when the transaction with the given txid was evicted. The txid
@@ -139,34 +139,38 @@ be that the complexity of accounting for this overhead is unwarranted given that
 the format of a transaction already imposes a minimum size. However, the proposed
 cost function is almost as simple as using transaction size directly.
 
-There is some ambiguity in the specification of "memory size", allowing
-implementations to use different approximations. Currently, `zcashd` uses a size
-computed by the `RecursiveDynamicUsage` function, and `zebra` uses the serialized
-size. This has been changed from a previous version of this ZIP that specified
-use of the serialized size, to reflect how the implementation in `zcashd` has
-worked since it was first deployed [#size-ambiguity]_.
+There is some ambiguity in the specification of a transaction's "memory size",
+allowing implementations to use different approximations. Currently, `zcashd`
+uses a size computed by the ``RecursiveDynamicUsage`` function, and `zebra` uses
+the serialized size. This has been changed from a previous version of this ZIP
+that specified use of the serialized size, to reflect how the implementation in
+`zcashd` has worked since it was first deployed [#size-ambiguity]_.
 
-The threshold 4000 for the cost function is chosen so that the size in bytes of a
-typical fully shielded Sapling transaction (with, say, 2 shielded outputs and up
-to 5 shielded inputs) will fall below the threshold. This has the effect of
-ensuring that such transactions are not evicted preferentially to typical
-transparent transactions because of their size.
+The threshold 10000 for the cost function is chosen so that the size in bytes of
+a minimal fully shielded Orchard transaction with 2 shielded actions (having a
+serialized size of 9165 bytes) will fall below the threshold. This has the effect
+of ensuring that such transactions are not evicted preferentially to typical
+transparent or Sapling transactions because of their size. This constant has been
+updated [#constants-update]_ from 4000 to 10000 in parallel with the changes for
+deployment of ZIP 317 [#zip-0317]_; the previous value had been chosen based on
+the typical size of fully shielded Sapling transactions.
 
 The proposed eviction policy differs significantly from that of Bitcoin Core
 [#BitcoinCore-PR6722]_, which is primarily fee-based. This reflects differing
 philosophies about the motivation for fees and the level of fee that legitimate
 users can reasonably be expected to pay. The proposed eviction weight function
-does involve a penalty for transactions with a fee lower than the standard
-(0.0001 ZEC) value, but since there is no further benefit to increasing the fee
-above the standard value, it creates no pressure toward escalating fees. For
-transactions up to 4000 bytes, this penalty makes a transaction that pays less
-than the standard fee value five times as likely to be chosen for eviction
-(because 4000 + 16000 = 20000 = 4000 \* 5).
+does involve a penalty for transactions with a fee lower than the ZIP 317
+[#zip-0317]_ conventional fee, but since there is no further benefit (as far
+as mempool limiting is concerned) to increasing the fee above the conventional
+fee value, it creates no pressure toward escalating fees. For transactions
+with a memory size up to 10000 bytes, this penalty makes a transaction that
+pays less than the conventional fee five times as likely to be chosen for
+eviction (because :math:`10000 + 40000 = 50000 = 10000 \times 5`).
 
 The fee penalty is not included in the cost that determines whether the mempool
 is considered full. This ensures that a DoS attacker does not have an incentive
-to pay less than the standard fee in order to cause the mempool to be considered
-full sooner.
+to pay less than the conventional fee in order to cause the mempool to be
+considered full sooner.
 
 The default value of 80000000 for ``mempooltxcostlimit`` represents no more
 than 40 blocks’ worth of transactions in the worst case, which is the default
@@ -186,8 +190,8 @@ to other node memory usage (in particular, small compared to the maximum memory
 usage of the mempool itself under the default ``mempooltxcostlimit``).
 ``eviction_memory_entries`` entries should be sufficient to mitigate any
 performance loss caused by re-accepting transactions that were previously evicted.
-In particular, since a transaction has a minimum cost of 4000, and the default
-``mempooltxcostlimit`` is 80000000, at most 20000 transactions can be in the
+In particular, since a transaction has a minimum cost of 10000, and the default
+``mempooltxcostlimit`` is 80000000, at most 8000 transactions can be in the
 mempool of a node using the default parameters. While the number of transactions
 “in flight” or across the mempools of all nodes in the network could exceed this
 number, we believe that is unlikely to be a problem in practice.
@@ -207,12 +211,22 @@ Deployment
 This specification was implemented in `zcashd` v2.1.0-1. It is independent of
 the Blossom network upgrade.
 
+The fee threshold for applying the *low_fee_penalty* was reduced from 10000 to
+1000 zatoshis as part of the deployment of ZIP 313 in `zcashd` v4.2.0.
+
+The fee threshold for applying the *low_fee_penalty* is planned to change again
+in `zcashd` v5.5.0 to match the ZIP 317 conventional fee. At the same time, the
+minimum cost threshold and the *low_fee_penalty* constant will be increased as
+proposed in [#constants-update]_.
+
 
 Reference implementation
 ========================
 
-* `PR 4145: Implementation <https://github.com/zcash/zcash/pull/4145>`_
-* `PR 4166: macOS compilation fix <https://github.com/zcash/zcash/pull/4166>`_
+* `zcashd PR 4145: DoS protection: Weighted random drop of txs if mempool full <https://github.com/zcash/zcash/pull/4145>`_
+* `zcashd PR 4166: Use same type when calling max (macOS compilation fix) <https://github.com/zcash/zcash/pull/4166>`_
+* `zcashd PR 4916: Reduce default fee to 1000 zatoshis <https://github.com/zcash/zcash/pull/4916>`_
+* `zcashd PR 6564: Change ZIP 401 mempool limiting to use conventional fee and new constants <https://github.com/zcash/zcash/pull/6564>`_
 
 
 References
@@ -223,5 +237,6 @@ References
 .. [#zip-0239] `ZIP 239: Relay of Version 5 Transactions <zip-0239.rst>`_
 .. [#zip-0252] `ZIP 252: Deployment of the NU5 Network Upgrade <zip-0252.rst>`_
 .. [#zip-0317] `ZIP 317: Proportional Transfer Fee Mechanism <zip-0317.rst>`_
+.. [#constants-update] `zcash/zips issue #565 - ZIP 401: Increase the minimum eviction cost to avoid penalizing Orchard <https://github.com/zcash/zips/issues/565>`_
 .. [#size-ambiguity] `zcash/zips issue #673 - ZIP 401 uses serialized size to calculate cost but the zcashd implementation uses RecursiveDynamicUsage <https://github.com/zcash/zips/issues/673>`_
 .. [#BitcoinCore-PR6722] `Bitcoin Core PR 6722: Limit mempool by throwing away the cheapest txn and setting min relay fee to it <https://github.com/bitcoin/bitcoin/pull/6722>`_

--- a/zip-0401.rst
+++ b/zip-0401.rst
@@ -19,7 +19,7 @@ as described in RFC 2119. [#RFC2119]_
 Abstract
 ========
 
-This proposal specifies a change to the behaviour of ``zcashd`` nodes intended to
+This proposal specifies a change to the behaviour of `zcashd` nodes intended to
 mitigate denial-of-service from transaction flooding.
 
 
@@ -70,10 +70,10 @@ does not preclude changes in fee policy.
 Specification
 =============
 
-This specification describes the intended behaviour of ``zcashd`` nodes. Other node
+This specification describes the intended behaviour of `zcashd` nodes. Other node
 implementations MAY implement the same or similar behaviour, but this is not a
 requirement of the network protocol. Thus, RFC 2119 conformance keywords below are
-to be interpreted only as placing requirements on the ``zcashd`` implementation (and
+to be interpreted only as placing requirements on the `zcashd` implementation (and
 potentially other implementations that have adopted this specification in full).
 
 The mempool of a node holds a set of transactions. Each transaction has a *cost*,

--- a/zip-0401.rst
+++ b/zip-0401.rst
@@ -79,7 +79,11 @@ potentially other implementations that have adopted this specification in full).
 The mempool of a node holds a set of transactions. Each transaction has a *cost*,
 which is an integer defined as:
 
-  max(serialized transaction size in bytes, 4000)
+  max(memory size in bytes, 4000)
+
+The memory size is an estimate of the size that a transaction occupies in the
+memory of a node. It MAY be approximated as the serialized transaction size in
+bytes.
 
 Each transaction also has an *eviction weight*, which is *cost* + *low_fee_penalty*,
 where *low_fee_penalty* is 16000 if the transaction pays a fee less than the
@@ -134,6 +138,13 @@ block, increasing the unaccounted-for overhead. A possible counterargument would
 be that the complexity of accounting for this overhead is unwarranted given that
 the format of a transaction already imposes a minimum size. However, the proposed
 cost function is almost as simple as using transaction size directly.
+
+There is some ambiguity in the specification of "memory size", allowing
+implementations to use different approximations. Currently, `zcashd` uses a size
+computed by the `RecursiveDynamicUsage` function, and `zebra` uses the serialized
+size. This has been changed from a previous version of this ZIP that specified
+use of the serialized size, to reflect how the implementation in `zcashd` has
+worked since it was first deployed [#size-ambiguity]_.
 
 The threshold 4000 for the cost function is chosen so that the size in bytes of a
 typical fully shielded Sapling transaction (with, say, 2 shielded outputs and up
@@ -212,4 +223,5 @@ References
 .. [#zip-0239] `ZIP 239: Relay of Version 5 Transactions <zip-0239.rst>`_
 .. [#zip-0252] `ZIP 252: Deployment of the NU5 Network Upgrade <zip-0252.rst>`_
 .. [#zip-0317] `ZIP 317: Proportional Transfer Fee Mechanism <zip-0317.rst>`_
+.. [#size-ambiguity] `zcash/zips issue #673 - ZIP 401 uses serialized size to calculate cost but the zcashd implementation uses RecursiveDynamicUsage <https://github.com/zcash/zips/issues/673>`_
 .. [#BitcoinCore-PR6722] `Bitcoin Core PR 6722: Limit mempool by throwing away the cheapest txn and setting min relay fee to it <https://github.com/bitcoin/bitcoin/pull/6722>`_

--- a/zip-0401.rst
+++ b/zip-0401.rst
@@ -193,8 +193,8 @@ attacker’s transactions cannot be relied on to expire.
 Deployment
 ==========
 
-This specification is proposed to be implemented in ``zcashd`` v2.1.0. It is
-independent of the Blossom network upgrade.
+This specification was implemented in `zcashd` v2.1.0-1. It is independent of
+the Blossom network upgrade.
 
 
 Reference implementation


### PR DESCRIPTION
fixes #673
fixes #565