### PR TITLE
Fix errors in protocol and ZIPs

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -11929,8 +11929,8 @@ When decoding this representation, the key \MUST be considered invalid if $\abst
 for either $\AuthSignPublic$ or $\NullifierKey$, or if $\AuthSignPublic \notin \SubgroupJstar$,
 or if $\NullifierKey \notin \SubgroupJ$.
 
-For \incomingViewingKeys on \Mainnet, the \humanReadablePart is \ascii{zviews}.
-For \incomingViewingKeys on \Testnet, the \humanReadablePart is \ascii{zviewtestsapling}.
+For \fullViewingKeys on \Mainnet, the \humanReadablePart is \ascii{zviews}.
+For \fullViewingKeys on \Testnet, the \humanReadablePart is \ascii{zviewtestsapling}.
 } %sapling
 
 

--- a/zip-0032.html
+++ b/zip-0032.html
@@ -232,7 +232,7 @@ License: MIT</pre>
                     </li>
                     <li>
                         <span class="math">\(\mathsf{EncodeExtFVKParts}(\mathsf{ak, nk, ovk, dk}) :=\)</span>
-                        <span class="math">\(\mathsf{LEBS2OS}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{ak}))\)</span>
+                        <span class="math">\(\mathsf{LEBS2OSP}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{ak}))\)</span>
                         <span class="math">\(||\,\mathsf{LEBS2OSP}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{nk}))\)</span>
                         <span class="math">\(||\,\mathsf{ovk}\)</span>
                         <span class="math">\(||\,\mathsf{dk}\)</span>

--- a/zip-0032.rst
+++ b/zip-0032.rst
@@ -177,7 +177,7 @@ Sapling helper functions
 Define
 
 * :math:`\mathsf{EncodeExtSKParts}(\mathsf{ask, nsk, ovk, dk}) :=`:math:`\mathsf{I2LEOSP}_{256}(\mathsf{ask})`:math:`||\,\mathsf{I2LEOSP}_{256}(\mathsf{nsk})`:math:`||\,\mathsf{ovk}`:math:`||\,\mathsf{dk}`
-* :math:`\mathsf{EncodeExtFVKParts}(\mathsf{ak, nk, ovk, dk}) :=`:math:`\mathsf{LEBS2OS}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{ak}))`:math:`||\,\mathsf{LEBS2OSP}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{nk}))`:math:`||\,\mathsf{ovk}`:math:`||\,\mathsf{dk}`
+* :math:`\mathsf{EncodeExtFVKParts}(\mathsf{ak, nk, ovk, dk}) :=`:math:`\mathsf{LEBS2OSP}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{ak}))`:math:`||\,\mathsf{LEBS2OSP}_{256}(\mathsf{repr}_\mathbb{J}(\mathsf{nk}))`:math:`||\,\mathsf{ovk}`:math:`||\,\mathsf{dk}`
 
 Sapling master key generation
 -----------------------------

--- a/zip-0316.html
+++ b/zip-0316.html
@@ -250,7 +250,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/482">https://g
                      is an encoding of
                         <span class="math">\((\mathsf{dk}, \mathsf{ivk})\)</span>
                      given by
-                        <span class="math">\(\mathsf{I2LEOSP}_{88}(\mathsf{dk})\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).\)</span>
+                        <span class="math">\(\mathsf{dk}\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).\)</span>
                     </li>
                     <li>There is no defined way to represent a Viewing Key for a Transparent P2SH Address in a UFVK or UIVK (because P2SH Addresses cannot be diversified in an unlinkable way). The Typecode
                         <span class="math">\(\mathtt{0x01}\)</span>

--- a/zip-0316.rst
+++ b/zip-0316.rst
@@ -431,7 +431,7 @@ The following FVK or IVK Encodings are used in place of the
 
 * A Sapling IVK Encoding, also with Typecode :math:`\mathtt{0x02},`
   is an encoding of :math:`(\mathsf{dk}, \mathsf{ivk})` given by
-  :math:`\mathsf{I2LEOSP}_{88}(\mathsf{dk})\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).`
+  :math:`\mathsf{I2LEOSP}_{256}(\mathsf{dk})\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).`
 
 * There is no defined way to represent a Viewing Key for a Transparent
   P2SH Address in a UFVK or UIVK (because P2SH Addresses cannot be

--- a/zip-0316.rst
+++ b/zip-0316.rst
@@ -431,7 +431,7 @@ The following FVK or IVK Encodings are used in place of the
 
 * A Sapling IVK Encoding, also with Typecode :math:`\mathtt{0x02},`
   is an encoding of :math:`(\mathsf{dk}, \mathsf{ivk})` given by
-  :math:`\mathsf{I2LEOSP}_{256}(\mathsf{dk})\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).`
+  :math:`\mathsf{dk}\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).`
 
 * There is no defined way to represent a Viewing Key for a Transparent
   P2SH Address in a UFVK or UIVK (because P2SH Addresses cannot be

--- a/zip-0321.html
+++ b/zip-0321.html
@@ -121,7 +121,7 @@ License: MIT</pre>
                     <p>Also invalid; <code>address.0=</code> and <code>amount.0=</code> are not permitted as leading 0s are forbidden in <code>paramindex</code>.</p>
                     <pre>zcash:?amount=1.234&amp;amount=2.345&amp;address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU
 
-zcash:?amount.1=1.234&amp;amount.1=2.345&amp;address.1=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"</pre>
+zcash:?amount.1=1.234&amp;amount.1=2.345&amp;address.1=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU</pre>
                     <p>Also invalid; duplicate <code>amount=</code> or <code>amount.1=</code> fields</p>
                     <pre>zcash:tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?amount=1%30
 zcash:tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?%61mount=1

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -260,7 +260,7 @@ forbidden in ``paramindex``.
 
   zcash:?amount=1.234&amount=2.345&address=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU
 
-  zcash:?amount.1=1.234&amount.1=2.345&address.1=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU"
+  zcash:?amount.1=1.234&amount.1=2.345&address.1=tmEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU
 
 Also invalid; duplicate ``amount=`` or ``amount.1=`` fields
 


### PR DESCRIPTION
- ZIP-321 had a stray `"` character at the end of a URI example.
- ZIP-316 assumes the wrong length for `dk`
  The `dk` value is 256 bits long. It's the *diversifier* that is only 88 bits long. The incoming viewing key requires the diversifier key -- not the diversifier.
    This change also reflects the de facto standard in implementations up to this point, including YWallet and the [zcash_address crate](https://docs.rs/zcash_address/latest/src/zcash_address/kind/unified/ivk.rs.html).
- ZIP-32 has a typo in a function name
   Fix reference to undefined LEBS2OS function
    The `LEBS2OS` function does not exist and isn't meant to. This reference is understood to have meant `LEBS2OSP`.
    See discussion at:
    https://forum.zcashcommunity.com/t/what-is-the-lebs2os-function-in-the-zip-32-spec/44886
- Zcash protocol: Fix identification of HRP for full viewing keys
    This was likely a copy-paste error with the section above it, which is very similar but presents the human-readable part of *incoming* viewing keys.