### PR TITLE
Update ZIP editors, and make process improvements and clarifications

### DIFF
--- a/zip-0000.html
+++ b/zip-0000.html
@@ -22,7 +22,7 @@ Category: Process
 Created: 2019-02-16
 License: BSD-2-Clause</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", "SHOULD NOT", "MAY", "RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", "RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zip-0000.html
+++ b/zip-0000.html
@@ -9,10 +9,13 @@
         <pre>ZIP: 0
 Title: ZIP Process
 Owners: Daira Emma Hopwood &lt;daira@electriccoin.co&gt;
-        Deirdre Connolly &lt;deirdre@zfnd.org&gt;
+        teor &lt;teor@zfnd.org&gt;
+        Jack Grigg &lt;str4d@electriccoin.co&gt;
+        Conrado Gouvea &lt;conrado@zfnd.org&gt;
 Original-Authors: Daira Emma Hopwood
                   Josh Cincinnati
                   George Tankersley
+                  Deirdre Connolly
 Credits: Luke Dashjr
 Status: Active
 Category: Process
@@ -54,29 +57,50 @@ License: BSD-2-Clause</pre>
                 <p>If an author of a ZIP is no longer an Owner, an Original-Authors: field SHOULD be added to the ZIP metadata indicating the original authorship (without email addresses), unless the original author(s) request otherwise.</p>
             </section>
             <section id="zip-editors"><h3><span class="section-heading">ZIP Editors</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The current ZIP Editors are Daira Emma Hopwood, representing the Electric Coin Company, and Deirdre Connolly, representing the Zcash Foundation. Both can be reached at <a href="mailto:zips@z.cash">zips@z.cash</a> . The current design of the ZIP Process dictates that there are always at least two ZIP Editors: one from the Electric Coin Company and one from the Zcash Foundation. Additional Editors may be selected by consensus among the current Editors.</p>
+                <p>The current ZIP Editors are:</p>
+                <ul>
+                    <li>Daira Emma Hopwood and Jack Grigg, associated with the Electric Coin Company;</li>
+                    <li>teor and Conrado Gouvea, associated with the Zcash Foundation.</li>
+                </ul>
+                <p>All can be reached at <a href="mailto:zips@z.cash">zips@z.cash</a>. The current design of the ZIP Process dictates that there are always at least two ZIP Editors: at least one from the Electric Coin Company and at least one from the Zcash Foundation.</p>
+                <p>ZIP Editors MUST declare any potential or perceived conflict of interest they have relating to their responsibilities as ZIP Editors.</p>
+                <p>Additional Editors may be selected, with their consent, by consensus among the current Editors. An Editor may be removed or replaced by consensus among the current Editors. However, if the other ZIP Editors have consensus, an Editor can not prevent their own removal. Any Editor can resign by informing the other Editors in writing.</p>
+                <p>Whenever the ZIP Editors change, the new ZIP Editors SHOULD: - review this ZIP to make sure it reflects current practice, - update the owners of this ZIP, - review access to the <cite>ZIPs repository &lt;<a href="https://github.com/zcash/zips">https://github.com/zcash/zips</a>&gt;</cite>, - update the &lt;<a href="mailto:zips@z.cash">zips@z.cash</a>&gt; email alias, and - invite new Editors to the Zcash Community Forums, and the #zips channel on Discord.</p>
+                <p>If it has been at least 12 months since the last ZIP Editor change, the ZIP Editors SHOULD: - review this ZIP to make sure it reflects current practice.</p>
             </section>
-            <section id="zip-editor-responsibilities-workflow"><h3><span class="section-heading">ZIP Editor Responsibilities &amp; Workflow</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-responsibilities-workflow"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+            <section id="zip-editor-responsibilities"><h3><span class="section-heading">ZIP Editor Responsibilities</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-responsibilities"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The ZIP Editors subscribe to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum.</a></p>
-                <p>For each new ZIP that comes in, a ZIP Editor confirms the following:</p>
+                <p>Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git repository <a id="footnote-reference-4" class="footnote_reference" href="#zips-repo">8</a>. It SHOULD NOT contain a ZIP number unless one had already been assigned by the ZIP Editors. The pull request SHOULD initially be marked as a Draft. The ZIP content SHOULD be submitted in reStructuredText <a id="footnote-reference-5" class="footnote_reference" href="#rst">5</a> or Markdown <a id="footnote-reference-6" class="footnote_reference" href="#markdown">6</a> format. Generating HTML for a ZIP is OPTIONAL.</p>
+                <p>For each new ZIP that comes in, the ZIP Editors SHOULD:</p>
                 <ul>
                     <li>Read the ZIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.</li>
-                    <li>The title should accurately describe the content.</li>
-                    <li>The ZIP draft must have been sent to the Zcash Community Forum or as a PR to the ZIPs git repository <a id="footnote-reference-4" class="footnote_reference" href="#zips-repo">8</a>.</li>
-                    <li>Motivation and backward compatibility (when applicable) must be addressed.</li>
-                    <li>The licensing terms are acceptable for ZIPs.</li>
+                    <li>Check that the title accurately describes the content.</li>
+                    <li>Ensure that the ZIP draft has been sent to the Zcash Community Forum and as a PR to the ZIPs git repository <a id="footnote-reference-7" class="footnote_reference" href="#zips-repo">8</a>.</li>
+                    <li>Ensure that motivation and backward compatibility have been addressed, if applicable.</li>
+                    <li>Check that the licensing terms are acceptable for ZIPs.</li>
                 </ul>
-                <p>If the ZIP isn't ready, the editor will send it back to the Owners for revision, with specific instructions.</p>
-                <p>Once the ZIP is ready for the repository it SHOULD be submitted as a "pull request" to the ZIPs git repository <a id="footnote-reference-5" class="footnote_reference" href="#zips-repo">8</a> where it may get further feedback. It SHOULD NOT contain a ZIP number unless one had already been assigned by the ZIP Editors. The pull request SHOULD initially be marked as a Draft.</p>
-                <p>The ZIP Editors will:</p>
+            </section>
+            <section id="reviewing-a-zip"><h3><span class="section-heading">Reviewing a ZIP</span><span class="section-anchor"> <a rel="bookmark" href="#reviewing-a-zip"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>Any ZIP Editor can suggest changes to a ZIP. These suggestions are the opinion of the individual ZIP Editor. Any technical or process review that ZIP Editors perform is expected to be independent of their contractual or other relationships.</p>
+                <p>ZIP Owners are free to clarify, modify, or decline suggestions from ZIP Editors. If the ZIP Editors make a change to a ZIP that the Owner disagrees with, then the Editors SHOULD revert the change.</p>
+                <p>Typically, the ZIP Editors suggest changes in two phases:</p>
                 <ul>
-                    <li>Assign a ZIP number in the pull request.</li>
-                    <li>Remove Draft status and merge the pull request when it is ready.</li>
+                    <li><cite>content review</cite>: multiple ZIP Editors discuss the ZIP, and suggest changes to the overall content. This is a "big picture" review.</li>
+                    <li><cite>format review</cite>: two ZIP Editors do a detailed review of the structure and format of the ZIP. This ensures the ZIP is consistent with other Zcash specifications.</li>
+                </ul>
+                <p>If the ZIP isn't ready, the Editors will send it back to the Owners for revision, with specific instructions. This decision is made by consensus among the current Editors.</p>
+                <p>When a ZIP is ready, the ZIP Editors will:</p>
+                <ul>
+                    <li>Ensure that a unique ZIP number has been assigned in the pull request.</li>
+                    <li>Regenerate the corresponding HTML documents, if required.</li>
+                    <li>Remove Draft status and merge the pull request.</li>
                 </ul>
                 <p>The ZIP editors monitor ZIP changes and update ZIP headers as appropriate.</p>
-                <p>The ZIP Editors MAY reject a proposed ZIP or update to an existing ZIP for any of the following reasons:</p>
+            </section>
+            <section id="rejecting-a-proposed-zip-or-update"><h3><span class="section-heading">Rejecting a proposed ZIP or update</span><span class="section-anchor"> <a rel="bookmark" href="#rejecting-a-proposed-zip-or-update"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The ZIP Editors MAY reject a proposed ZIP or update to an existing ZIP, by consensus among the current Editors. Rejections can be based on any of the following reasons:</p>
                 <ul>
-                    <li>it violates the Zcash Code of Conduct <a id="footnote-reference-6" class="footnote_reference" href="#conduct">4</a> ;</li>
+                    <li>it violates the Zcash Code of Conduct <a id="footnote-reference-8" class="footnote_reference" href="#conduct">4</a> ;</li>
                     <li>it appears too unfocused or broad;</li>
                     <li>it duplicates effort in other ZIPs without sufficient technical justification (however, alternative proposals to address similar or overlapping problems are not excluded for this reason);</li>
                     <li>it has manifest security flaws (including being unrealistically dependent on user vigilance to avoid security weaknesses);</li>
@@ -94,17 +118,35 @@ License: BSD-2-Clause</pre>
                     <li>a new ZIP has been proposed for a category that does not reflect its content, or an update would change a ZIP to an inappropriate category;</li>
                     <li>it updates a Released ZIP to Draft when the specification is already implemented and has been in common use;</li>
                     <li>it violates any specific "MUST" or "MUST NOT" rule in this document;</li>
-                    <li>the expressed political views of a Owner of the document are inimical to the Zcash Code of Conduct <a id="footnote-reference-7" class="footnote_reference" href="#conduct">4</a> (except in the case of an update removing that Owner);</li>
+                    <li>the expressed political views of a Owner of the document are inimical to the Zcash Code of Conduct <a id="footnote-reference-9" class="footnote_reference" href="#conduct">4</a> (except in the case of an update removing that Owner);</li>
                     <li>it is not authorized by the stated ZIP Owners;</li>
                     <li>it removes an Owner without their consent (unless the reason for removal is directly related to a breach of the Code of Conduct by that Owner).</li>
                 </ul>
                 <p>The ZIP Editors MUST NOT unreasonably deny publication of a ZIP proposal or update that does not violate any of these criteria. If they refuse a proposal or update, they MUST give an explanation of which of the criteria were violated, with the exception that spam may be deleted without an explanation.</p>
                 <p>Note that it is not the primary responsibility of the ZIP Editors to review proposals for security, correctness, or implementability.</p>
-                <p>Please send all ZIP-related communications either by email to &lt;<a href="mailto:zips@z.cash">zips@z.cash</a>&gt;, or by opening an issue on the <a href="https://github.com/zcash/zips/issues">ZIPs issue tracker</a>. All communications should abide by the Zcash Code of Conduct <a id="footnote-reference-8" class="footnote_reference" href="#conduct">4</a> and follow <a href="https://www.gnu.org/philosophy/kind-communication.en.html">the GNU Kind Communication Guidelines</a></p>
+            </section>
+            <section id="communicating-with-the-zip-editors"><h3><span class="section-heading">Communicating with the ZIP Editors</span><span class="section-anchor"> <a rel="bookmark" href="#communicating-with-the-zip-editors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>Please send all ZIP-related communications either:</p>
+                <ul>
+                    <li>by email to &lt;<a href="mailto:zips@z.cash">zips@z.cash</a>&gt;,</li>
+                    <li>by opening an issue on the <cite>ZIPs issue tracker &lt;<a href="https://github.com/zcash/zips/issues">https://github.com/zcash/zips/issues</a>&gt;</cite>, or</li>
+                    <li>by sending a message in the <cite>#zips channel on the Zcash R&amp;D Discord &lt;<a href="https://discord.com/channels/809218587167293450/809251050741170187">https://discord.com/channels/809218587167293450/809251050741170187</a>&gt;</cite>.</li>
+                </ul>
+                <p>__All communications should abide by the Zcash Code of Conduct <a id="footnote-reference-10" class="footnote_reference" href="#conduct">4</a> and follow <cite>the GNU Kind Communication Guidelines &lt;<a href="https://www.gnu.org/philosophy/kind-communication.en.html">https://www.gnu.org/philosophy/kind-communication.en.html</a>&gt;</cite>.__</p>
+            </section>
+            <section id="zip-editor-meeting-practices"><h3><span class="section-heading">ZIP Editor Meeting Practices</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-meeting-practices"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The ZIP Editors SHOULD meet on a regular basis to review draft changes to ZIPs. Meeting times are agreed by consensus among the current ZIP Editors. A ZIP Editor meeting can be held even if some ZIP Editors are not available, but all Editors SHOULD be informed of significant decisions that are likely to be made at upcoming meetings.</p>
+                <p>The ZIP Editors will appoint a ZIP Secretary, which can be a shared or rotating role. The ZIP Secretary will:</p>
+                <ul>
+                    <li>share a draft agenda with the ZIP Editors at least 24 hours before each ZIP Editors' meeting;</li>
+                    <li>share draft minutes of significant decisions with the ZIP Editors in the week after the ZIP Editors' meeting; and</li>
+                    <li>share significant ZIP changes on the Zcash Community Forums.</li>
+                </ul>
+                <p>If the draft agenda is empty, any ZIP Editor MAY submit agenda items, or suggest that the meeting is cancelled.</p>
             </section>
         </section>
         <section id="zip-format-and-structure"><h2><span class="section-heading">ZIP format and structure</span><span class="section-anchor"> <a rel="bookmark" href="#zip-format-and-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>ZIPs SHOULD be written in reStructuredText <a id="footnote-reference-9" class="footnote_reference" href="#rst">5</a>, Markdown <a id="footnote-reference-10" class="footnote_reference" href="#markdown">6</a>, or LaTeX <a id="footnote-reference-11" class="footnote_reference" href="#latex">7</a>. For ZIPs written in LaTeX, a <code>Makefile</code> MUST be provided to build (at least) a PDF version of the document.</p>
+            <p>ZIPs SHOULD be written in reStructuredText <a id="footnote-reference-11" class="footnote_reference" href="#rst">5</a>, Markdown <a id="footnote-reference-12" class="footnote_reference" href="#markdown">6</a>, or LaTeX <a id="footnote-reference-13" class="footnote_reference" href="#latex">7</a>. For ZIPs written in LaTeX, a <code>Makefile</code> MUST be provided to build (at least) a PDF version of the document.</p>
             <p>Each ZIP SHOULD have the following parts:</p>
             <ul>
                 <li>Preamble — Headers containing metadata about the ZIP (<a href="#zip-header-preamble">see below</a>). The License field of the preamble indicates the licensing terms, which MUST be acceptable according to <a href="#zip-licensing">the ZIP licensing requirements</a>.</li>
@@ -151,11 +193,11 @@ Important but hidden rationale!
 
    &lt;/details&gt;</pre>
                 </li>
-                <li>Security and privacy considerations — If applicable, security and privacy considerations should be explicitly described, particularly if the ZIP makes explicit trade-offs or assumptions. For guidance on this section consider RFC 3552 <a id="footnote-reference-12" class="footnote_reference" href="#rfc3552">2</a> as a starting point.</li>
+                <li>Security and privacy considerations — If applicable, security and privacy considerations should be explicitly described, particularly if the ZIP makes explicit trade-offs or assumptions. For guidance on this section consider RFC 3552 <a id="footnote-reference-14" class="footnote_reference" href="#rfc3552">2</a> as a starting point.</li>
                 <li>Reference implementation — Literal code implementing the ZIP's specification, and/or a link to the reference implementation of the ZIP's specification. The reference implementation MUST be completed before any ZIP is given status “Implemented” or “Final”, but it generally need not be completed before the ZIP is accepted into “Proposed”.</li>
             </ul>
             <section id="zip-stubs"><h3><span class="section-heading">ZIP stubs</span><span class="section-anchor"> <a rel="bookmark" href="#zip-stubs"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>A ZIP stub records that the ZIP Editors have reserved a number for a ZIP that is under development. It is not a ZIP, but exists in the ZIPs git repository <a id="footnote-reference-13" class="footnote_reference" href="#zips-repo">8</a> at the same path that will be used for the corresponding ZIP if and when it is published. It consists only of a preamble.</p>
+                <p>A ZIP stub records that the ZIP Editors have reserved a number for a ZIP that is under development. It is not a ZIP, but exists in the ZIPs git repository <a id="footnote-reference-15" class="footnote_reference" href="#zips-repo">8</a> at the same path that will be used for the corresponding ZIP if and when it is published. It consists only of a preamble.</p>
                 <p>ZIP stubs can be added and removed, or replaced by the corresponding ZIP, at the discretion of the ZIP Editors. If a ZIP stub is removed then its number MAY be reused, possibly for an entirely different ZIP.</p>
             </section>
             <section id="zip-header-preamble"><h3><span class="section-heading">ZIP header preamble</span><span class="section-anchor"> <a rel="bookmark" href="#zip-header-preamble"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -173,8 +215,8 @@ License:</pre>
 Original-Authors:
 Discussions-To:
 Pull-Request:
-Obsoleted by:
-Updated by:
+Obsoleted-By:
+Updated-By:
 Obsoletes:
 Updates:</pre>
                 <p>For ZIP stubs, only the ZIP:, Title:, Status:, and Category: fields are REQUIRED. Typically the other fields applicable to ZIP stubs are Credits:, Discussions-To: and Pull-Request:, which are OPTIONAL.</p>
@@ -225,21 +267,18 @@ Updates:</pre>
                 <li>Draft: All initial ZIP submissions have this status.</li>
                 <li>Withdrawn: If the Owner decides to remove the ZIP from consideration by the community, they may set the status to Withdrawn.</li>
                 <li>Active: Typically only used for Process/Informational ZIPs, achieved once rough consensus is reached in PR/forum posts from Draft Process ZIP.</li>
-                <li>Proposed: Typically the stage after Draft, added to a ZIP after consideration, feedback, and rough consensus from the community. The ZIP Editors must validate this change before it is approved.</li>
-                <li>Rejected: The status when progress hasn't been made on the ZIP in one year. Can revert back to Draft/Proposed if the Owner resumes work or resolves issues preventing consensus.</li>
-                <li>Implemented: When a Consensus or Standards ZIP has a working reference implementation but before activation on the Zcash network.</li>
+                <li>Proposed: Typically the stage after Draft, added to a ZIP after consideration, feedback, and rough consensus from the community. The Proposed status MUST be approved by consensus among the current ZIP Editors.</li>
+                <li>Rejected: If no progress on a Draft or Proposed ZIP has been made for one year, the ZIP Editors SHOULD move it to Rejected status. It can revert back to Draft/Proposed if the Owner resumes work or resolves issues preventing consensus. The Rejected status MUST be approved by consensus among the current ZIP Editors.</li>
+                <li>Implemented: When a Consensus or Standards ZIP has a working reference implementation but before activation on the Zcash network. The status MAY indicate which node implementation has implemented the ZIP, e.g. "Implemented (zcashd)" or "Implemented (zebra)".</li>
                 <li>Final: When a Consensus or Standards ZIP is both implemented and activated on the Zcash network.</li>
                 <li>Obsolete: The status when a ZIP is no longer relevant (typically when superseded by another ZIP).</li>
             </ul>
-            <p>More details on the status workflow are given in the section below.</p>
-            <section id="specification"><h3><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Owners of a ZIP may decide on their own to change the status between Draft or Withdrawn.</p>
-                <p>A ZIP may only change status from Draft (or Rejected) to Proposed, when the Owner deems it is complete and there is rough consensus on the forums, validated by both the Electric Coin Company and Zcash Foundation Editors. One Editor will not suffice — there needs to be consensus among the Editors. If it's a Consensus ZIP, a Deployment section MUST be present in order for the ZIP to change status to Proposed. Typically, although not necessarily, this will specify a network upgrade in which the consensus change is to activate.</p>
-                <p>A Standards ZIP may only change status from Proposed to Implemented once the Owners provide an associated reference implementation, typically in the period after the network upgrade's specification freeze but before the implementation audit. If the Owners miss this deadline, the Editors or Owners MAY choose to update the Deployment section of the ZIP to target another upgrade, at their discretion.</p>
-                <p>ZIPs should be changed from Draft or Proposed status, to Rejected status, upon request by any person, if they have not made progress in one year. Such a ZIP may be changed to Draft status if the Owner provides revisions that meaningfully address public criticism of the proposal, or to Proposed status if it meets the criteria required as described in the previous paragraphs.</p>
-                <p>A Consensus or Standards ZIP becomes Final when its associated network upgrade or other protocol change is activated on Zcash's mainnet.</p>
-                <p>A Process or Informational ZIP may change status from Draft to Active when it achieves rough consensus on the forum or PR. Such a proposal is said to have rough consensus if it has been open to discussion on the forum or GitHub PR for at least one month, and no person maintains any unaddressed substantiated objections to it. Addressed or obstructive objections may be ignored/overruled by general agreement that they have been sufficiently addressed, but clear reasoning must be given in such circumstances.</p>
-                <p>When an Active or Final ZIP is no longer relevant, its status may be changed to Obsolete. This change must also be objectively verifiable and/or discussed. Final ZIPs may be updated; the specification is still in force but modified by another specified ZIP or ZIPs (check the optional Updated-by header).</p>
+            <section id="specification-of-status-workflow"><h3><span class="section-heading">Specification of Status Workflow</span><span class="section-anchor"> <a rel="bookmark" href="#specification-of-status-workflow"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>Owners of a ZIP MAY decide on their own to change the status between Draft or Withdrawn.</p>
+                <p>A ZIP SHOULD only change status from Draft (or Rejected) to Proposed, when the Owner deems it is complete and there is rough consensus on the forums, validated by consensus among the current ZIP Editors. If it's a Consensus ZIP, a Deployment section MUST be present in order for the ZIP to change status to Proposed. Typically, although not necessarily, this will specify a network upgrade in which the consensus change is to activate.</p>
+                <p>A Standards ZIP SHOULD only change status from Proposed to Implemented once the Owners provide an associated reference implementation, typically in the period after the network upgrade's specification freeze but before the implementation audit. If the Owners miss this deadline, the Editors or Owners MAY choose to update the Deployment section of the ZIP to target another upgrade, at their discretion.</p>
+                <p>A Process or Informational ZIP SHOULD change status from Draft to Active when it achieves rough consensus on the forum or PR. Such a proposal is said to have rough consensus if it has been open to discussion on the forum or GitHub PR for at least one month, and no person maintains any unaddressed substantiated objections to it. Addressed or obstructive objections can be ignored/overruled by general agreement that they have been sufficiently addressed, but clear reasoning MUST be given in such circumstances.</p>
+                <p>When an Active or Final ZIP is no longer relevant, its status SHOULD be changed to Obsolete. This change MUST also be objectively verifiable and/or discussed. Final ZIPs MAY be updated; the specification is still in force but modified by another specified ZIP or ZIPs (check the optional Updated-By header).</p>
             </section>
         </section>
         <section id="zip-comments"><h2><span class="section-heading">ZIP Comments</span><span class="section-anchor"> <a rel="bookmark" href="#zip-comments"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -277,7 +316,7 @@ Updates:</pre>
                 </ul>
             </section>
             <section id="not-acceptable-licenses"><h3><span class="section-heading">Not acceptable licenses</span><span class="section-anchor"> <a rel="bookmark" href="#not-acceptable-licenses"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>All licenses not explicitly included in the above lists are not acceptable terms for a Zcash Improvement Proposal.</p>
+                <p>All licenses not explicitly included in the above lists are not acceptable terms and MUST NOT be used for a Zcash Improvement Proposal.</p>
             </section>
             <section id="rationale"><h3><span class="section-heading">Rationale</span><span class="section-anchor"> <a rel="bookmark" href="#rationale"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Bitcoin's BIP 1 allowed the Open Publication License or releasing into the public domain; was this insufficient?</p>

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -163,10 +163,10 @@ SHOULD be added to the ZIP metadata indicating the original authorship
 ZIP Editors
 -----------
 
-The current ZIP Editors are Daira Emma Hopwood, representing the Electric Coin
-Company, and Deirdre Connolly, representing the Zcash Foundation. Both
-can be reached at zips@z.cash . The current design of the ZIP Process
-dictates that there are always at least two ZIP Editors: one from the
+The current ZIP Editors are Daira Emma Hopwood and Jack Grigg (representing the Electric Coin
+Company), Deirdre Connolly, teor, and Conrado Gouvea, representing the Zcash Foundation. All
+can be reached at zips@z.cash. The current design of the ZIP Process
+dictates that there are always at least two ZIP Editors: at least one from the
 Electric Coin Company and one from the Zcash Foundation. Additional Editors may
 be selected by consensus among the current Editors.
 

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -167,27 +167,27 @@ ZIP Editors
 -----------
 
 The current ZIP Editors are:
-- Daira Emma Hopwood and Jack Grigg (representing the Electric Coin
-Company)
-- teor and Conrado Gouvea (representing the Zcash Foundation).
+- Daira Emma Hopwood and Jack Grigg, associated with the Electric Coin
+Company;
+- teor and Conrado Gouvea, associated with the Zcash Foundation.
 
 All can be reached at zips@z.cash. The current design of the ZIP Process
 dictates that there are always at least two ZIP Editors: at least one from the
 Electric Coin Company and at least one from the Zcash Foundation.
 
-Additional Editors may be selected by consensus among the current Editors.
+Additional Editors may be selected, with their consent, by consensus among the current Editors.
 An Editor may be removed or replaced by consensus among the current Editors.
-However, if the other ZIP editors have consensus, an Editor can not prevent their own removal.
+However, if the other ZIP Editors have consensus, an Editor can not prevent their own removal.
 Any Editor can resign by informing the other Editors in writing.
 
-Whenever the ZIP editors change, the new ZIP editors should:
+Whenever the ZIP Editors change, the new ZIP Editors should:
 - review this ZIP to make sure it reflects current practice,
 - update the owners of this ZIP,
-- review ZIP editor access to the `ZIPs repository <https://github.com/zcash/zips>`,
+- review access to the `ZIPs repository <https://github.com/zcash/zips>`,
 - update the <zips@z.cash> email alias, and
-- invite new editors to the Zcash Community Forums, and the #zips channel on Discord.
+- invite new Editors to the Zcash Community Forums, and the #zips channel on Discord.
 
-If it has been at least 12 months since the last ZIP editor change, the ZIP editors should:
+If it has been at least 12 months since the last ZIP Editor change, the ZIP Editors should:
 - review this ZIP to make sure it reflects current practice.
 
 

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -201,19 +201,20 @@ Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git
 repository [#zips-repo]_. It SHOULD NOT contain a ZIP number unless
 one had already been assigned by the ZIP Editors. The pull request
 SHOULD initially be marked as a Draft. The ZIP content SHOULD be
-submitted in RST format. Generating HTML for a ZIP is optional.
+submitted in reStructuredText [#rst]_ or Markdown [#markdown]_
+format. Generating HTML for a ZIP is OPTIONAL.
 
-For each new ZIP that comes in, the ZIP Editors will:
+For each new ZIP that comes in, the ZIP Editors SHOULD:
 
 * Read the ZIP to check if it is ready: sound and complete. The ideas
   must make technical sense, even if they don't seem likely to be
   accepted.
-* The title should accurately describe the content.
-* The ZIP draft must have been sent to the Zcash Community Forum and as
-  a PR to the ZIPs git repository [#zips-repo]_.
-* Motivation and backward compatibility (when applicable) must be
-  addressed.
-* The licensing terms are acceptable for ZIPs.
+* Check that the title accurately describes the content.
+* Ensure that the ZIP draft has been sent to the Zcash Community Forum
+  and as a PR to the ZIPs git repository [#zips-repo]_.
+* Ensure that motivation and backward compatibility have been
+  addressed, if applicable.
+* Check that the licensing terms are acceptable for ZIPs.
 
 Reviewing a ZIP
 ---------------

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -20,9 +20,9 @@
 Terminology
 ===========
 
-The key words "MUST", "SHOULD", "SHOULD NOT", "MAY", "RECOMMENDED",
-"OPTIONAL", and "REQUIRED" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY",
+"RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to
+be interpreted as described in RFC 2119. [#RFC2119]_
 
 The term "network upgrade" in this document is to be interpreted as
 described in ZIP 200. [#zip-0200]_

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -597,6 +597,8 @@ ZIP Status Field
 
 * Implemented: When a Consensus or Standards ZIP has a working
   reference implementation but before activation on the Zcash network.
+  The status MAY indicate which node implementation has implemented
+  the ZIP, e.g. "Implemented (zcashd)" or "Implemented (zebra)".
 
 * Final: When a Consensus or Standards ZIP is both implemented
   and activated on the Zcash network.
@@ -609,7 +611,7 @@ More details on the status workflow are given in the section below.
 Specification
 -------------
 
-Owners of a ZIP may decide on their own to change the status between
+Owners of a ZIP MAY decide on their own to change the status between
 Draft or Withdrawn.
 
 A ZIP SHOULD only change status from Draft (or Rejected) to Proposed,

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -163,11 +163,14 @@ SHOULD be added to the ZIP metadata indicating the original authorship
 ZIP Editors
 -----------
 
-The current ZIP Editors are Daira Emma Hopwood and Jack Grigg (representing the Electric Coin
-Company), Deirdre Connolly, teor, and Conrado Gouvea, representing the Zcash Foundation. All
-can be reached at zips@z.cash. The current design of the ZIP Process
+The current ZIP Editors are:
+- Daira Emma Hopwood and Jack Grigg (representing the Electric Coin
+Company)
+- Deirdre Connolly, teor, and Conrado Gouvea (representing the Zcash Foundation). 
+
+All can be reached at zips@z.cash. The current design of the ZIP Process
 dictates that there are always at least two ZIP Editors: at least one from the
-Electric Coin Company and one from the Zcash Foundation. Additional Editors may
+Electric Coin Company and at least one from the Zcash Foundation. Additional Editors may
 be selected by consensus among the current Editors.
 
 

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -583,13 +583,14 @@ ZIP Status Field
 
 * Proposed: Typically the stage after Draft, added to a ZIP after
   consideration, feedback, and rough consensus from the community.
-  The Proposed status is approved by consensus among the current ZIP
-  Editors.
+  The Proposed status MUST be approved by consensus among the current
+  ZIP Editors.
 
-* Rejected: The status when progress hasn't been made on the ZIP in one
-  year. Can revert back to Draft/Proposed if the Owner resumes work
-  or resolves issues preventing consensus. The Rejected status is
-  approved by consensus among the current ZIP Editors.
+* Rejected: If no progress on a Draft or Proposed ZIP has been made for
+  one year, the ZIP Editors SHOULD move it to Rejected status. It can revert
+  back to Draft/Proposed if the Owner resumes work or resolves issues
+  preventing consensus. The Rejected status MUST be approved by
+  consensus among the current ZIP Editors.
 
 * Implemented: When a Consensus or Standards ZIP has a working
   reference implementation but before activation on the Zcash network.
@@ -608,14 +609,14 @@ Specification
 Owners of a ZIP may decide on their own to change the status between
 Draft or Withdrawn.
 
-A ZIP may only change status from Draft (or Rejected) to Proposed, when
-the Owner deems it is complete and there is rough consensus on the
+A ZIP SHOULD only change status from Draft (or Rejected) to Proposed,
+when the Owner deems it is complete and there is rough consensus on the
 forums, validated by consensus among the current ZIP Editors. If it's a
 Consensus ZIP, a Deployment section MUST be present in order for the ZIP
 to change status to Proposed. Typically, although not necessarily, this
 will specify a network upgrade in which the consensus change is to activate.
 
-A Standards ZIP may only change status from Proposed to Implemented once
+A Standards ZIP SHOULD only change status from Proposed to Implemented once
 the Owners provide an associated reference implementation, typically in
 the period after the network upgrade's specification freeze but before
 the implementation audit. If the Owners miss this deadline, the Editors

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -175,19 +175,22 @@ All can be reached at zips@z.cash. The current design of the ZIP Process
 dictates that there are always at least two ZIP Editors: at least one from the
 Electric Coin Company and at least one from the Zcash Foundation.
 
+ZIP Editors MUST declare any potential or perceived conflict of interest they have
+relating to their responsibilities as ZIP Editors.
+
 Additional Editors may be selected, with their consent, by consensus among the current Editors.
 An Editor may be removed or replaced by consensus among the current Editors.
 However, if the other ZIP Editors have consensus, an Editor can not prevent their own removal.
 Any Editor can resign by informing the other Editors in writing.
 
-Whenever the ZIP Editors change, the new ZIP Editors should:
+Whenever the ZIP Editors change, the new ZIP Editors SHOULD:
 - review this ZIP to make sure it reflects current practice,
 - update the owners of this ZIP,
 - review access to the `ZIPs repository <https://github.com/zcash/zips>`,
 - update the <zips@z.cash> email alias, and
 - invite new Editors to the Zcash Community Forums, and the #zips channel on Discord.
 
-If it has been at least 12 months since the last ZIP Editor change, the ZIP Editors should:
+If it has been at least 12 months since the last ZIP Editor change, the ZIP Editors SHOULD:
 - review this ZIP to make sure it reflects current practice.
 
 

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -249,8 +249,8 @@ When a ZIP is ready, the ZIP Editors will:
 The ZIP editors monitor ZIP changes and update ZIP headers as
 appropriate.
 
-Rejecting a proposed ZIP
-------------------------
+Rejecting a proposed ZIP or update
+----------------------------------
 
 The ZIP Editors MAY reject a proposed ZIP or update to an existing ZIP,
 by consensus among the current Editors. Rejections can be based on any
@@ -318,19 +318,20 @@ Guidelines <https://www.gnu.org/philosophy/kind-communication.en.html>`.__
 ZIP Editor Meeting Practices
 ----------------------------
 
-The ZIP Editors should meet on a regular basis to review draft changes to
-ZIPs. Meeting times are agreed by rough consensus among the current ZIP Editors.
+The ZIP Editors SHOULD meet on a regular basis to review draft changes to
+ZIPs. Meeting times are agreed by consensus among the current ZIP Editors.
 A ZIP Editor meeting can be held even if some ZIP Editors are not available, but
-all Editors should be informed of the decisions that will be made at upcoming
-meetings.
+all Editors SHOULD be informed of significant decisions that are likely to be made
+at upcoming meetings.
 
 The ZIP Editors will appoint a ZIP Secretary, which can be a shared or rotating
 role. The ZIP Secretary will:
-- share a draft agenda with the ZIP Editors at least 24 hours before each ZIP Editors meeting,
-- share draft minutes with the ZIP Editors in the week after the ZIP Editors meeting, and
+- share a draft agenda with the ZIP Editors at least 24 hours before each ZIP Editors' meeting;
+- share draft minutes of significant decisions with the ZIP Editors in the week after the
+  ZIP Editors' meeting; and
 - share significant ZIP changes on the Zcash Community Forums.
 
-If the draft agenda is empty, any ZIP Editor can submit agenda items, or suggest
+If the draft agenda is empty, any ZIP Editor MAY submit agenda items, or suggest
 that the meeting is cancelled.
 
 ZIP format and structure

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -220,16 +220,19 @@ Reviewing a ZIP
 ---------------
 
 Any ZIP Editor can suggest changes to a ZIP. These suggestions are the
-opinion of the individual ZIP Editor. ZIP Editors are expected to perform
-independent technical and process review, regardless of contractural or
-any other relationships.
+opinion of the individual ZIP Editor. Any technical or process review that
+ZIP Editors perform is expected to be independent of their contractual or
+other relationships.
 
-ZIP Owners can clarify, modify, or decline suggestions from ZIP Editors.
+ZIP Owners are free to clarify, modify, or decline suggestions from ZIP Editors.
+If the ZIP Editors make a change to a ZIP that the Owner disagrees with, then
+the Editors SHOULD revert the change.
+
 
 Typically, the ZIP Editors suggest changes in two phases:
 - `content review`: multiple ZIP Editors discuss the ZIP, and suggest
   changes to the overall content. This is a "big picture" review.
-- `format review`: one or two ZIP Editors do a detailed review of the
+- `format review`: two ZIP Editors do a detailed review of the
   structure and format of the ZIP. This ensures the ZIP is consistent
   with other Zcash specifications.
 
@@ -239,9 +242,9 @@ among the current Editors.
 
 When a ZIP is ready, the ZIP Editors will:
 
-* Assign a ZIP number in the pull request.
+* Ensure that a unique ZIP number has been assigned in the pull request.
 * Regenerate the corresponding HTML documents, if required.
-* Remove Draft status and merge the pull request when it is ready.
+* Remove Draft status and merge the pull request.
 
 The ZIP editors monitor ZIP changes and update ZIP headers as
 appropriate.

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -3,10 +3,13 @@
   ZIP: 0
   Title: ZIP Process
   Owners: Daira Emma Hopwood <daira@electriccoin.co>
-          Deirdre Connolly <deirdre@zfnd.org>
+          teor <teor@zfnd.org>
+          Jack Grigg <str4d@electriccoin.co>
+          Conrado Gouvea <conrado@zfnd.org>
   Original-Authors: Daira Emma Hopwood
                     Josh Cincinnati
                     George Tankersley
+                    Deirdre Connolly
   Credits: Luke Dashjr
   Status: Active
   Category: Process
@@ -166,51 +169,88 @@ ZIP Editors
 The current ZIP Editors are:
 - Daira Emma Hopwood and Jack Grigg (representing the Electric Coin
 Company)
-- Deirdre Connolly, teor, and Conrado Gouvea (representing the Zcash Foundation). 
+- teor and Conrado Gouvea (representing the Zcash Foundation).
 
 All can be reached at zips@z.cash. The current design of the ZIP Process
 dictates that there are always at least two ZIP Editors: at least one from the
-Electric Coin Company and at least one from the Zcash Foundation. Additional Editors may
-be selected by consensus among the current Editors.
+Electric Coin Company and at least one from the Zcash Foundation.
+
+Additional Editors may be selected by consensus among the current Editors.
+An Editor may be removed or replaced by consensus among the current Editors.
+However, if the other ZIP editors have consensus, an Editor can not prevent their own removal.
+Any Editor can resign by informing the other Editors in writing.
+
+Whenever the ZIP editors change, the new ZIP editors should:
+- review this ZIP to make sure it reflects current practice,
+- update the owners of this ZIP,
+- review ZIP editor access to the `ZIPs repository <https://github.com/zcash/zips>`,
+- update the <zips@z.cash> email alias, and
+- invite new editors to the Zcash Community Forums, and the #zips channel on Discord.
+
+If it has been at least 12 months since the last ZIP editor change, the ZIP editors should:
+- review this ZIP to make sure it reflects current practice.
 
 
-ZIP Editor Responsibilities & Workflow
---------------------------------------
+ZIP Editor Responsibilities
+---------------------------
 
 The ZIP Editors subscribe to the `Zcash Community Forum.
 <https://forum.zcashcommunity.com/>`__
 
-For each new ZIP that comes in, a ZIP Editor confirms the following:
+Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git
+repository [#zips-repo]_. It SHOULD NOT contain a ZIP number unless
+one had already been assigned by the ZIP Editors. The pull request
+SHOULD initially be marked as a Draft. The ZIP content SHOULD be
+submitted in RST format. Generating HTML for a ZIP is optional.
+
+For each new ZIP that comes in, the ZIP Editors will:
 
 * Read the ZIP to check if it is ready: sound and complete. The ideas
   must make technical sense, even if they don't seem likely to be
   accepted.
 * The title should accurately describe the content.
-* The ZIP draft must have been sent to the Zcash Community Forum or as
+* The ZIP draft must have been sent to the Zcash Community Forum and as
   a PR to the ZIPs git repository [#zips-repo]_.
 * Motivation and backward compatibility (when applicable) must be
   addressed.
 * The licensing terms are acceptable for ZIPs.
 
-If the ZIP isn't ready, the editor will send it back to the Owners for
-revision, with specific instructions.
+Reviewing a ZIP
+---------------
 
-Once the ZIP is ready for the repository it SHOULD be submitted as a
-"pull request" to the ZIPs git repository [#zips-repo]_ where it may
-get further feedback. It SHOULD NOT contain a ZIP number unless one
-had already been assigned by the ZIP Editors. The pull request SHOULD
-initially be marked as a Draft.
+Any ZIP Editor can suggest changes to a ZIP. These suggestions are the
+opinion of the individual ZIP Editor. ZIP Editors are expected to perform
+independent technical and process review, regardless of contractural or
+any other relationships.
 
-The ZIP Editors will:
+ZIP Owners can clarify, modify, or decline suggestions from ZIP Editors.
+
+Typically, the ZIP Editors suggest changes in two phases:
+- `content review`: multiple ZIP Editors discuss the ZIP, and suggest
+  changes to the overall content. This is a "big picture" review.
+- `format review`: one or two ZIP Editors do a detailed review of the
+  structure and format of the ZIP. This ensures the ZIP is consistent
+  with other Zcash specifications.
+
+If the ZIP isn't ready, the Editors will send it back to the Owners for
+revision, with specific instructions. This decision is made by consensus
+among the current Editors.
+
+When a ZIP is ready, the ZIP Editors will:
 
 * Assign a ZIP number in the pull request.
+* Regenerate the corresponding HTML documents, if required.
 * Remove Draft status and merge the pull request when it is ready.
 
 The ZIP editors monitor ZIP changes and update ZIP headers as
 appropriate.
 
-The ZIP Editors MAY reject a proposed ZIP or update to an existing ZIP
-for any of the following reasons:
+Rejecting a proposed ZIP
+------------------------
+
+The ZIP Editors MAY reject a proposed ZIP or update to an existing ZIP,
+by consensus among the current Editors. Rejections can be based on any
+of the following reasons:
 
 * it violates the Zcash Code of Conduct [#conduct]_ ;
 * it appears too unfocused or broad;
@@ -259,13 +299,35 @@ without an explanation.
 Note that it is not the primary responsibility of the ZIP Editors to
 review proposals for security, correctness, or implementability.
 
-Please send all ZIP-related communications either by email to
-<zips@z.cash>, or by opening an issue on the `ZIPs issue
-tracker <https://github.com/zcash/zips/issues>`__. All communications
-should abide by the Zcash Code of Conduct [#conduct]_
-and follow `the GNU Kind Communication
-Guidelines <https://www.gnu.org/philosophy/kind-communication.en.html>`__
+Communicating with the ZIP Editors
+----------------------------------
 
+Please send all ZIP-related communications either:
+- by email to <zips@z.cash>,
+- by opening an issue on the `ZIPs issue tracker <https://github.com/zcash/zips/issues>`, or
+- by sending a message in the `#zips channel on the Zcash R&D Discord <https://discord.com/channels/809218587167293450/809251050741170187>`.
+
+__All communications should abide by the Zcash Code of Conduct [#conduct]_
+and follow `the GNU Kind Communication
+Guidelines <https://www.gnu.org/philosophy/kind-communication.en.html>`.__
+
+ZIP Editor Meeting Practices
+----------------------------
+
+The ZIP Editors should meet on a regular basis to review draft changes to
+ZIPs. Meeting times are agreed by rough consensus among the current ZIP Editors.
+A ZIP Editor meeting can be held even if some ZIP Editors are not available, but
+all Editors should be informed of the decisions that will be made at upcoming
+meetings.
+
+The ZIP Editors will appoint a ZIP Secretary, which can be a shared or rotating
+role. The ZIP Secretary will:
+- share a draft agenda with the ZIP Editors at least 24 hours before each ZIP Editors meeting,
+- share draft minutes with the ZIP Editors in the week after the ZIP Editors meeting, and
+- share significant ZIP changes on the Zcash Community Forums.
+
+If the draft agenda is empty, any ZIP Editor can submit agenda items, or suggest
+that the meeting is cancelled.
 
 ZIP format and structure
 ========================
@@ -515,12 +577,14 @@ ZIP Status Field
   once rough consensus is reached in PR/forum posts from Draft Process ZIP.
 
 * Proposed: Typically the stage after Draft, added to a ZIP after
-  consideration, feedback, and rough consensus from the community. The ZIP
-  Editors must validate this change before it is approved.
+  consideration, feedback, and rough consensus from the community.
+  The Proposed status is approved by consensus among the current ZIP
+  Editors.
 
 * Rejected: The status when progress hasn't been made on the ZIP in one
   year. Can revert back to Draft/Proposed if the Owner resumes work
-  or resolves issues preventing consensus.
+  or resolves issues preventing consensus. The Rejected status is
+  approved by consensus among the current ZIP Editors.
 
 * Implemented: When a Consensus or Standards ZIP has a working
   reference implementation but before activation on the Zcash network.
@@ -541,12 +605,10 @@ Draft or Withdrawn.
 
 A ZIP may only change status from Draft (or Rejected) to Proposed, when
 the Owner deems it is complete and there is rough consensus on the
-forums, validated by both the Electric Coin Company and Zcash Foundation
-Editors. One Editor will not suffice — there needs to be consensus
-among the Editors. If it's a Consensus ZIP, a Deployment section MUST
-be present in order for the ZIP to change status to Proposed. Typically,
-although not necessarily, this will specify a network upgrade in which
-the consensus change is to activate.
+forums, validated by consensus among the current ZIP Editors. If it's a
+Consensus ZIP, a Deployment section MUST be present in order for the ZIP
+to change status to Proposed. Typically, although not necessarily, this
+will specify a network upgrade in which the consensus change is to activate.
 
 A Standards ZIP may only change status from Proposed to Implemented once
 the Owners provide an associated reference implementation, typically in
@@ -560,7 +622,8 @@ status, upon request by any person, if they have not made progress in
 one year. Such a ZIP may be changed to Draft status if the Owner
 provides revisions that meaningfully address public criticism of the
 proposal, or to Proposed status if it meets the criteria required as
-described in the previous paragraphs.
+described in the previous paragraphs. Rejections are applied by consensus
+among the current ZIP Editors.
 
 A Consensus or Standards ZIP becomes Final when its associated network
 upgrade or other protocol change is activated on Zcash's mainnet.

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -167,9 +167,10 @@ ZIP Editors
 -----------
 
 The current ZIP Editors are:
-- Daira Emma Hopwood and Jack Grigg, associated with the Electric Coin
-Company;
-- teor and Conrado Gouvea, associated with the Zcash Foundation.
+
+* Daira Emma Hopwood and Jack Grigg, associated with the Electric Coin
+  Company;
+* teor and Conrado Gouvea, associated with the Zcash Foundation.
 
 All can be reached at zips@z.cash. The current design of the ZIP Process
 dictates that there are always at least two ZIP Editors: at least one from the
@@ -233,9 +234,10 @@ the Editors SHOULD revert the change.
 
 
 Typically, the ZIP Editors suggest changes in two phases:
-- `content review`: multiple ZIP Editors discuss the ZIP, and suggest
+
+* `content review`: multiple ZIP Editors discuss the ZIP, and suggest
   changes to the overall content. This is a "big picture" review.
-- `format review`: two ZIP Editors do a detailed review of the
+* `format review`: two ZIP Editors do a detailed review of the
   structure and format of the ZIP. This ensures the ZIP is consistent
   with other Zcash specifications.
 
@@ -310,9 +312,10 @@ Communicating with the ZIP Editors
 ----------------------------------
 
 Please send all ZIP-related communications either:
-- by email to <zips@z.cash>,
-- by opening an issue on the `ZIPs issue tracker <https://github.com/zcash/zips/issues>`, or
-- by sending a message in the `#zips channel on the Zcash R&D Discord <https://discord.com/channels/809218587167293450/809251050741170187>`.
+
+* by email to <zips@z.cash>,
+* by opening an issue on the `ZIPs issue tracker <https://github.com/zcash/zips/issues>`, or
+* by sending a message in the `#zips channel on the Zcash R&D Discord <https://discord.com/channels/809218587167293450/809251050741170187>`.
 
 __All communications should abide by the Zcash Code of Conduct [#conduct]_
 and follow `the GNU Kind Communication
@@ -329,10 +332,11 @@ at upcoming meetings.
 
 The ZIP Editors will appoint a ZIP Secretary, which can be a shared or rotating
 role. The ZIP Secretary will:
-- share a draft agenda with the ZIP Editors at least 24 hours before each ZIP Editors' meeting;
-- share draft minutes of significant decisions with the ZIP Editors in the week after the
+
+* share a draft agenda with the ZIP Editors at least 24 hours before each ZIP Editors' meeting;
+* share draft minutes of significant decisions with the ZIP Editors in the week after the
   ZIP Editors' meeting; and
-- share significant ZIP changes on the Zcash Community Forums.
+* share significant ZIP changes on the Zcash Community Forums.
 
 If the draft agenda is empty, any ZIP Editor MAY submit agenda items, or suggest
 that the meeting is cancelled.

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -469,8 +469,8 @@ The following additional header fields are OPTIONAL for ZIPs::
   Original-Authors:
   Discussions-To:
   Pull-Request:
-  Obsoleted by:
-  Updated by:
+  Obsoleted-By:
+  Updated-By:
   Obsoletes:
   Updates:
 
@@ -639,7 +639,7 @@ When an Active or Final ZIP is no longer relevant, its status SHOULD be
 changed to Obsolete. This change MUST also be objectively verifiable
 and/or discussed. Final ZIPs MAY be updated; the specification is still
 in force but modified by another specified ZIP or ZIPs (check the
-optional Updated-by header).
+optional Updated-By header).
 
 
 ZIP Comments

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -606,10 +606,8 @@ ZIP Status Field
 * Obsolete: The status when a ZIP is no longer relevant (typically when
   superseded by another ZIP).
 
-More details on the status workflow are given in the section below.
-
-Specification
--------------
+Specification of Status Workflow
+--------------------------------
 
 Owners of a ZIP MAY decide on their own to change the status between
 Draft or Withdrawn.
@@ -628,29 +626,18 @@ the implementation audit. If the Owners miss this deadline, the Editors
 or Owners MAY choose to update the Deployment section of the ZIP to
 target another upgrade, at their discretion.
 
-ZIPs should be changed from Draft or Proposed status, to Rejected
-status, upon request by any person, if they have not made progress in
-one year. Such a ZIP may be changed to Draft status if the Owner
-provides revisions that meaningfully address public criticism of the
-proposal, or to Proposed status if it meets the criteria required as
-described in the previous paragraphs. Rejections are applied by consensus
-among the current ZIP Editors.
-
-A Consensus or Standards ZIP becomes Final when its associated network
-upgrade or other protocol change is activated on Zcash's mainnet.
-
-A Process or Informational ZIP may change status from Draft to Active
+A Process or Informational ZIP SHOULD change status from Draft to Active
 when it achieves rough consensus on the forum or PR. Such a proposal is
 said to have rough consensus if it has been open to discussion on the
 forum or GitHub PR for at least one month, and no person maintains
 any unaddressed substantiated objections to it. Addressed or obstructive
-objections may be ignored/overruled by general agreement that they have
-been sufficiently addressed, but clear reasoning must be given in such
+objections can be ignored/overruled by general agreement that they have
+been sufficiently addressed, but clear reasoning MUST be given in such
 circumstances.
 
-When an Active or Final ZIP is no longer relevant, its status may be
-changed to Obsolete. This change must also be objectively verifiable
-and/or discussed. Final ZIPs may be updated; the specification is still
+When an Active or Final ZIP is no longer relevant, its status SHOULD be
+changed to Obsolete. This change MUST also be objectively verifiable
+and/or discussed. Final ZIPs MAY be updated; the specification is still
 in force but modified by another specified ZIP or ZIPs (check the
 optional Updated-by header).
 
@@ -738,7 +725,7 @@ Not acceptable licenses
 -----------------------
 
 All licenses not explicitly included in the above lists are not
-acceptable terms for a Zcash Improvement Proposal.
+acceptable terms and MUST NOT be used for a Zcash Improvement Proposal.
 
 Rationale
 ---------


### PR DESCRIPTION
### Summary

This PR appoints multiple ZIP editors, and modifies the decision-making process for multiple editors. It also improves the ZIP review process, and updates ZIP processes to reflect current practice.

### Detailed Changes

ZIP Editor changes:
- Adds str4d, teor, and Conrado as ZIP editors;
- Removes Deirdre as a ZIP editor;
- Ensures that ZIP editors declare potential or perceived conflicts of interest;
- Clarifies how editors are added, removed, or resign;
- Lists actions that should be taken when editors change;
- List processes that should be reviewed on an ongoing basis;
- Updates how ZIP editors can be contacted.

Decision-making changes:
- Clarifies that ZIP editor consensus is required for significant ZIP changes;
- Documents the current ZIP meeting process;
- Adds a ZIP Secretary role for agendas, minutes, and posting significant decisions to the forums.

ZIP process changes:
- Splits big-picture content review from detailed format review;
- Clarifies that ZIP editor suggestions are individual opinions, which should be independent of employment or other relationships;
- Clarifies that ZIP owners can reject suggestions;
- Documents that draft ZIPs should be submitted to the forums and the git repository;
- Documents that HTML updates are the responsibility of ZIP editors, not ZIP owners;
- Clarifies conformance wording in a number of places and removes redundancies;
- Fixes inconsistent spelling of the `Obsoleted-By` and `Updated-By` headers.