### PR TITLE
Fix typo in protocol.tex.

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -2982,7 +2982,7 @@ $\PaymentAddress = (\AuthPublic, \TransmitPublic)$ are derived from the
 \saplingonward{
 \defining{An \expandedSpendingKey is composed of a \authSigningKey $\AuthSignPrivate$,
 a \authNullifierKey $\AuthProvePrivate$, and an \outgoingViewingKey $\OutViewingKey$.
-From these components we can derive an \authProvingKey $(\AuthSignPublic, \AuthProvePrivate)$,
+From these components we can derive a \authProvingKey $(\AuthSignPublic, \AuthProvePrivate)$,
 a \fullViewingKey $(\AuthSignPublic, \NullifierKey, \OutViewingKey)$,
 an \incomingViewingKey $\InViewingKey$, and a set of \diversifiedPaymentAddresses
 $\DiversifiedPaymentAddress = (\Diversifier, \DiversifiedTransmitPublic)$,


### PR DESCRIPTION
`\authProvingKey` expands to 'proof authorizing key', so the article must be 'a' instead of 'an'.