### PR TITLE
Add repo files to help maintain conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome:http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.sh]
+indent_size = 4
+
+[*.json]
+indent_size = 2
+
+[*.css]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto
+
+# Ensure shell scripts use LF line endings (linux only accepts LF)
+*.sh eol=lf
+*.ps1 eol=lf


### PR DESCRIPTION
- `.editorconfig` helps maintain whitespace rules and other things. For now, I'm just setting indenting and trailing whitespace rules.
- `.gitattributes` sets checked in line ending rules. Without this file. each git client follows the rules configured by the machine that installed it. This can lead to large walls of diffs in PRs where nothing but the line endings changed. But with this file, we can constrain git in all installations to follow the line ending policies of this repo. Those policies, as I've been able to detect, are to check in LF line endings exclusively. This file ensures that policy continues to be consistently respected.