### PR TITLE
ZIP 313: Obsoleted by ZIP 317

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,7 +129,7 @@ Index of ZIPs
     <tr> <td>310</td> <td class="left"><a href="zip-0310.rst">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311.rst">Sapling Payment Disclosure</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312.rst">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
-    <tr> <td>313</td> <td class="left"><a href="zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></td> <td>Active</td>
+    <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
     <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">315</span></td> <td class="left"><a class="reserved" href="zip-0315.rst">Best Practices for Wallet Handling of Multiple Pools</a></td> <td>Reserved</td>
     <tr> <td>316</td> <td class="left"><a href="zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>Final</td>

--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,29 @@
   #index-of-zips table tr:hover {
     background-color: #eff1f2;
   }
+  aside.note {
+    background-color: #a0a0ff;
+    color: #111519;
+  }
+  aside.note::before {
+    background-color: #5858ff;
+    color: #000000;
+  }
+  aside.warning {
+    background-color: #ffb090;
+    color: #111519;
+    font-weight: 500;
+  }
+  aside.warning::before {
+    background-color: #ff7050;
+    font-weight: 600;
+  }
+  aside > p > a, a:visited {
+    color: #0077a1;
+  }
+  aside > p > a:hover {
+    color: #00455c;
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -46,6 +69,57 @@
   #index-of-zips table tr:hover {
     background-color: #303030;
   }
+  aside.note {
+    background-color: #6060e0;
+    color: #ffffff;
+  }
+  aside.note::before {
+    background-color: #3030e0;
+  }
+  aside.warning {
+    background-color: #e08060;
+    color: #ffffff;
+    font-weight: 700;
+  }
+  aside.warning::before {
+    background-color: #e05030;
+    font-weight: 800;
+  }
+  aside > p > a, a:visited {
+    color: #50e7f4;
+  }
+  aside > p > a:hover {
+    color: #90ffff;
+  }
+}
+
+aside {
+  display: flex;
+  flex-direction: column;
+  gap: 1em;
+  padding-top: 0.15rem;
+  padding-left: 0.15rem;
+  padding-right: 0.15rem;
+  padding-bottom: 0;
+  margin-bottom: 1.5rem;
+}
+aside::before {
+  font-size: 130%;
+  padding-top: 0.2rem;
+  padding-left: 1rem;
+  padding-right: 0.2rem;
+  padding-bottom: 0.3rem;
+  margin-bottom: 1.2rem;
+}
+aside.note::before {
+  content: "Note";
+}
+aside.warning::before {
+  content: "Warning";
+}
+aside > p {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 @font-face {

--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
   <tr> <td>310</td> <td class="left"><a href="zip-0310">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311">Sapling Payment Disclosure</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
-  <tr> <td>313</td> <td class="left"><a href="zip-0313">Reduce Conventional Transaction Fee to 1000 zatoshis</a></td> <td>Active</td>
+  <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zip-0313">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
   <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">315</span></td> <td class="left"><a class="reserved" href="zip-0315">Best Practices for Wallet Handling of Multiple Pools</a></td> <td>Reserved</td>
   <tr> <td>316</td> <td class="left"><a href="zip-0316">Unified Addresses and Unified Viewing Keys</a></td> <td>Final</td>

--- a/zip-0313.html
+++ b/zip-0313.html
@@ -20,13 +20,14 @@ License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566">https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://github.com/zcash/zips/pull/408</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The key words "SHOULD" and "RECOMMENDED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
             <p>The term "conventional transaction fee" in this document is in reference to the value of a transaction fee that is conventionally used by wallets, and that a user can reasonably expect miners on the Zcash network to accept for including a transaction in a block.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The goal of this ZIP is to gather wallet developers, miners &amp; Zcash users for social consensus on reducing the conventional transaction fees and to get the Zcash conventional transaction fee reduced from 10,000 zatoshis to 1,000 zatoshis.</p>
-            <p>In addition, this specification harmonizes transaction fees between different kinds of transaction (involving shielded addresses, transparent addresses, or both), as proposed in <a id="footnote-reference-1" class="footnote_reference" href="#zcash-2942">6</a>.</p>
+            <p>In addition, this specification harmonizes transaction fees between different kinds of transaction (involving shielded addresses, transparent addresses, or both), as proposed in <a id="footnote-reference-2" class="footnote_reference" href="#zcash-2942">7</a>.</p>
             <aside class="warning">
-                <p>This ZIP has been obsoleted by ZIP 317 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0317">8</a>. In particular, transactions using the 1,000-zatoshi fee specified in this ZIP will be treated as having no "paid actions", and therefore will be deprioritized by the block construction algorithm in ZIP 317. If they have more than 50 logical actions, they will never be mined by that algorithm, and so will not appear in block templates created by <cite>zcashd</cite> or <cite>zebrad</cite> with the default parameters. They will also incur the low fee penalty specified in ZIP 401 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0401">9</a>, which will make them more likely to be evicted from the mempool without being mined.</p>
+                <p>This ZIP has been obsoleted by ZIP 317 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0317">9</a>. In particular, transactions using the 1,000-zatoshi fee specified in this ZIP will be treated as having no "paid actions", and therefore will be deprioritized by the RECOMMENDED block template construction algorithm in ZIP 317. If they have more than 50 logical actions, they will never be included by that algorithm, and so will not appear in block templates created by <cite>zcashd</cite> or <cite>zebrad</cite> with the default parameters. They will also incur the low fee penalty specified in ZIP 401 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0401">10</a>, which will make them more likely to be evicted from the mempool without being mined.</p>
                 <p>Wallets SHOULD move to using ZIP 317 fees with all due haste.</p>
             </aside>
         </section>
@@ -48,8 +49,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             </section>
             <section id="security-and-privacy-considerations"><h3><span class="section-heading">Security and privacy considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Unique transaction fees may reveal specific users or wallets or wallet versions, which would reduce privacy for those specific users and the rest of the network. Hence this change should be accepted by a majority of shielded transaction software providers before deploying the change.</p>
-                <p>Varying/unique fees are bad for privacy. For the short term before blocks get full, it is fine for everyone to use a constant fee, as long as it is enough to compensate miners for including the transaction. <a id="footnote-reference-4" class="footnote_reference" href="#nathan-1">1</a></p>
-                <p>Long term, the issue of fees needs to be re-visited in separate future proposals as the blocks start getting consistently full. New ZIPs with flexible fees, such as <a id="footnote-reference-5" class="footnote_reference" href="#ian-1">2</a>, along with scaling solutions, will need to be evaluated and applied.</p>
+                <p>Varying/unique fees are bad for privacy. For the short term before blocks get full, it is fine for everyone to use a constant fee, as long as it is enough to compensate miners for including the transaction. <a id="footnote-reference-5" class="footnote_reference" href="#nathan-1">2</a></p>
+                <p>Long term, the issue of fees needs to be re-visited in separate future proposals as the blocks start getting consistently full. New ZIPs with flexible fees, such as <a id="footnote-reference-6" class="footnote_reference" href="#ian-1">3</a>, along with scaling solutions, will need to be evaluated and applied.</p>
                 <section id="denial-of-service-vulnerability"><h4><span class="section-heading">Denial of Service Vulnerability</span><span class="section-anchor"> <a rel="bookmark" href="#denial-of-service-vulnerability"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>A transaction-rate-based denial of service attack occurs when an attacker generates enough transactions over a window of time to prevent legitimate transactions from being mined, or to hinder syncing blocks for full nodes or miners.</p>
                     <p>There are two primary protections to this kind of attack in Zcash: the block size limit, and transaction fees. The block size limit ensures that full nodes and miners can keep up with the block chain even if blocks are completely full. However, users sending legitimate transactions may not have their transactions confirmed in a timely manner.</p>
@@ -63,10 +64,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <p>Wallets implementing this specification will use a default fee of 0.00001 ZEC (1000 zatoshis) from block 1,080,000, for all transactions.</p>
             <section id="transaction-relaying"><h3><span class="section-heading">Transaction relaying</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-relaying"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>zcashd, and potentially other node implementations, implements fee-based restrictions on relaying of mempool transactions. Nodes that normally relay transactions are expected to do so for transactions that pay at least the conventional fee, unless there are other reasons not to do so for robustness or denial-of-service mitigation.</p>
-                <p>In zcashd 4.2.0, this change is implemented by <a id="footnote-reference-6" class="footnote_reference" href="#zcash-relaying">7</a>.</p>
+                <p>In zcashd 4.2.0, this change is implemented by <a id="footnote-reference-7" class="footnote_reference" href="#zcash-relaying">8</a>.</p>
             </section>
             <section id="mempool-size-limiting"><h3><span class="section-heading">Mempool size limiting</span><span class="section-anchor"> <a rel="bookmark" href="#mempool-size-limiting"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>zcashd limits the size of the mempool as described in <a id="footnote-reference-7" class="footnote_reference" href="#zip-0401">9</a>. This specifies a <em>low_fee_penalty</em> that is added to the "eviction weight" if the transaction pays a fee less than (in the original ZIP) 10,000 zatoshis. This threshold is modified to match the new conventional fee in zcashd 4.2.0.</p>
+                <p>zcashd limits the size of the mempool as described in <a id="footnote-reference-8" class="footnote_reference" href="#zip-0401">10</a>. This specifies a <em>low_fee_penalty</em> that is added to the "eviction weight" if the transaction pays a fee less than (in the original ZIP) 10,000 zatoshis. This threshold is modified to match the new conventional fee in zcashd 4.2.0.</p>
             </section>
         </section>
         <section id="support"><h2><span class="section-heading">Support</span><span class="section-anchor"> <a rel="bookmark" href="#support"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -75,18 +76,26 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
                 <li>Zbay;</li>
                 <li>Zecwallet Suite (Zecwallet Lite for Desktop/iOS/Android &amp; Zecwallet FullNode);</li>
                 <li>Nighthawk Wallet for Android &amp; iOS;</li>
-                <li>zcashd built-in wallet <a id="footnote-reference-8" class="footnote_reference" href="#zcash-4916">5</a>.</li>
+                <li>zcashd built-in wallet <a id="footnote-reference-9" class="footnote_reference" href="#zcash-4916">6</a>.</li>
             </ul>
-            <p>In zcashd this fee change is implemented in version 4.2.0 (not dependent on block height), and in that version is limited to transactions created using <cite>z_*</cite> RPC APIs. It is planned to extend this to all transactions in a future version <a id="footnote-reference-9" class="footnote_reference" href="#zcash-2942">6</a>.</p>
+            <p>In zcashd this fee change is implemented in version 4.2.0 (not dependent on block height), and in that version is limited to transactions created using <cite>z_*</cite> RPC APIs. It is planned to extend this to all transactions in a future version <a id="footnote-reference-10" class="footnote_reference" href="#zcash-2942">7</a>.</p>
         </section>
         <section id="acknowledgements"><h2><span class="section-heading">Acknowledgements</span><span class="section-anchor"> <a rel="bookmark" href="#acknowledgements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Thanks to Nathan Wilcox for suggesting improvements to the denial of service section. Thanks to Daira Emma Hopwood and Deirdre Connolly for reviewing and fixing the wording in this ZIP.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="nathan-1" class="footnote">
+            <table id="rfc2119" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
+                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="nathan-1" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>2</th>
                         <td><a href="https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566/40">Conventional Shielded Fees</a></td>
                     </tr>
                 </tbody>
@@ -94,7 +103,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="ian-1" class="footnote">
                 <tbody>
                     <tr>
-                        <th>2</th>
+                        <th>3</th>
                         <td><a href="https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566/31">Ian Miers. Mechanism for fee suggester/oracle</a></td>
                     </tr>
                 </tbody>
@@ -102,7 +111,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zooko-1" class="footnote">
                 <tbody>
                     <tr>
-                        <th>3</th>
+                        <th>4</th>
                         <td><a href="https://twitter.com/zooko/status/1295032258282156034?s=20">Zooko Wilcox. Tweet on reducing tx fees</a></td>
                     </tr>
                 </tbody>
@@ -110,7 +119,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zooko-2" class="footnote">
                 <tbody>
                     <tr>
-                        <th>4</th>
+                        <th>5</th>
                         <td><a href="https://twitter.com/zooko/status/1295032621294956545?s=20">Zooko Wilcox. Tweet on sharing tx fee with wallet developer</a></td>
                     </tr>
                 </tbody>
@@ -118,7 +127,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zcash-4916" class="footnote">
                 <tbody>
                     <tr>
-                        <th>5</th>
+                        <th>6</th>
                         <td><a href="https://github.com/zcash/zcash/pull/4916">Reduce default fee to 1000 zatoshis</a></td>
                     </tr>
                 </tbody>
@@ -126,7 +135,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zcash-2942" class="footnote">
                 <tbody>
                     <tr>
-                        <th>6</th>
+                        <th>7</th>
                         <td><a href="https://github.com/zcash/zcash/pull/2942">Ecosystem-wide standard transaction fee</a></td>
                     </tr>
                 </tbody>
@@ -134,7 +143,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zcash-relaying" class="footnote">
                 <tbody>
                     <tr>
-                        <th>7</th>
+                        <th>8</th>
                         <td><a href="https://github.com/zcash/zcash/pull/4916/commits/e6a44ff833bce280a30115d10ef0070ad4d52b38">zcashd commit e6a44ff: Always allow transactions paying at least DEFAULT_FEE to be relayed</a></td>
                     </tr>
                 </tbody>
@@ -142,7 +151,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zip-0317" class="footnote">
                 <tbody>
                     <tr>
-                        <th>8</th>
+                        <th>9</th>
                         <td><a href="zip-0317">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
                     </tr>
                 </tbody>
@@ -150,7 +159,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <table id="zip-0401" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
+                        <th>10</th>
                         <td><a href="zip-0401">ZIP 401: Addressing Mempool Denial-of-Service</a></td>
                     </tr>
                 </tbody>

--- a/zip-0313.html
+++ b/zip-0313.html
@@ -12,7 +12,8 @@ Owners: Aditya Bharadwaj &lt;nighthawkwallet@protonmail.com&gt;
 Credits: Daira Emma Hopwood
          Deirdre Connolly
          Nathan Wilcox
-Status: Active
+Status: Obsolete
+Obsoleted-By: 317
 Category: Wallet
 Created: 2020-10-11
 License: MIT
@@ -24,6 +25,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The goal of this ZIP is to gather wallet developers, miners &amp; Zcash users for social consensus on reducing the conventional transaction fees and to get the Zcash conventional transaction fee reduced from 10,000 zatoshis to 1,000 zatoshis.</p>
             <p>In addition, this specification harmonizes transaction fees between different kinds of transaction (involving shielded addresses, transparent addresses, or both), as proposed in <a id="footnote-reference-1" class="footnote_reference" href="#zcash-2942">6</a>.</p>
+            <aside class="warning">
+                <p>This ZIP has been obsoleted by ZIP 317 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0317">8</a>. In particular, transactions using the 1,000-zatoshi fee specified in this ZIP will be treated as having no "paid actions", and therefore will be deprioritized by the block construction algorithm in ZIP 317. If they have more than 50 logical actions, they will never be mined by that algorithm, and so will not appear in block templates created by <cite>zcashd</cite> or <cite>zebrad</cite> with the default parameters. They will also incur the low fee penalty specified in ZIP 401 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0401">9</a>, which will make them more likely to be evicted from the mempool without being mined.</p>
+                <p>Wallets SHOULD move to using ZIP 317 fees with all due haste.</p>
+            </aside>
         </section>
         <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The conventional transaction fee presently is 0.0001 ZEC or 10,000 zatoshis. At a ZEC market price of USD 100, for example, a user can send 10,000 transactions for 1 ZEC. This works out to 1 U.S. cent per transaction and it rises with any increase in the price of ZEC.</p>
@@ -43,8 +48,8 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             </section>
             <section id="security-and-privacy-considerations"><h3><span class="section-heading">Security and privacy considerations</span><span class="section-anchor"> <a rel="bookmark" href="#security-and-privacy-considerations"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Unique transaction fees may reveal specific users or wallets or wallet versions, which would reduce privacy for those specific users and the rest of the network. Hence this change should be accepted by a majority of shielded transaction software providers before deploying the change.</p>
-                <p>Varying/unique fees are bad for privacy. For the short term before blocks get full, it is fine for everyone to use a constant fee, as long as it is enough to compensate miners for including the transaction. <a id="footnote-reference-2" class="footnote_reference" href="#nathan-1">1</a></p>
-                <p>Long term, the issue of fees needs to be re-visited in separate future proposals as the blocks start getting consistently full. New ZIPs with flexible fees, such as <a id="footnote-reference-3" class="footnote_reference" href="#ian-1">2</a>, along with scaling solutions, will need to be evaluated and applied.</p>
+                <p>Varying/unique fees are bad for privacy. For the short term before blocks get full, it is fine for everyone to use a constant fee, as long as it is enough to compensate miners for including the transaction. <a id="footnote-reference-4" class="footnote_reference" href="#nathan-1">1</a></p>
+                <p>Long term, the issue of fees needs to be re-visited in separate future proposals as the blocks start getting consistently full. New ZIPs with flexible fees, such as <a id="footnote-reference-5" class="footnote_reference" href="#ian-1">2</a>, along with scaling solutions, will need to be evaluated and applied.</p>
                 <section id="denial-of-service-vulnerability"><h4><span class="section-heading">Denial of Service Vulnerability</span><span class="section-anchor"> <a rel="bookmark" href="#denial-of-service-vulnerability"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
                     <p>A transaction-rate-based denial of service attack occurs when an attacker generates enough transactions over a window of time to prevent legitimate transactions from being mined, or to hinder syncing blocks for full nodes or miners.</p>
                     <p>There are two primary protections to this kind of attack in Zcash: the block size limit, and transaction fees. The block size limit ensures that full nodes and miners can keep up with the block chain even if blocks are completely full. However, users sending legitimate transactions may not have their transactions confirmed in a timely manner.</p>
@@ -58,10 +63,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <p>Wallets implementing this specification will use a default fee of 0.00001 ZEC (1000 zatoshis) from block 1,080,000, for all transactions.</p>
             <section id="transaction-relaying"><h3><span class="section-heading">Transaction relaying</span><span class="section-anchor"> <a rel="bookmark" href="#transaction-relaying"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>zcashd, and potentially other node implementations, implements fee-based restrictions on relaying of mempool transactions. Nodes that normally relay transactions are expected to do so for transactions that pay at least the conventional fee, unless there are other reasons not to do so for robustness or denial-of-service mitigation.</p>
-                <p>In zcashd 4.2.0, this change is implemented by <a id="footnote-reference-4" class="footnote_reference" href="#zcash-relaying">7</a>.</p>
+                <p>In zcashd 4.2.0, this change is implemented by <a id="footnote-reference-6" class="footnote_reference" href="#zcash-relaying">7</a>.</p>
             </section>
             <section id="mempool-size-limiting"><h3><span class="section-heading">Mempool size limiting</span><span class="section-anchor"> <a rel="bookmark" href="#mempool-size-limiting"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>zcashd limits the size of the mempool as described in <a id="footnote-reference-5" class="footnote_reference" href="#zip-0401">8</a>. This specifies a <em>low_fee_penalty</em> that is added to the "eviction weight" if the transaction pays a fee less than (in the original ZIP) 10,000 zatoshis. This threshold is modified to match the new conventional fee in zcashd 4.2.0.</p>
+                <p>zcashd limits the size of the mempool as described in <a id="footnote-reference-7" class="footnote_reference" href="#zip-0401">9</a>. This specifies a <em>low_fee_penalty</em> that is added to the "eviction weight" if the transaction pays a fee less than (in the original ZIP) 10,000 zatoshis. This threshold is modified to match the new conventional fee in zcashd 4.2.0.</p>
             </section>
         </section>
         <section id="support"><h2><span class="section-heading">Support</span><span class="section-anchor"> <a rel="bookmark" href="#support"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -70,9 +75,9 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
                 <li>Zbay;</li>
                 <li>Zecwallet Suite (Zecwallet Lite for Desktop/iOS/Android &amp; Zecwallet FullNode);</li>
                 <li>Nighthawk Wallet for Android &amp; iOS;</li>
-                <li>zcashd built-in wallet <a id="footnote-reference-6" class="footnote_reference" href="#zcash-4916">5</a>.</li>
+                <li>zcashd built-in wallet <a id="footnote-reference-8" class="footnote_reference" href="#zcash-4916">5</a>.</li>
             </ul>
-            <p>In zcashd this fee change is implemented in version 4.2.0 (not dependent on block height), and in that version is limited to transactions created using <cite>z_*</cite> RPC APIs. It is planned to extend this to all transactions in a future version <a id="footnote-reference-7" class="footnote_reference" href="#zcash-2942">6</a>.</p>
+            <p>In zcashd this fee change is implemented in version 4.2.0 (not dependent on block height), and in that version is limited to transactions created using <cite>z_*</cite> RPC APIs. It is planned to extend this to all transactions in a future version <a id="footnote-reference-9" class="footnote_reference" href="#zcash-2942">6</a>.</p>
         </section>
         <section id="acknowledgements"><h2><span class="section-heading">Acknowledgements</span><span class="section-anchor"> <a rel="bookmark" href="#acknowledgements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Thanks to Nathan Wilcox for suggesting improvements to the denial of service section. Thanks to Daira Emma Hopwood and Deirdre Connolly for reviewing and fixing the wording in this ZIP.</p>
@@ -134,10 +139,18 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0401" class="footnote">
+            <table id="zip-0317" class="footnote">
                 <tbody>
                     <tr>
                         <th>8</th>
+                        <td><a href="zip-0317">ZIP 317: Proportional Transfer Fee Mechanism</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0401" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>9</th>
                         <td><a href="zip-0401">ZIP 401: Addressing Mempool Denial-of-Service</a></td>
                     </tr>
                 </tbody>

--- a/zip-0313.rst
+++ b/zip-0313.rst
@@ -6,7 +6,8 @@
   Credits: Daira Emma Hopwood
            Deirdre Connolly
            Nathan Wilcox
-  Status: Active
+  Status: Obsolete
+  Obsoleted-By: 317
   Category: Wallet
   Created: 2020-10-11
   License: MIT
@@ -34,6 +35,19 @@ to 1,000 zatoshis.
 In addition, this specification harmonizes transaction fees between different
 kinds of transaction (involving shielded addresses, transparent addresses, or
 both), as proposed in [#zcash-2942]_.
+
+.. warning::
+    This ZIP has been obsoleted by ZIP 317 [#zip-0317]_. In particular,
+    transactions using the 1,000-zatoshi fee specified in this ZIP will be
+    treated as having no "paid actions", and therefore will be deprioritized
+    by the block construction algorithm in ZIP 317. If they have more than
+    50 logical actions, they will never be mined by that algorithm, and so
+    will not appear in block templates created by `zcashd` or `zebrad` with
+    the default parameters. They will also incur the low fee penalty
+    specified in ZIP 401 [#zip-0401]_, which will make them more likely to
+    be evicted from the mempool without being mined.
+
+    Wallets SHOULD move to using ZIP 317 fees with all due haste.
 
 
 Motivation
@@ -195,4 +209,5 @@ References
 .. [#zcash-4916] `Reduce default fee to 1000 zatoshis <https://github.com/zcash/zcash/pull/4916>`_
 .. [#zcash-2942] `Ecosystem-wide standard transaction fee <https://github.com/zcash/zcash/pull/2942>`_
 .. [#zcash-relaying] `zcashd commit e6a44ff: Always allow transactions paying at least DEFAULT_FEE to be relayed <https://github.com/zcash/zcash/pull/4916/commits/e6a44ff833bce280a30115d10ef0070ad4d52b38>`_
+.. [#zip-0317] `ZIP 317: Proportional Transfer Fee Mechanism <zip-0317.rst>`_
 .. [#zip-0401] `ZIP 401: Addressing Mempool Denial-of-Service <zip-0401.rst>`_

--- a/zip-0313.rst
+++ b/zip-0313.rst
@@ -18,6 +18,9 @@
 Terminology
 ===========
 
+The key words "SHOULD" and "RECOMMENDED" in this document are to be
+interpreted as described in RFC 2119. [#RFC2119]_
+
 The term "conventional transaction fee" in this document is in reference
 to the value of a transaction fee that is conventionally used by wallets,
 and that a user can reasonably expect miners on the Zcash network to accept
@@ -40,12 +43,12 @@ both), as proposed in [#zcash-2942]_.
     This ZIP has been obsoleted by ZIP 317 [#zip-0317]_. In particular,
     transactions using the 1,000-zatoshi fee specified in this ZIP will be
     treated as having no "paid actions", and therefore will be deprioritized
-    by the block construction algorithm in ZIP 317. If they have more than
-    50 logical actions, they will never be mined by that algorithm, and so
-    will not appear in block templates created by `zcashd` or `zebrad` with
-    the default parameters. They will also incur the low fee penalty
-    specified in ZIP 401 [#zip-0401]_, which will make them more likely to
-    be evicted from the mempool without being mined.
+    by the RECOMMENDED block template construction algorithm in ZIP 317.
+    If they have more than 50 logical actions, they will never be included
+    by that algorithm, and so will not appear in block templates created by
+    `zcashd` or `zebrad` with the default parameters. They will also incur
+    the low fee penalty specified in ZIP 401 [#zip-0401]_, which will make
+    them more likely to be evicted from the mempool without being mined.
 
     Wallets SHOULD move to using ZIP 317 fees with all due haste.
 
@@ -202,6 +205,7 @@ the wording in this ZIP.
 References
 ==========
 
+.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
 .. [#nathan-1] `Conventional Shielded Fees <https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566/40>`_
 .. [#ian-1] `Ian Miers. Mechanism for fee suggester/oracle <https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566/31>`_
 .. [#zooko-1] `Zooko Wilcox. Tweet on reducing tx fees <https://twitter.com/zooko/status/1295032258282156034?s=20>`_

--- a/zip-guide.html
+++ b/zip-guide.html
@@ -84,6 +84,16 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/253">https://githu
                 , so you will need to double-check that the rendering is as intended.</p>
                 <p>In general the conventions in the Zcash protocol specification SHOULD be followed. If you find this difficult, don't worry too much about it in initial drafts; the ZIP editors will catch any inconsistencies in review.</p>
             </section>
+            <section id="notes-and-warnings"><h3><span class="section-heading">Notes and warnings</span><span class="section-anchor"> <a rel="bookmark" href="#notes-and-warnings"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <aside class="note">
+                    <p>"<code>.. note::</code>" in reStructuredText, or "<code>:::info</code>" (terminated by "<code>:::</code>") in Markdown, can be used for an aside from the main text.</p>
+                    <p>The rendering of notes is colourful and may be distracting, so they should only be used for important points.</p>
+                </aside>
+                <aside class="warning">
+                    <p>"<code>.. warning::</code>" in reStructuredText, or "<code>:::warning</code>" (terminated by "<code>:::</code>") in Markdown, can be used for warnings.</p>
+                    <p>Warnings should be used very sparingly — for example to signal that a entire specification, or part of it, may be inapplicable or could cause significant interoperability or security problems. In most cases, a "MUST" or "SHOULD" conformance requirement is more appropriate.</p>
+                </aside>
+            </section>
             <section id="valid-restructuredtext"><h3><span class="section-heading">Valid reStructuredText</span><span class="section-anchor"> <a rel="bookmark" href="#valid-restructuredtext"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>This is optional before publishing a PR, but to check whether a document is valid reStructuredText, first install <code>rst2html5</code>. E.g. on Debian-based distros:</p>
                 <pre>sudo apt install python3-pip pandoc perl sed

--- a/zip-guide.rst
+++ b/zip-guide.rst
@@ -160,6 +160,25 @@ In general the conventions in the Zcash protocol specification SHOULD be followe
 If you find this difficult, don't worry too much about it in initial drafts; the
 ZIP editors will catch any inconsistencies in review.
 
+Notes and warnings
+------------------
+
+.. note::
+    "``.. note::``" in reStructuredText, or "``:::info``" (terminated by
+    "``:::``") in Markdown, can be used for an aside from the main text.
+
+    The rendering of notes is colourful and may be distracting, so they should
+    only be used for important points.
+
+.. warning::
+    "``.. warning::``" in reStructuredText, or "``:::warning``" (terminated by
+    "``:::``") in Markdown, can be used for warnings.
+
+    Warnings should be used very sparingly — for example to signal that a
+    entire specification, or part of it, may be inapplicable or could cause
+    significant interoperability or security problems. In most cases, a "MUST"
+    or "SHOULD" conformance requirement is more appropriate.
+
 Valid reStructuredText
 ----------------------
 


### PR DESCRIPTION
Also add a warning explaining why wallets should move to ZIP 317.