### PR TITLE
Updates to reference BCP 14 rather than RFC 2119

### DIFF
--- a/zip-0000.html
+++ b/zip-0000.html
@@ -23,7 +23,7 @@ Category: Process
 Created: 2019-02-16
 License: BSD-2-Clause</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", "RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", "RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -359,11 +359,11 @@ Updates:</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0000.rst
+++ b/zip-0000.rst
@@ -23,7 +23,8 @@ Terminology
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY",
 "RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to
-be interpreted as described in RFC 2119. [#RFC2119]_
+be interpreted as described in BCP 14 [#BCP14]_ when, and only when,
+they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as
 described in ZIP 200. [#zip-0200]_
@@ -800,7 +801,7 @@ See Also
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#RFC3552] `RFC 3552: Guidelines for Writing RFC Text on Security Considerations <https://www.rfc-editor.org/rfc/rfc3552.html>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#conduct] `Zcash Code of Conduct <https://github.com/zcash/zcash/blob/master/code_of_conduct.md>`_

--- a/zip-0032.html
+++ b/zip-0032.html
@@ -25,7 +25,7 @@ License: MIT</pre>
             <span class="math">\(% This ZIP makes heavy use of mathematical markup. If you can see this, you may want to instead view the rendered version at https://zips.z.cash/zip-0032 .\)</span>
         </p>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>"Jubjub" refers to the elliptic curve defined in <a id="footnote-reference-2" class="footnote_reference" href="#protocol-jubjub">15</a>.</p>
             <p>A "chain code" is a cryptovalue that is needed, in addition to a spending key, in order to derive descendant keys and addresses of that key.</p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">10</a>.</p>
@@ -979,11 +979,11 @@ License: MIT</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0032.rst
+++ b/zip-0032.rst
@@ -20,8 +20,8 @@
 Terminology
 ===========
 
-The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in RFC 2119.
-[#RFC2119]_
+The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described
+in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 "Jubjub" refers to the elliptic curve defined in [#protocol-jubjub]_.
 
@@ -687,7 +687,7 @@ Reference Implementation
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#bip-0032] `BIP 32: Hierarchical Deterministic Wallets <https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki>`_
 .. [#bip-0039] `BIP 39: Mnemonic code for generating deterministic keys <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki>`_
 .. [#bip-0043] `BIP 43: Purpose Field for Deterministic Wallets <https://github.com/bitcoin/bips/blob/master/bip-0043.mediawiki>`_

--- a/zip-0143.html
+++ b/zip-0143.html
@@ -18,7 +18,7 @@ Category: Consensus
 Created: 2017-12-27
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">10</a></p>
             <p>The term "Overwinter" in this document is to be interpreted as described in ZIP 201. <a id="footnote-reference-3" class="footnote_reference" href="#zip-0201">11</a></p>
         </section>
@@ -348,11 +348,11 @@ sighash: 23652e76cb13b85a0e3363bb5fca061fa791c40c533eccee899364e6e60bb4f7</pre>
             <p><a href="https://github.com/zcash/zcash/pull/2903">https://github.com/zcash/zcash/pull/2903</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0143.rst
+++ b/zip-0143.rst
@@ -16,7 +16,8 @@
 Terminology
 ===========
 
-The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. [#RFC2119]_
+The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 [#BCP14]_
+when, and only when, they appear in all capitals.
 
 The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as
 described in ZIP 200. [#zip-0200]_
@@ -454,7 +455,7 @@ https://github.com/zcash/zcash/pull/2903
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-sproutsend] `Zcash Protocol Specification, Version 2021.2.16. Section 4.7.1: Sending Notes (Sprout) <protocol/protocol.pdf#sproutsend>`_
 .. [#wiki-checksig] `OP\_CHECKSIG. Bitcoin Wiki <https://en.bitcoin.it/wiki/OP_CHECKSIG>`_
 .. [#quadratic]

--- a/zip-0155.html
+++ b/zip-0155.html
@@ -18,7 +18,7 @@ License: BSD-2-Clause
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/542">https://github.com/zcash/zips/issues/542</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/543">https://github.com/zcash/zips/pull/543</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">4</a></p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">2</a>.</p>
             <p>"P2P network" means the Zcash peer-to-peer network.</p>
@@ -185,11 +185,11 @@ CHECKSUM = H(".onion checksum" || PUBKEY || VERSION)[:2]  // first 2 bytes</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0155.rst
+++ b/zip-0155.rst
@@ -17,7 +17,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and only
+when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -237,7 +238,7 @@ Acknowledgements for BIP 155:
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 3.12 Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#bip-0155] `BIP 155: addrv2 message <https://github.com/bitcoin/bips/blob/master/bip-0155.mediawiki>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_

--- a/zip-0173.html
+++ b/zip-0173.html
@@ -18,7 +18,7 @@ Category: Standards / Wallet
 Created: 2018-06-13
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">4</a></p>
             <p>The term "Sapling" in this document is to be interpreted as described in ZIP 205. <a id="footnote-reference-3" class="footnote_reference" href="#zip-0205">5</a></p>
         </section>
@@ -350,11 +350,11 @@ def bech32_verify_checksum(hrp, data):
             <p>This document is closely based on BIP 173 written by Pieter Wuille and Greg Maxwell, which was inspired by the <a href="https://rusty.ozlabs.org/?p=578">address proposal</a> by Rusty Russell and the <a href="https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-February/004402.html">base32</a> proposal by Mark Friedenbach. BIP 173 also had input from Luke Dashjr, Johnson Lau, Eric Lombrozo, Peter Todd, and various other reviewers.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0173.rst
+++ b/zip-0173.rst
@@ -17,7 +17,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are
-to be interpreted as described in RFC 2119. [#RFC2119]_
+to be interpreted as described in BCP 14 [#BCP14]_ when, and only when, they appear
+in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -461,7 +462,7 @@ Eric Lombrozo, Peter Todd, and various other reviewers.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#zip-0032] `ZIP 32: Shielded Hierarchical Deterministic Wallets <zip-0032.rst>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_

--- a/zip-0200.html
+++ b/zip-0200.html
@@ -14,7 +14,7 @@ Category: Consensus
 Created: 2018-01-08
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
                 <dt>Block chain</dt>
@@ -117,11 +117,11 @@ License: MIT</pre>
             <p><a href="https://github.com/zcash/zcash/pull/2898">https://github.com/zcash/zcash/pull/2898</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0200.rst
+++ b/zip-0200.rst
@@ -13,7 +13,7 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms below are to be interpreted as follows:
 
@@ -223,7 +223,7 @@ https://github.com/zcash/zcash/pull/2898
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#consensual-currency] `Consensual Currency. Electric Coin Company blog <https://electriccoin.co/blog/consensual-currency/>`_
 .. [#release-lifecycle]
    - `Release Cycle and Lifetimes. Electric Coin Company blog <https://electriccoin.co/blog/release-cycle-and-lifetimes/>`_

--- a/zip-0201.html
+++ b/zip-0201.html
@@ -15,7 +15,7 @@ Category: Network
 Created: 2018-01-15
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch" and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
@@ -185,11 +185,11 @@ if (nActivationHeight &gt; 0 &amp;&amp;
             <p><a href="https://github.com/zcash/zcash/pull/2919">https://github.com/zcash/zcash/pull/2919</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0201.rst
+++ b/zip-0201.rst
@@ -14,7 +14,7 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described
-in RFC 2119. [#RFC2119]_
+in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms "consensus branch" and "network upgrade" in this document are to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -248,7 +248,7 @@ https://github.com/zcash/zcash/pull/2919
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0143] `ZIP 143: Transaction Signature Validation for Overwinter <zip-0143.rst>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0202] `ZIP 202: Version 3 Transaction Format for Overwinter <zip-0202.rst>`_

--- a/zip-0202.html
+++ b/zip-0202.html
@@ -15,7 +15,7 @@ Category: Consensus
 Created: 2018-01-10
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch", "network upgrade", and "consensus rule change" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
             <p>The term "Overwinter" in this document is to be interpreted as described in ZIP 201. <a id="footnote-reference-3" class="footnote_reference" href="#zip-0201">4</a></p>
         </section>
@@ -331,11 +331,11 @@ License: MIT</pre>
             <p><a href="https://github.com/zcash/zcash/pull/2925">https://github.com/zcash/zcash/pull/2925</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0202.rst
+++ b/zip-0202.rst
@@ -14,7 +14,7 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms "consensus branch", "network upgrade", and "consensus rule change" in this document are
 to be interpreted as described in ZIP 200. [#zip-0200]_
@@ -281,7 +281,7 @@ https://github.com/zcash/zcash/pull/2925
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0143] `ZIP 143: Transaction Signature Validation for Overwinter <zip-0143.rst>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0201] `ZIP 201: Network Handshaking for Overwinter <zip-0201.rst>`_

--- a/zip-0205.html
+++ b/zip-0205.html
@@ -15,7 +15,7 @@ Category: Consensus / Network
 Created: 2018-10-08
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch" and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">7</a></p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">3</a>.</p>
             <p>The terms below are to be interpreted as follows:</p>
@@ -74,11 +74,11 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24 * 24 * 3;</pr
             <p>Support for Sapling consensus rules was implemented in zcashd version 2.0.0. The majority of support for RPC calls and persistence of Sapling z-addresses was implemented in version 2.0.1. Both of these versions advertise protocol version 170007.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0205.rst
+++ b/zip-0205.rst
@@ -14,7 +14,7 @@ Terminology
 ===========
 
 The key words "MUST" and "SHOULD" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms "consensus branch" and "network upgrade" in this document are to be
 interpreted as described in ZIP 200. [#zip-0200]_
@@ -143,7 +143,7 @@ version 170007.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#protocol-constants] `Zcash Protocol Specification, Version 2021.2.16. Section 5.3: Constants <protocol/protocol.pdf#constants>`_

--- a/zip-0206.html
+++ b/zip-0206.html
@@ -15,7 +15,7 @@ Category: Consensus / Network
 Created: 2019-07-29
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
@@ -71,11 +71,11 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 24 * 24 * 3;</pr
             <p>Support for Blossom on testnet is implemented in <code>zcashd</code> version 2.0.7, which advertises protocol version 170008. Support for Blossom on mainnet is implemented in <code>zcashd</code> version 2.1.0, which advertises protocol version 170009.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0206.rst
+++ b/zip-0206.rst
@@ -14,7 +14,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be
-interpreted as described in RFC 2119. [#RFC2119]_
+interpreted as described in BCP 14 [#BCP14]_ when, and only when, they appear in
+all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -121,7 +122,7 @@ in ``zcashd`` version 2.1.0, which advertises protocol version 170009.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0201] `ZIP 201: Network Peer Management for Overwinter <zip-0201.rst>`_

--- a/zip-0207.html
+++ b/zip-0207.html
@@ -16,7 +16,7 @@ Category: Consensus
 Created: 2019-01-04
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "block subsidy" and "halving" in this document are to be interpreted as described in sections 3.9 and 7.7 of the Zcash Protocol Specification. <a id="footnote-reference-2" class="footnote_reference" href="#protocol-subsidyconcepts">3</a> <a id="footnote-reference-3" class="footnote_reference" href="#protocol-subsidies">7</a></p>
             <p>The terms "consensus branch" and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-4" class="footnote_reference" href="#zip-0200">10</a></p>
             <p>The terms below are to be interpreted as follows:</p>
@@ -223,11 +223,11 @@ License: MIT</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0207.rst
+++ b/zip-0207.rst
@@ -14,7 +14,8 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", "SHOULD NOT", and "MAY" in this document are
-to be interpreted as described in RFC 2119. [#RFC2119]_
+to be interpreted as described in BCP 14 [#BCP14]_ when, and only when, they
+appear in all capitals.
 
 The terms "block subsidy" and "halving" in this document are to be interpreted
 as described in sections 3.9 and 7.7 of the Zcash Protocol Specification.
@@ -233,7 +234,7 @@ Reference Implementation
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-subsidyconcepts] `Zcash Protocol Specification, Version 2021.2.16. Section 3.10: Block Subsidy and Founders' Reward <protocol/protocol.pdf#subsidyconcepts>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_

--- a/zip-0208.html
+++ b/zip-0208.html
@@ -17,7 +17,7 @@ Created: 2019-01-10
 License: MIT
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/237">https://github.com/zcash/zips/pull/237</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "block chain", "consensus rule change", "consensus branch", and "network upgrade" are to be interpreted as defined in <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">9</a>.</p>
             <p>The term "block target spacing" means the time interval between blocks targeted by the difficulty adjustment algorithm in a given consensus branch. It is normally measured in seconds. (This is also sometimes called the "target block time", but "block target spacing" is the term used in the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-diffadjustment">6</a>.)</p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-4" class="footnote_reference" href="#protocol-networks">4</a>.</p>
@@ -203,11 +203,11 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;</pre>
             <p><a href="https://github.com/zcash/zcash/pull/4025">https://github.com/zcash/zcash/pull/4025</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0208.rst
+++ b/zip-0208.rst
@@ -16,7 +16,7 @@ Terminology
 ===========
 
 The key words "MUST" and "SHOULD" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms "block chain", "consensus rule change", "consensus branch", and
 "network upgrade" are to be interpreted as defined in [#zip-0200]_.
@@ -394,7 +394,7 @@ https://github.com/zcash/zcash/pull/4025
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#preblossom-protocol] `Zcash Protocol Specification, Version 2018.0-beta-37 (exactly) <https://github.com/zcash/zips/blob/9515d73aac0aea3494f77bcd634e1e4fbd744b97/protocol/protocol.pdf>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_

--- a/zip-0209.html
+++ b/zip-0209.html
@@ -15,7 +15,7 @@ Category: Consensus
 Created: 2019-02-25
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "block chain" and "network upgrade" are to be interpreted as defined in <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a>.</p>
             <p>The "Sprout chain value pool balance" for a given block chain is the sum of all <code>vpub_old</code> fields for transactions in the block chain, minus the sum of all <code>vpub_new</code> fields for transactions in the block chain.</p>
             <p>The "Sapling chain value pool balance" for a given block chain is the negation of the sum of all <code>valueBalanceSapling</code> fields for transactions in the block chain.</p>
@@ -39,11 +39,11 @@ License: MIT</pre>
             <p>This specification was deployed in zcashd v2.0.4 for Testnet, and in zcashd v2.0.5 for Mainnet. The application to the Orchard chain value pool balance will be deployed from NU5 activation <a id="footnote-reference-5" class="footnote_reference" href="#zip-0252">4</a>.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0209.rst
+++ b/zip-0209.rst
@@ -14,7 +14,7 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The term "block chain" and "network upgrade" are to be interpreted as defined in [#zip-0200]_.
 
@@ -83,7 +83,7 @@ The application to the Orchard chain value pool balance will be deployed from NU
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16 or later. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0252] `ZIP 252: Deployment of the NU5 Network Upgrade <zip-0252.rst>`_

--- a/zip-0210.html
+++ b/zip-0210.html
@@ -17,7 +17,7 @@ License: MIT</pre>
             <p>This ZIP has been withdrawn because a similar change has been incorporated into the ZIP 225 proposal for a version 5 transaction format. <a id="footnote-reference-1" class="footnote_reference" href="#zip-0225">5</a></p>
         </section>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-2" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-2" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0200">3</a>.</p>
             <p>The term "Sapling" in this document is to be interpreted as described in ZIP 205 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0205">4</a>.</p>
         </section>
@@ -50,11 +50,11 @@ License: MIT</pre>
             <p>TBD</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0210.rst
+++ b/zip-0210.rst
@@ -20,7 +20,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in ZIP 200
 [#zip-0200]_.
@@ -112,7 +112,7 @@ TBD
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2021.2.16. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0205] `ZIP 205: Deployment of the Sapling Network Upgrade <zip-0205.rst>`_

--- a/zip-0211.html
+++ b/zip-0211.html
@@ -15,7 +15,7 @@ Category: Consensus
 Created: 2019-03-29
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a>.</p>
             <p>The term "Sprout shielded protocol" in this document refers to the shielded payment protocol defined at the launch of the Zcash network.</p>
             <p>The term "Sapling shielded protocol" in this document refers to the shielded payment protocol introduced in the Sapling network upgrade <a id="footnote-reference-3" class="footnote_reference" href="#zip-0205">4</a> <a id="footnote-reference-4" class="footnote_reference" href="#protocol">2</a>.</p>
@@ -62,11 +62,11 @@ License: MIT</pre>
             <p><a href="https://github.com/zcash/zcash/pull/4489">https://github.com/zcash/zcash/pull/4489</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0211.rst
+++ b/zip-0211.rst
@@ -14,7 +14,7 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", and "OPTIONAL" in this document are to be interpreted
-as described in RFC 2119. [#RFC2119]_
+as described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in ZIP 200
 [#zip-0200]_.
@@ -143,7 +143,7 @@ https://github.com/zcash/zcash/pull/4489
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0205] `ZIP 205: Deployment of the Sapling Network Upgrade <zip-0205.rst>`_

--- a/zip-0212.html
+++ b/zip-0212.html
@@ -15,7 +15,7 @@ Category: Consensus
 Created: 2019-03-31
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The following functions are defined in the Zcash Protocol Specification <a id="footnote-reference-2" class="footnote_reference" href="#protocol">2</a> according to the type (Sapling or Orchard) of note plaintext being processed:</p>
             <ul>
                 <li>let
@@ -280,11 +280,11 @@ License: MIT</pre>
             <p>The discovery that diversified address unlinkability depended on the zk-SNARK knowledge assumption was made by Sean Bowe and Zooko Wilcox.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0212.rst
+++ b/zip-0212.rst
@@ -13,7 +13,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD NOT", and "MAY" in this document are
-to be interpreted as described in RFC 2119. [#RFC2119]_
+to be interpreted as described in BCP 14 [#BCP14]_ when, and only when, they appear
+in all capitals.
 
 The following functions are defined in the Zcash Protocol Specification [#protocol]_
 according to the type (Sapling or Orchard) of note plaintext being processed:
@@ -324,7 +325,7 @@ knowledge assumption was made by Sean Bowe and Zooko Wilcox.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-abstractprfs] `Zcash Protocol Specification, Version 2021.2.16. Section 4.1.2: Pseudo Random Functions <protocol/protocol.pdf#abstractprfs>`_
 .. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2021.2.16. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_

--- a/zip-0213.html
+++ b/zip-0213.html
@@ -14,7 +14,7 @@ Category: Consensus
 Created: 2019-03-30
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">2</a>.</p>
             <p>The term "Sapling" in this document is to be interpreted as described in ZIP 205 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0205">3</a>.</p>
             <p>The terms "Founders' Reward" and "funding stream" in this document are to be interpreted as described in ZIP 207 <a id="footnote-reference-4" class="footnote_reference" href="#zip-0207">4</a>.</p>
@@ -77,11 +77,11 @@ License: MIT</pre>
             <p><a href="https://github.com/zcash/zcash/pull/4256">https://github.com/zcash/zcash/pull/4256</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0213.rst
+++ b/zip-0213.rst
@@ -13,7 +13,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in ZIP 200
 [#zip-0200]_.
@@ -199,7 +199,7 @@ https://github.com/zcash/zcash/pull/4256
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0205] `ZIP 205: Deployment of the Sapling Network Upgrade <zip-0205.rst>`_
 .. [#zip-0207] `ZIP 207: Split Founders' Reward <zip-0207.rst>`_

--- a/zip-0214.html
+++ b/zip-0214.html
@@ -15,7 +15,7 @@ Created: 2020-02-28
 License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/community-sentiment-polling-results-nu4-and-draft-zip-1014/35560">https://forum.zcashcommunity.com/t/community-sentiment-polling-results-nu4-and-draft-zip-1014/35560</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHALL", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHALL", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "Zcash" in this document is to be interpreted as described in the Zcash Trademark Donation and License Agreement (<a id="footnote-reference-2" class="footnote_reference" href="#trademark">6</a> or successor agreement).</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0200">8</a> and the Zcash Trademark Donation and License Agreement (<a id="footnote-reference-4" class="footnote_reference" href="#trademark">6</a> or successor agreement).</p>
             <p>The term "block subsidy" in this document is to be interpreted as described in section 3.10 of the Zcash Protocol Specification <a id="footnote-reference-5" class="footnote_reference" href="#protocol-subsidyconcepts">3</a>.</p>
@@ -267,11 +267,11 @@ FS_ZIP214_MG.AddressList[0..50] = ["t2Gvxv2uNM7hbbACjNox4H6DjByoKZ2Fa3P"] * 51</
             <p>This proposal is intended to be deployed with Canopy. <a id="footnote-reference-16" class="footnote_reference" href="#zip-0251">11</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0214.rst
+++ b/zip-0214.rst
@@ -14,7 +14,8 @@ Terminology
 ===========
 
 The key words "MUST", "SHALL", "SHOULD", and "MAY" in this document are to be
-interpreted as described in RFC 2119. [#RFC2119]_
+interpreted as described in BCP 14 [#BCP14]_ when, and only when, they appear
+in all capitals.
 
 The term "Zcash" in this document is to be interpreted as described in the
 Zcash Trademark Donation and License Agreement ([#trademark]_ or successor
@@ -336,7 +337,7 @@ This proposal is intended to be deployed with Canopy. [#zip-0251]_
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-subsidyconcepts] `Zcash Protocol Specification, Version 2021.2.16. Section 3.10: Block Subsidy, Funding Streams, and Founders' Reward <protocol/protocol.pdf#subsidyconcepts>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_

--- a/zip-0215.html
+++ b/zip-0215.html
@@ -15,7 +15,7 @@ Category: Consensus
 Created: 2020-04-27
 License: BSD-2-Clause</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MUST NOT" in this document is to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MUST NOT" in this document is to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Zcash uses Ed25519 signatures as part of Sprout transactions. However, Ed25519 does not clearly define criteria for signature validity, and implementations conformant to RFC 8032 <a id="footnote-reference-2" class="footnote_reference" href="#rfc8032">2</a> need not agree on whether signatures are valid. This is unacceptable for a consensus-critical application like Zcash. Currently, Zcash inherits criteria for signature validity from an obsolete version of <cite>libsodium</cite>. Instead, this ZIP settles the situation by explicitly defining the Ed25519 validity criteria and changing them to be compatible with batch validation.</p>
@@ -80,11 +80,11 @@ License: BSD-2-Clause</pre>
             <p>This is intended to be deployed with the Canopy Network Upgrade <a id="footnote-reference-7" class="footnote_reference" href="#zip-0251">6</a>, which is scheduled to activate on Mainnet <a id="footnote-reference-8" class="footnote_reference" href="#protocol-networks">4</a> at block height 1046400.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0215.rst
+++ b/zip-0215.rst
@@ -13,7 +13,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MUST NOT" in this document is to be interpreted as described
-in RFC 2119. [#RFC2119]_
+in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 
 Abstract
@@ -111,7 +111,7 @@ which is scheduled to activate on Mainnet [#protocol-networks]_ at block height
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#RFC8032] `RFC 8032: Edwards-Curve Digital Signature Algorithm (EdDSA) <https://www.rfc-editor.org/rfc/rfc8032.html>`_
 .. [#protocol-2020.1.1] `Zcash Protocol Specification, Version 2020.1.1 <https://github.com/zcash/zips/blob/v2020.1.1/protocol/protocol.pdf>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_

--- a/zip-0216.html
+++ b/zip-0216.html
@@ -17,7 +17,7 @@ Created: 2021-02-11
 License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/400">https://github.com/zcash/zips/issues/400</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key word "MUST" in this document is to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key word "MUST" in this document is to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">12</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -206,11 +206,11 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/400">https://g
             <p>This ZIP is proposed to activate with Network Upgrade 5. Requirements on points encoded in payment addresses and full viewing keys MAY be enforced in advance of NU5 activation.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0216.rst
+++ b/zip-0216.rst
@@ -14,8 +14,8 @@
 Terminology
 ===========
 
-The key word "MUST" in this document is to be interpreted as described in RFC 2119.
-[#RFC2119]_
+The key word "MUST" in this document is to be interpreted as described in BCP 14 [#BCP14]_
+when, and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -214,7 +214,7 @@ payment addresses and full viewing keys MAY be enforced in advance of NU5 activa
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later [NU5 proposal] <protocol/protocol.pdf>`_
 .. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
 .. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_

--- a/zip-0221.html
+++ b/zip-0221.html
@@ -18,7 +18,7 @@ Category: Consensus
 Created: 2019-03-30
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">8</a></p>
             <dl>
                 <dt><em>Light client</em></dt>
@@ -661,11 +661,11 @@ License: MIT</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0221.rst
+++ b/zip-0221.rst
@@ -16,7 +16,7 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted
-as described in RFC 2119. [#RFC2119]_
+as described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms "consensus branch", "epoch", and "network upgrade" in this document are to be
 interpreted as described in ZIP 200. [#zip-0200]_
@@ -827,7 +827,7 @@ Additional Reading
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#FlyClient] `FlyClient protocol <https://eprint.iacr.org/2019/226>`_
 .. [#protocol-blockheader] `Zcash Protocol Specification, Version 2021.2.16. Section 7.6: Block Header Encoding and Consensus <protocol/protocol.pdf#blockheader>`_
 .. [#protocol-workdef] `Zcash Protocol Specification, Version 2021.2.16. Section 7.7.5: Definition of Work <protocol/protocol.pdf#workdef>`_

--- a/zip-0222.html
+++ b/zip-0222.html
@@ -18,7 +18,7 @@ Category: Consensus
 Created: 2019-07-01
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">6</a>.</p>
             <p>The term "prefix-free" in this document is to be interpreted as to mean that no valid encoding of a value may have the same binary representation as any prefix of the binary encoding of another value of the same type.</p>
             <p>The term "non-malleable" in this document is to be interpreted as described in ZIP 244 <a id="footnote-reference-3" class="footnote_reference" href="#zip-0244">7</a>.</p>
@@ -286,11 +286,11 @@ nShieldedSpend, and nJoinSplit MUST be nonzero</code> in <a id="footnote-referen
             <p>We would also like to thank the numerous other individuals who participated in discussions at Zcon1 that led to the earlier draft version of this ZIP.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0222.rst
+++ b/zip-0222.rst
@@ -17,7 +17,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in ZIP 200
 [#zip-0200]_.
@@ -321,7 +321,7 @@ at Zcon1 that led to the earlier draft version of this ZIP.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-constants] `Zcash Protocol Specification, Version 2021.2.16. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
 .. [#protocol-txnconsensus] `Zcash Protocol Specification, Version 2021.2.16. Section 7.1: Transaction Consensus Rules <protocol/protocol.pdf#txnconsensus>`_

--- a/zip-0224.html
+++ b/zip-0224.html
@@ -20,7 +20,7 @@ Created: 2021-02-27
 License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/435">https://github.com/zcash/zips/issues/435</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key word "MUST" in this document is to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-2" class="footnote_reference" href="#protocol-networks">5</a>.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -164,9 +164,9 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/435">https://g
                 <li>The "transparent turnstile" created by the
                     <span class="math">\(\mathsf{valueBalanceOrchard}\)</span>
                  field, combined with the consensus checks that each pool's balance cannot be negative, together enforce that any potential counterfeiting bugs in the Orchard protocol or implementation are contained within the Orchard pool, and similarly any potential counterfeiting bugs in existing shielded pools cannot cause inflation of the Orchard pool.</li>
-                <li>Spending funds residing in the Orchard pool to a non-Orchard address will reveal the value of the transaction. This is a necessary side-effect of the transparent turnstile, but can be mitigated by migrating the majority of shielded activity to the Orchard pool and making these transactions a minority. Wallets should convey within their transaction creation UX that amounts are revealed in these situations.
+                <li>Spending funds residing in the Orchard pool to a non-Orchard address will reveal the value of the transaction. This is a necessary side-effect of the transparent turnstile, but can be mitigated by migrating the majority of shielded activity to the Orchard pool and making these transactions a minority. Wallets SHOULD convey within their transaction creation UX that amounts are revealed in these situations.
                     <ul>
-                        <li>Wallets should take steps to migrate their user bases to store funds uniformly within the Orchard pool. Best practices for wallet handling of multiple pools will be covered in a subsequent ZIP. <a id="footnote-reference-35" class="footnote_reference" href="#zip-0315">31</a></li>
+                        <li>Wallets SHOULD take steps to migrate their user bases to store funds uniformly within the Orchard pool. Best practices for wallet handling of multiple pools will be covered in a subsequent ZIP. <a id="footnote-reference-35" class="footnote_reference" href="#zip-0315">31</a></li>
                     </ul>
                 </li>
             </ul>
@@ -186,11 +186,11 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/435">https://g
             <p>This ZIP is proposed to activate with Network Upgrade 5.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0224.rst
+++ b/zip-0224.rst
@@ -17,7 +17,8 @@
 Terminology
 ===========
 
-The key word "MUST" in this document is to be interpreted as described in RFC 2119. [#RFC2119]_
+The key words "MUST" and "SHOULD" in this document are to be interpreted as described in
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of
 the Zcash Protocol Specification [#protocol-networks]_.
@@ -248,10 +249,10 @@ considerations:
 - Spending funds residing in the Orchard pool to a non-Orchard address will reveal the
   value of the transaction. This is a necessary side-effect of the transparent turnstile,
   but can be mitigated by migrating the majority of shielded activity to the Orchard pool
-  and making these transactions a minority. Wallets should convey within their transaction
+  and making these transactions a minority. Wallets SHOULD convey within their transaction
   creation UX that amounts are revealed in these situations.
 
-  - Wallets should take steps to migrate their user bases to store funds uniformly within
+  - Wallets SHOULD take steps to migrate their user bases to store funds uniformly within
     the Orchard pool. Best practices for wallet handling of multiple pools will be covered
     in a subsequent ZIP. [#zip-0315]_
 
@@ -278,7 +279,7 @@ This ZIP is proposed to activate with Network Upgrade 5.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zcash-paramgen] `Parameter Generation <https://z.cash/technology/paramgen/>`_
 .. [#bctv14-vuln] `Zcash Counterfeiting Vulnerability Successfully Remediated <https://electriccoin.co/blog/zcash-counterfeiting-vulnerability-successfully-remediated/>`_
 .. [#protocol-orchard] `Zcash Protocol Specification, Version 2021.2.16 or later [NU5 proposal] <protocol/protocol.pdf>`_

--- a/zip-0225.html
+++ b/zip-0225.html
@@ -20,7 +20,7 @@ Created: 2021-02-28
 License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://github.com/zcash/zips/issues/440</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The character § is used when referring to sections of the Zcash Protocol Specification <a id="footnote-reference-2" class="footnote_reference" href="#protocol">2</a>.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -471,11 +471,11 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0225.rst
+++ b/zip-0225.rst
@@ -18,7 +18,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The character § is used when referring to sections of the Zcash Protocol Specification
 [#protocol]_.
@@ -321,7 +321,7 @@ Reference implementation
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later [NU5 proposal] <protocol/protocol.pdf>`_
 .. [#protocol-spenddesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.4: Spend Descriptions <protocol/protocol.pdf#spenddesc>`_
 .. [#protocol-outputdesc] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 4.5: Output Descriptions <protocol/protocol.pdf#outputdesc>`_

--- a/zip-0239.html
+++ b/zip-0239.html
@@ -17,7 +17,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/515">https://github.com/zcash/zips/issues/515</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/516">https://github.com/zcash/zips/pull/516</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "RECOMMENDED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "RECOMMENDED" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">4</a></p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">2</a>.</p>
             <p>The term "txid" means a transaction identifier, computed as a SHA-256d hash of the transaction data for v4 and earlier transactions, or as specified in <a id="footnote-reference-4" class="footnote_reference" href="#zip-0244">6</a> for v5 and later transactions.</p>
@@ -68,11 +68,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/516">https://githu
             <p>This ZIP is partly based on BIP 339, written by Suhas Daftuar. <a id="footnote-reference-18" class="footnote_reference" href="#bip-0339">9</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0239.rst
+++ b/zip-0239.rst
@@ -16,7 +16,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "RECOMMENDED" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and only when,
+they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -189,7 +190,7 @@ This ZIP is partly based on BIP 339, written by Suhas Daftuar. [#bip-0339]_
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 3.12 Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_

--- a/zip-0243.html
+++ b/zip-0243.html
@@ -16,7 +16,7 @@ Category: Consensus
 Created: 2018-04-10
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">5</a></p>
             <p>The term "Sapling" in this document is to be interpreted as described in ZIP 205. <a id="footnote-reference-3" class="footnote_reference" href="#zip-0205">6</a></p>
         </section>
@@ -443,11 +443,11 @@ vJoinSplit:      00</pre>
             <p><a href="https://github.com/zcash/zcash/pull/3233">https://github.com/zcash/zcash/pull/3233</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0243.rst
+++ b/zip-0243.rst
@@ -14,7 +14,8 @@
 Terminology
 ===========
 
-The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. [#RFC2119]_
+The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 [#BCP14]_
+when, and only when, they appear in all capitals.
 
 The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as
 described in ZIP 200. [#zip-0200]_
@@ -527,7 +528,7 @@ https://github.com/zcash/zcash/pull/3233
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#BLAKE2-personalization] `"BLAKE2: simpler, smaller, fast as MD5", Section 2.8 <https://blake2.net/blake2.pdf>`_
 .. [#zip-0143] `ZIP 143: Transaction Signature Validation for Overwinter <zip-0143.rst>`_

--- a/zip-0244.html
+++ b/zip-0244.html
@@ -18,7 +18,7 @@ Created: 2021-01-06
 License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/411">https://github.com/zcash/zips/issues/411</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
             <p>The term "field encoding" refers to the binary serialized form of a Zcash transaction field, as specified in section 7.1 of the Zcash protocol specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-txnencoding">2</a>.</p>
         </section>
@@ -436,11 +436,11 @@ terminator          [0u8;32]</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -16,10 +16,11 @@
 Terminology
 ===========
 
-The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. [#RFC2119]_
+The key words "MUST" and "MUST NOT" in this document are to be interpreted as described
+in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
-The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as
-described in ZIP 200. [#zip-0200]_
+The terms "consensus branch", "epoch", and "network upgrade" in this document are to be
+interpreted as described in ZIP 200. [#zip-0200]_
 
 The term "field encoding" refers to the binary serialized form of a Zcash transaction
 field, as specified in section 7.1 of the Zcash protocol specification
@@ -881,7 +882,7 @@ Reference implementation
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0221] `ZIP 221: FlyClient - Consensus Layer Changes <zip-0221.rst>`_

--- a/zip-0245.html
+++ b/zip-0245.html
@@ -15,7 +15,7 @@ Created: 2021-01-13
 License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/384">https://github.com/zcash/zips/issues/384</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">2</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -122,11 +122,11 @@ A.4: sapling_auth_digest        (32-byte hash output)</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0245.rst
+++ b/zip-0245.rst
@@ -13,10 +13,11 @@
 Terminology
 ===========
 
-The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. [#RFC2119]_
+The key words "MUST" and "MUST NOT" in this document are to be interpreted as described
+in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
-The terms "consensus branch", "epoch", and "network upgrade" in this document are to be interpreted as
-described in ZIP 200. [#zip-0200]_
+The terms "consensus branch", "epoch", and "network upgrade" in this document are to be
+interpreted as described in ZIP 200. [#zip-0200]_
 
 
 Abstract
@@ -189,7 +190,7 @@ Reference implementation
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0222] `ZIP 222: Transparent Zcash Extensions <zip-0222.rst>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.rst>`_

--- a/zip-0250.html
+++ b/zip-0250.html
@@ -14,7 +14,7 @@ Category: Consensus / Network
 Created: 2020-02-28
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
@@ -74,11 +74,11 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;</pre>
             <p>Support for Heartwood on testnet will be implemented in <code>zcashd</code> version 2.1.2, which will advertise protocol version 170010. Support for Heartwood on mainnet will be implemented in <code>zcashd</code> version 3.0.0, which will advertise protocol version 170011.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0250.rst
+++ b/zip-0250.rst
@@ -13,7 +13,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be
-interpreted as described in RFC 2119. [#RFC2119]_
+interpreted as described in BCP 14 [#BCP14]_ when, and only when, they appear in
+all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -127,7 +128,7 @@ be implemented in ``zcashd`` version 3.0.0, which will advertise protocol versio
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0201] `ZIP 201: Network Peer Management for Overwinter <zip-0201.rst>`_

--- a/zip-0251.html
+++ b/zip-0251.html
@@ -14,7 +14,7 @@ Category: Consensus / Network
 Created: 2020-02-28
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">5</a></p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">3</a>.</p>
             <p>"Canopy" is the code-name for the fifth Zcash network upgrade, also known as Network Upgrade 4.</p>
@@ -71,11 +71,11 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;</pre>
             <p>Support for Canopy on testnet will be implemented in <code>zcashd</code> version 3.1.0, which will advertise protocol version 170012. Support for Canopy on mainnet will be implemented in <code>zcashd</code> version 4.0.0, which will advertise protocol version 170013.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0251.rst
+++ b/zip-0251.rst
@@ -13,7 +13,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be
-interpreted as described in RFC 2119. [#RFC2119]_
+interpreted as described in BCP 14 [#BCP14]_ when, and only when, they appear in
+all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -127,7 +128,7 @@ in ``zcashd`` version 4.0.0, which will advertise protocol version 170013.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2021.2.16. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_

--- a/zip-0252.html
+++ b/zip-0252.html
@@ -17,7 +17,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://github.com/zcash/zips/issues/440</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/446">https://github.com/zcash/zips/pull/446</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">6</a></p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">3</a>.</p>
         </section>
@@ -123,11 +123,11 @@ static const int NETWORK_UPGRADE_PEER_PREFERENCE_BLOCK_PERIOD = 1728;</pre>
             </section>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0252.rst
+++ b/zip-0252.rst
@@ -16,7 +16,7 @@ Terminology
 ===========
 
 The key words "MUST" and "SHOULD" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described in
 ZIP 200. [#zip-0200]_
@@ -222,7 +222,7 @@ peers, and reject new connections from pre-NU5 peers.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2021.2.16 [NU5 proposal]. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_

--- a/zip-0301.html
+++ b/zip-0301.html
@@ -19,7 +19,7 @@ Category: Standards / Ecosystem
 Created: 2016-09-23
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "MAY", and "RECOMMENDED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "MAY", and "RECOMMENDED" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This ZIP describes the Zcash variant of the Stratum protocol, used by miners to communicate with mining pool servers.</p>
@@ -342,11 +342,11 @@ License: MIT</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0301.rst
+++ b/zip-0301.rst
@@ -18,7 +18,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", "MAY", and "RECOMMENDED" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and only
+when, they appear in all capitals.
 
 
 Abstract
@@ -488,7 +489,7 @@ Thanks to:
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-blockheader] `Zcash Protocol Specification, Version 2020.1.15. Section 7.3: Block Headers <protocol/protocol.pdf#blockheader>`_
 .. [#protocol-difficulty] `Zcash Protocol Specification, Version 2020.1.15. Section 7.6.2: Difficulty filter <protocol/protocol.pdf#difficulty>`_
 .. [#Slushpool-Stratum] `Stratum Mining Protocol. Slush Pool <https://slushpool.com/help/stratum-protocol/>`_

--- a/zip-0304.html
+++ b/zip-0304.html
@@ -19,7 +19,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/345">https://github.com/zcash/zips/issues/345</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/376">https://github.com/zcash/zips/pull/376</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "SHOULD" in this document is to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "SHOULD" in this document is to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This proposal describes a mechanism for creating signatures with Sapling addresses, suitable for use by the <code>signmessage</code> and <code>verifymessage</code> RPC methods in <code>zcashd</code>.</p>
@@ -310,11 +310,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/376">https://githu
             <p><a href="https://github.com/zcash/librustzcash/pull/210">https://github.com/zcash/librustzcash/pull/210</a></p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0304.rst
+++ b/zip-0304.rst
@@ -17,7 +17,7 @@ Terminology
 ===========
 
 The key words "MUST" and "SHOULD" in this document is to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 
 Abstract
@@ -275,7 +275,7 @@ https://github.com/zcash/librustzcash/pull/210
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#RFC4648] `RFC 4648: The Base16, Base32, and Base64 Data Encodings <https://www.rfc-editor.org/rfc/rfc4648>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2020.1.15 or later <protocol/protocol.pdf>`_
 .. [#protocol-merklepath] `Zcash Protocol Specification, Version 2020.1.15. Section 4.8: Merkle path validity <protocol/protocol.pdf#merklepath>`_

--- a/zip-0307.html
+++ b/zip-0307.html
@@ -18,7 +18,7 @@ Status: Draft
 Created: 2018-09-17
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
                 <dt>Light client</dt>
@@ -523,11 +523,11 @@ License: MIT</pre>
             <p>This proposal is supported by a set of libraries and reference code made available by the Electric Coin Company.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0307.rst
+++ b/zip-0307.rst
@@ -16,7 +16,7 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 The terms below are to be interpreted as follows:
 
@@ -608,7 +608,7 @@ Electric Coin Company.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-merkletree] `Zcash Protocol Specification, Version 2020.1.15. Section 3.7: Note Commitment Trees <protocol/protocol.pdf#merkletree>`_
 .. [#protocol-merklepath] `Zcash Protocol Specification, Version 2020.1.15. Section 4.8: Merkle Path Validity <protocol/protocol.pdf#merklepath>`_
 .. [#protocol-saplingdecryptivk] `Zcash Protocol Specification, Version 2020.1.15. Section 4.17.2: Decryption using an Incoming Viewing Key (Sapling) <protocol/protocol.pdf#saplingdecryptivk>`_

--- a/zip-0308.html
+++ b/zip-0308.html
@@ -16,7 +16,7 @@ Category: Standards / RPC / Wallet
 Created: 2018-11-27
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
                 <dt>Sprout protocol</dt>
@@ -230,11 +230,11 @@ License: MIT</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0308.rst
+++ b/zip-0308.rst
@@ -15,7 +15,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to
-be interpreted as described in RFC 2119. [#RFC2119]_
+be interpreted as described in BCP 14 [#BCP14]_ when, and only when, they
+appear in all capitals.
 
 The terms below are to be interpreted as follows:
 
@@ -426,7 +427,7 @@ The following PRs implement this specification:
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#transparent-value-pool] `Zcash Protocol Specification, Version 2020.1.15. Sections 3.4, 4.11 and 4.12 <protocol/protocol.pdf>`_
 .. [#zip-0032] `ZIP 32: Shielded Hierarchical Deterministic Wallets <zip-0032.rst>`_
 .. [#zip-0205] `ZIP 205: Deployment of the Sapling Network Upgrade <zip-0205.rst>`_

--- a/zip-0313.html
+++ b/zip-0313.html
@@ -20,7 +20,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566">https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://github.com/zcash/zips/pull/408</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "SHOULD" and "RECOMMENDED" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "SHOULD" and "RECOMMENDED" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "conventional transaction fee" in this document is in reference to the value of a transaction fee that is conventionally used by wallets, and that a user can reasonably expect miners on the Zcash network to accept for including a transaction in a block.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -84,11 +84,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/408">https://githu
             <p>Thanks to Nathan Wilcox for suggesting improvements to the denial of service section. Thanks to Daira Emma Hopwood and Deirdre Connolly for reviewing and fixing the wording in this ZIP.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0313.rst
+++ b/zip-0313.rst
@@ -19,7 +19,8 @@ Terminology
 ===========
 
 The key words "SHOULD" and "RECOMMENDED" in this document are to be
-interpreted as described in RFC 2119. [#RFC2119]_
+interpreted as described in BCP 14 [#BCP14]_ when, and only when, they
+appear in all capitals.
 
 The term "conventional transaction fee" in this document is in reference
 to the value of a transaction fee that is conventionally used by wallets,
@@ -205,7 +206,7 @@ the wording in this ZIP.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#nathan-1] `Conventional Shielded Fees <https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566/40>`_
 .. [#ian-1] `Ian Miers. Mechanism for fee suggester/oracle <https://forum.zcashcommunity.com/t/zip-reduce-default-shielded-transaction-fee-to-1000-zats/37566/31>`_
 .. [#zooko-1] `Zooko Wilcox. Tweet on reducing tx fees <https://twitter.com/zooko/status/1295032258282156034?s=20>`_

--- a/zip-0316.html
+++ b/zip-0316.html
@@ -24,7 +24,7 @@ Created: 2021-04-07
 License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/482">https://github.com/zcash/zips/issues/482</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
                 <dt>Recipient</dt>
@@ -732,11 +732,11 @@ c^{n+m}}{q}.\)</span>
             <p>The authors would like to thank Benjamin Winston, Zooko Wilcox, Francisco Gindre, Marshall Gaucher, Joseph Van Geffen, Brad Miller, Deirdre Connolly, Teor, Eran Tromer, Conrado Gouvêa, and Marek Bielik for discussions on the subject of Unified Addresses and Unified Viewing Keys.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0316.rst
+++ b/zip-0316.rst
@@ -21,8 +21,9 @@
 Terminology
 ===========
 
-The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are to
-be interpreted as described in RFC 2119. [#RFC2119]_
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document are
+to be interpreted as described in BCP 14 [#BCP14]_ when, and only when, they
+appear in all capitals.
 
 The terms below are to be interpreted as follows:
 
@@ -1028,7 +1029,7 @@ Unified Addresses and Unified Viewing Keys.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-nu5] `Zcash Protocol Specification, Version 2022.2.19 or later [NU5 proposal] <protocol/protocol.pdf>`_
 .. [#protocol-notation] `Zcash Protocol Specification, Version 2022.2.19. Section 2: Notation <protocol/protocol.pdf#notation>`_
 .. [#protocol-saplingkeycomponents] `Zcash Protocol Specification, Version 2022.2.19. Section 4.2.2: Sapling Key Components <protocol/protocol.pdf#saplingkeycomponents>`_

--- a/zip-0317.html
+++ b/zip-0317.html
@@ -23,7 +23,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-proportional-output-fee-mechanism-pofm/42808">https://forum.zcashcommunity.com/t/zip-proportional-output-fee-mechanism-pofm/42808</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://github.com/zcash/zips/pull/631</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "SHOULD", "SHOULD NOT", "RECOMMENDED", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "SHOULD", "SHOULD NOT", "RECOMMENDED", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "conventional transaction fee" in this document is in reference to the value of a transaction fee that is conventionally used by wallets, and that a user can reasonably expect miners on the Zcash network to accept for including a transaction in a block.</p>
             <p>The terms "Mainnet, "Testnet", and "zatoshi" in this document are defined as in <a id="footnote-reference-2" class="footnote_reference" href="#protocol-networks">2</a>.</p>
         </section>
@@ -495,11 +495,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
             <p>Thanks to Madars Virza for initially proposing a fee mechanism similar to that proposed in this ZIP <a id="footnote-reference-11" class="footnote_reference" href="#madars-1">5</a>, and for finding a potential weakness in an earlier version of the block template construction algorithm. Thanks also to Kris Nuttycombe, Jack Grigg, Francisco Gindre, Greg Pfeil, Teor, and Deirdre Connolly for reviews and suggested improvements.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0317.rst
+++ b/zip-0317.rst
@@ -21,7 +21,8 @@ Terminology
 ===========
 
 The key words "SHOULD", "SHOULD NOT", "RECOMMENDED", and "MAY" in this document
-are to be interpreted as described in RFC 2119. [#RFC2119]_
+are to be interpreted as described in BCP 14 [#BCP14]_ when, and only when, they
+appear in all capitals.
 
 The term "conventional transaction fee" in this document is in reference
 to the value of a transaction fee that is conventionally used by wallets,
@@ -567,7 +568,7 @@ Deirdre Connolly for reviews and suggested improvements.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2022.3.8. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2022.3.8. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#sigop-limit] `zcash/zips issue #568 - Document block transparent sigops limit consensus rule <https://github.com/zcash/zips/issues/568>`_

--- a/zip-0321.html
+++ b/zip-0321.html
@@ -17,7 +17,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/347">https://g
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/395">https://github.com/zcash/zips/pull/395</a>&gt;
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.11 of the Zcash Protocol Specification <a id="footnote-reference-2" class="footnote_reference" href="#protocol-networks">10</a>.</p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
@@ -140,11 +140,11 @@ zcash:%74mEZhbWHTpdKMw5it8YDspUXSMGQyFwovpU?amount=1</pre>
             </section>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0321.rst
+++ b/zip-0321.rst
@@ -16,7 +16,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", "RECOMMENDED", and "MAY" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and only
+when, they appear in all capitals.
 
 The terms "Testnet" and "Mainnet" are to be interpreted as described in
 section 3.11 of the Zcash Protocol Specification [#protocol-networks]_.
@@ -310,7 +311,7 @@ of old clients to upgrade.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#RFC5234] `RFC 5234: Augmented BNF for Syntax Specifications: ABNF <https://www.rfc-editor.org/rfc/rfc5234.html>`_
 .. [#RFC3986] `RFC 3986: URI Generic Syntax, Appendix A. Collected ABNF for URI <https://www.rfc-editor.org/rfc/rfc3986.html#appendix-A>`_
 .. [#base64url] `RFC 4648 section 5: Base64 Encoding with URL and Filename Safe Alphabet <https://www.rfc-editor.org/rfc/rfc4648.html#section-5>`_

--- a/zip-0400.html
+++ b/zip-0400.html
@@ -14,7 +14,7 @@ Category: Wallet
 Created: 2020-05-26
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This proposal defines the current format used in zcashd for wallet persistent storage, commonly known as <code>wallet.dat</code>.</p>
@@ -469,11 +469,11 @@ License: MIT</pre>
             </section>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0400.rst
+++ b/zip-0400.rst
@@ -13,7 +13,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MAY" in this document are to be interpreted as described in
-RFC 2119. [#RFC2119]_
+BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 Abstract
 ========
@@ -141,7 +141,7 @@ For a deeper understanding of the current encryption mechanism please refer to [
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#BDB] `Oracle Berkeley Database <https://www.oracle.com/database/berkeley-db/db.html>`_
 .. [#ZIP400Issue] `ZIP 400 issue <https://github.com/zcash/zips/issues/350>`_
 .. [#zip-0032] `ZIP 32: Shielded Hierarchical Deterministic Wallets <zip-0032.rst>`_

--- a/zip-0401.html
+++ b/zip-0401.html
@@ -15,7 +15,7 @@ Category: Network
 Created: 2019-09-09
 License: MIT</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>This proposal specifies a change to the behaviour of <cite>zcashd</cite> nodes intended to mitigate denial-of-service from transaction flooding.</p>
@@ -87,11 +87,11 @@ License: MIT</pre>
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-0401.rst
+++ b/zip-0401.rst
@@ -13,7 +13,7 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted
-as described in RFC 2119. [#RFC2119]_
+as described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 
 Abstract
@@ -232,7 +232,7 @@ Reference implementation
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0208] `ZIP 208: Shorter Block Target Spacing <zip-0208.rst>`_
 .. [#zip-0239] `ZIP 239: Relay of Version 5 Transactions <zip-0239.rst>`_
 .. [#zip-0252] `ZIP 252: Deployment of the NU5 Network Upgrade <zip-0252.rst>`_

--- a/zip-1001.html
+++ b/zip-1001.html
@@ -15,7 +15,7 @@ Created: 2019-08-01
 License: CC BY-SA 4.0 &lt;<a href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</a>&gt;
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-proposal-keep-the-block-distribution-as-initaly-defined-90-to-miners/33843">https://forum.zcashcommunity.com/t/zip-proposal-keep-the-block-distribution-as-initaly-defined-90-to-miners/33843</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">2</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">2</a> when, and only when, they appear in all capitals.</p>
             <p>For clarity this ZIP defines these terms:</p>
             <ul>
                 <li>Mining software in the context of this ZIP refers to pool software, local mining software, or staking software.</li>
@@ -76,11 +76,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-proposal-kee
             <p>This ZIP requires no changes to current consensus implementations.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>2</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1001.rst
+++ b/zip-1001.rst
@@ -16,7 +16,8 @@ Terminology
 .. role:: editor-note
 
 The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document
-are to be interpreted as described in RFC 2119. [#RFC2119]_
+are to be interpreted as described in BCP 14 [#BCP14]_ when, and only when,
+they appear in all capitals.
 
 For clarity this ZIP defines these terms:
 
@@ -107,7 +108,7 @@ This ZIP requires no changes to current consensus implementations.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#funding] `Zcash blog: Funding, Incentives, and Governance. February 1, 2016 <https://electriccoin.co/blog/funding/>`_
 .. [#spec-subsidies] `Zcash Protocol Specification, Version 2019.0.8 exactly. Section 7.7: Calculation of Block Subsidy and Founders Reward <protocol/protocol.pdf#subsidies>`_
 .. [#spec-foundersreward] `Zcash Protocol Specification, Version 2019.0.8 exactly. Section 7.8: Payment of Founders’ Reward <protocol/protocol.pdf#foundersreward>`_

--- a/zip-1002.html
+++ b/zip-1002.html
@@ -15,7 +15,7 @@ Created: 2019-07-17
 License: CC BY-SA 4.0 &lt;<a href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</a>&gt;
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-proposal-a-genuine-opt-in-protocol-level-development-donation-option/33846">https://forum.zcashcommunity.com/t/zip-proposal-a-genuine-opt-in-protocol-level-development-donation-option/33846</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">3</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">3</a> when, and only when, they appear in all capitals.</p>
             <p>This ZIP defines these terms:</p>
             <ul>
                 <li>Signalling is defined as expressing a voice through whatever mechanism is implemented or sought for that decision. In the context of this ZIP it primarily refers to signalling what to do with funds. This could be done by miners, straw poll, coinbase, proof of value, some internet poll thing, etc.</li>
@@ -129,11 +129,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-proposal-a-g
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>3</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1002.rst
+++ b/zip-1002.rst
@@ -14,7 +14,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and only
+when, they appear in all capitals.
 
 This ZIP defines these terms:
 
@@ -196,5 +197,5 @@ Stuff that is already implemented in some form or another:
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zfnd-guidance] `Zcash Foundation Guidance on Dev Fund Proposals. Zcash Foundation blog, August 6, 2019. <https://www.zfnd.org/blog/dev-fund-guidance-and-timeline/>`_

--- a/zip-1003.html
+++ b/zip-1003.html
@@ -15,7 +15,7 @@ Created: 2019-06-19
 License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/dev-fund-proposal-20-split-between-the-ecc-and-the-foundation/33862">https://forum.zcashcommunity.com/t/dev-fund-proposal-20-split-between-the-ecc-and-the-foundation/33862</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>For clarity in this ZIP I define these terms:</p>
             <dl>
                 <dt>2nd Halvening period</dt>
@@ -79,11 +79,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/dev-fund-proposa
             </section>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1003.rst
+++ b/zip-1003.rst
@@ -14,7 +14,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document
-are to be interpreted as described in RFC 2119. [#RFC2119]_
+are to be interpreted as described in BCP 14 [#BCP14]_ when, and only when,
+they appear in all capitals.
 
 For clarity in this ZIP I define these terms:
 
@@ -153,7 +154,7 @@ development fund’ should instead not be minted.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zfnd-state] `The State of the Zcash Foundation in 2019. Zcash Foundation blog, January 31, 2019. <https://www.zfnd.org/blog/foundation-in-2019/>`_
 .. [#zfnd-guidance] `Zcash Foundation Guidance on Dev Fund Proposals. Zcash Foundation blog, August 6, 2019. <https://www.zfnd.org/blog/dev-fund-guidance-and-timeline/>`_
 

--- a/zip-1004.html
+++ b/zip-1004.html
@@ -15,7 +15,7 @@ Created: 2019-06-19
 License: public domain
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/dev-fund-proposal-miner-directed-dev-fund-was-20-to-any-combination-of-ecc-zfnd-parity-or-burn/33864">https://forum.zcashcommunity.com/t/dev-fund-proposal-miner-directed-dev-fund-was-20-to-any-combination-of-ecc-zfnd-parity-or-burn/33864</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>For clarity, this ZIP defines these terms:</p>
             <dl>
                 <dt>2nd Halvening Period</dt>
@@ -83,11 +83,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/dev-fund-proposa
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1004.rst
+++ b/zip-1004.rst
@@ -14,7 +14,8 @@ Terminology
 ===========
 
 The key words "MUST", "SHOULD", and "MAY" in this document are to be
-interpreted as described in RFC 2119. [#RFC2119]_
+interpreted as described in BCP 14 [#BCP14]_ when, and only when, they
+appear in all capitals.
 
 For clarity, this ZIP defines these terms:
 
@@ -166,7 +167,7 @@ Raised objections and issues so far:
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#amiller-notes] `Notes on reaching agreement about a potential Zcash development fund. Andrew Miller, June 3, 2019. <https://medium.com/@socrates1024/here-are-a-couple-of-points-on-framing-the-discussion-of-a-potential-new-dev-fund-in-zcash-c13bcbf4ed5b>`_
 .. [#acityinohio-comment] `Comment on a post “The future of Zcash in the year 2020” in the Zcash Community Forum. Josh Cincinnati, June 3, 2019. <https://forum.zcashcommunity.com/t/the-future-of-zcash-in-the-year-2020/32372/267>`_
 .. [#blocktown-summary] `Executive Summary: Blocktown Proposal for Zcash 2020 Network Upgrade. Blocktown Capital, August 15, 2019. <https://medium.com/blocktown/executive-summary-blocktown-proposal-for-zcash-2020-network-upgrade-84ff20997502>`_

--- a/zip-1006.html
+++ b/zip-1006.html
@@ -18,7 +18,7 @@ Created: 2019-08-31
 License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/blocktown-development-fund-proposal-10-to-a-2-of-3-multisig-with-community-involved-third-entity/34782">https://forum.zcashcommunity.com/t/blocktown-development-fund-proposal-10-to-a-2-of-3-multisig-with-community-involved-third-entity/34782</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words “MUST”, “SHOULD”, “SHOULD NOT”, and “MAY” in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words “MUST”, “SHOULD”, “SHOULD NOT”, and “MAY” in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The additional terms below are to be interpreted as follows:</p>
             <dl>
                 <dt>Mining</dt>
@@ -122,11 +122,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/blocktown-develo
             <p>Aspects of this proposal, particularly the Terminology and Specification sections, were adapted and expanded definitions and concepts put forth in Placeholder’s dev fund proposal from August 22, 2019 <a id="footnote-reference-14" class="footnote_reference" href="#placeholder-proposal">8</a>.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1006.rst
+++ b/zip-1006.rst
@@ -17,7 +17,8 @@ Terminology
 ===========
 
 The key words “MUST”, “SHOULD”, “SHOULD NOT”, and “MAY” in this document
-are to be interpreted as described in RFC 2119. [#RFC2119]_
+are to be interpreted as described in BCP 14 [#BCP14]_ when, and only when,
+they appear in all capitals.
 
 The additional terms below are to be interpreted as follows:
 
@@ -365,7 +366,7 @@ in Placeholder’s dev fund proposal from August 22, 2019 [#placeholder-proposal
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zfnd-guidance] `Zcash Foundation Guidance on Dev Fund Proposals. Zcash Foundation blog, August 6, 2019. <https://www.zfnd.org/blog/dev-fund-guidance-and-timeline/>`_
 .. [#ecc-assessment] `ECC Initial Assessment of Community Proposals. Electric Coin Company blog, August 26, 2019. <https://electriccoin.co/blog/ecc-initial-assessment-of-community-proposals/>`_
 .. [#blocktown-proposal] `Proposal for the Zcash 2020 Network Upgrade (topic on the Zcash community forum). <https://forum.zcashcommunity.com/t/proposal-for-the-zcash-2020-network-upgrade/34503>`_

--- a/zip-1007.html
+++ b/zip-1007.html
@@ -16,7 +16,7 @@ Created: 2019-08-24
 License: CC BY-SA 4.0 &lt;<a href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</a>&gt;
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/dev-fund-supplemental-proposal-enforce-devfund-commitments-with-legal-charter/34709">https://forum.zcashcommunity.com/t/dev-fund-supplemental-proposal-enforce-devfund-commitments-with-legal-charter/34709</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>For clarity this ZIP defines these terms:</p>
             <ul>
                 <li>Covenant is defined as a legally binding agreement, upon which a specific aspect of development of the Zcash protocol and/or adoption is scheduled and agreed.</li>
@@ -82,11 +82,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/dev-fund-supplem
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1007.rst
+++ b/zip-1007.rst
@@ -15,7 +15,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and only
+when, they appear in all capitals.
 
 For clarity this ZIP defines these terms:
 
@@ -184,5 +185,5 @@ Raised Concerns
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-1006] `ZIP 1006: Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity <zip-1006.rst>`_

--- a/zip-1008.html
+++ b/zip-1008.html
@@ -16,7 +16,7 @@ Created: 2019-09-02
 License: CC BY-SA 4.0 &lt;<a href="https://creativecommons.org/licenses/by-sa/4.0/">https://creativecommons.org/licenses/by-sa/4.0/</a>&gt;
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/kek-s-proposal-fund-ecc-for-2-more-years/34778">https://forum.zcashcommunity.com/t/kek-s-proposal-fund-ecc-for-2-more-years/34778</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">2</a></p>
+            <p>The key words "MUST" and "MUST NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">2</a> when, and only when, they appear in all capitals.</p>
             <p>For clarity this ZIP defines these terms:</p>
             <ul>
                 <li>Spirit is defined as what is the intended outcome of the ZIP. <a id="footnote-reference-2" class="footnote_reference" href="#spirit">1</a></li>
@@ -66,11 +66,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/kek-s-proposal-f
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>2</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1008.rst
+++ b/zip-1008.rst
@@ -15,7 +15,7 @@ Terminology
 ===========
 
 The key words "MUST" and "MUST NOT" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 For clarity this ZIP defines these terms:
 
@@ -117,6 +117,6 @@ Implications to other users
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0206] `ZIP 206: Deployment of the Blossom Network Upgrade <zip-0206.rst>`_
 .. [#zip-0208] `ZIP 208: Shorter Block Target Spacing <zip-0208.rst>`_

--- a/zip-1010.html
+++ b/zip-1010.html
@@ -21,7 +21,7 @@ Created: 2019-08-31
 License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/a-grand-compromise-synthesis-zip-proposal/34812">https://forum.zcashcommunity.com/t/a-grand-compromise-synthesis-zip-proposal/34812</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">2</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -123,11 +123,11 @@ Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/a-grand-compromi
             </ul>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1010.rst
+++ b/zip-1010.rst
@@ -20,7 +20,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHOULD", and "SHOULD NOT" in this document
-are to be interpreted as described in RFC 2119. [#RFC2119]_
+are to be interpreted as described in BCP 14 [#BCP14]_ when, and only when,
+they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as described
 in ZIP 200. [#zip-0200]_
@@ -342,7 +343,7 @@ Issues and further discussion
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zfnd-guidance] `Zcash Foundation Guidance on Dev Fund Proposals. Zcash Foundation blog, August 6, 2019. <https://www.zfnd.org/blog/dev-fund-guidance-and-timeline/>`_
 .. [#tromer-comment] `Comment on a post “How to hire ECC” in the Zcash Community Forum. Eran Tromer, August 11, 2019. <https://forum.zcashcommunity.com/t/how-to-hire-ecc/34379/55>`_

--- a/zip-1013.html
+++ b/zip-1013.html
@@ -16,7 +16,7 @@ License: Public Domain
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/zip-keep-it-simple-zcashers-kisz-10-to-ecc-10-to-zfnd/35425">https://forum.zcashcommunity.com/t/zip-keep-it-simple-zcashers-kisz-10-to-ecc-10-to-zfnd/35425</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/293">https://github.com/zcash/zips/pull/293</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST" and "SHOULD" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The terms below are to be interpreted as follows:</p>
             <dl>
                 <dt>ECC</dt>
@@ -68,11 +68,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/293">https://githu
             <p>From original "Founders’ Reward"-era development-funds, roughly 15% has been directed to the ZF. (Or, about 3 points of the full 20 points of bootstrap- funds.) However, from its later start, the ZF has recently grown its technical, grantmaking, and organizational capabilities, and wide sentiment in the Zcash community, ECC, and ZF desires the ZF grow to a role of equivalent or greater importance as the ECC for long-term Zcash evolution. Thus this proposal specifies a 50:50 split of future development funds, rather than continuing any prior proportions.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1013.rst
+++ b/zip-1013.rst
@@ -15,7 +15,7 @@ Terminology
 ===========
 
 The key words "MUST" and "SHOULD" in this document are to be interpreted as
-described in RFC 2119. [#RFC2119]_
+described in BCP 14 [#BCP14]_ when, and only when, they appear in all capitals.
 
 
 The terms below are to be interpreted as follows:
@@ -133,4 +133,4 @@ continuing any prior proportions.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_

--- a/zip-1014.html
+++ b/zip-1014.html
@@ -25,7 +25,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://forum.zcashcommunity.com/t/community-sentiment-polling-results-nu4-and-draft-zip-1014/35560">https://forum.zcashcommunity.com/t/community-sentiment-polling-results-nu4-and-draft-zip-1014/35560</a>&gt;
 Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/308">https://github.com/zcash/zips/pull/308</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>The key words "MUST", "MUST NOT", "SHALL", "SHALL NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The key words "MUST", "MUST NOT", "SHALL", "SHALL NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200 <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">6</a> and the Zcash Trademark Donation and License Agreement (<a id="footnote-reference-3" class="footnote_reference" href="#trademark">4</a> or successor agreement).</p>
             <p>The terms "block subsidy" and "halving" in this document are to be interpreted as described in sections 3.10 and 7.8 of the Zcash Protocol Specification. <a id="footnote-reference-4" class="footnote_reference" href="#protocol">2</a></p>
             <p>"Electric Coin Company", also called "ECC", refers to the Zerocoin Electric Coin Company, LLC.</p>
@@ -153,11 +153,11 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/308">https://githu
             <p>The authors are grateful to all of the above for their excellent ideas and any insightful discussions, and to forum users <em>@aristarchus</em> and <em>@dontbeevil</em> for valuable initial comments on ZIP 1012.</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-1014.rst
+++ b/zip-1014.rst
@@ -24,7 +24,8 @@ Terminology
 ===========
 
 The key words "MUST", "MUST NOT", "SHALL", "SHALL NOT", "SHOULD", and "MAY"
-in this document are to be interpreted as described in RFC 2119. [#RFC2119]_
+in this document are to be interpreted as described in BCP 14 [#BCP14]_ when,
+and only when, they appear in all capitals.
 
 The term "network upgrade" in this document is to be interpreted as
 described in ZIP 200 [#zip-0200]_ and the Zcash Trademark Donation and License
@@ -429,7 +430,7 @@ and *@dontbeevil* for valuable initial comments on ZIP 1012.
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2021.2.16 or later <protocol/protocol.pdf>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2021.2.16. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
 .. [#trademark] `Zcash Trademark Donation and License Agreement <https://electriccoin.co/wp-content/uploads/2019/11/Final-Consolidated-Version-ECC-Zcash-Trademark-Transfer-Documents-1.pdf>`_

--- a/zip-guide.html
+++ b/zip-guide.html
@@ -23,7 +23,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/253">https://githu
             <p>{Delete this section.}</p>
         </section>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>{Edit this to reflect the key words that are actually used.} The key words "MUST", "REQUIRED", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>{Edit this to reflect the key words that are actually used.} The key words "MUST", "REQUIRED", "MUST NOT", "SHOULD", and "MAY" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
             <p>{Avoid duplicating definitions from other ZIPs. Instead use wording like this:}</p>
             <p>The terms "Mainnet" and "Testnet" in this document are to be interpreted as defined in the Zcash protocol specification <a id="footnote-reference-2" class="footnote_reference" href="#protocol-networks">5</a>.</p>
             <p>The term "full validator" in this document is to be interpreted as defined in the Zcash protocol specification <a id="footnote-reference-3" class="footnote_reference" href="#protocol-blockchain">4</a>.</p>
@@ -111,11 +111,11 @@ pip3 install docutils==0.19 rst2html5</pre>
             <p>{This section is entirely optional; if present, it usually gives links to zcashd or zebrad PRs.}</p>
         </section>
         <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <table id="rfc2119" class="footnote">
+            <table id="bcp14" class="footnote">
                 <tbody>
                     <tr>
                         <th>1</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc2119.html">RFC 2119: Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/zip-guide.rst
+++ b/zip-guide.rst
@@ -30,7 +30,8 @@ Terminology
 
 {Edit this to reflect the key words that are actually used.}
 The key words "MUST", "REQUIRED", "MUST NOT", "SHOULD", and "MAY" in this
-document are to be interpreted as described in RFC 2119. [#RFC2119]_
+document are to be interpreted as described in BCP 14 [#BCP14]_ when, and
+only when, they appear in all capitals.
 
 {Avoid duplicating definitions from other ZIPs. Instead use wording like this:}
 
@@ -217,7 +218,7 @@ zebrad PRs.}
 References
 ==========
 
-.. [#RFC2119] `RFC 2119: Key words for use in RFCs to Indicate Requirement Levels <https://www.rfc-editor.org/rfc/rfc2119.html>`_
+.. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2022.3.8 or later <protocol/protocol.pdf>`_
 .. [#protocol-introduction] `Zcash Protocol Specification, Version 2022.3.8. Section 1: Introduction <protocol/protocol.pdf#introduction>`_
 .. [#protocol-blockchain] `Zcash Protocol Specification, Version 2022.3.8. Section 3.3: The Block Chain <protocol/protocol.pdf#blockchain>`_


### PR DESCRIPTION
Also change two "should"s in ZIP 224 to "SHOULD"s. fixes #729