### PR TITLE
Add `zsf_deposit` to transaction id and signature digest in ZIP-244

### DIFF
--- a/zip-0244.rst
+++ b/zip-0244.rst
@@ -141,13 +141,14 @@ below::
     │   │   ├── sapling_outputs_memos_digest
     │   │   └── sapling_outputs_noncompact_digest
     │   └── valueBalance
-    └── orchard_digest
-        ├── orchard_actions_compact_digest
-        ├── orchard_actions_memos_digest
-        ├── orchard_actions_noncompact_digest
-        ├── flagsOrchard
-        ├── valueBalanceOrchard
-        └── anchorOrchard
+    ├── orchard_digest
+    |   ├── orchard_actions_compact_digest
+    |   ├── orchard_actions_memos_digest
+    |   ├── orchard_actions_noncompact_digest
+    |   ├── flagsOrchard
+    |   ├── valueBalanceOrchard
+    |   └── anchorOrchard
+    ├── zsf_digest
 
 Each node written as ``snake_case`` in this tree is a BLAKE2b-256 hash of its
 children, initialized with a personalization string specific to that branch
@@ -162,6 +163,7 @@ A BLAKE2b-256 hash of the following values ::
    T.2: transparent_digest  (32-byte hash output)
    T.3: sapling_digest      (32-byte hash output)
    T.4: orchard_digest      (32-byte hash output)
+   T.5: zsf_deposit_digest  (32-byte hash output)
 
 The personalization field of this hash is set to::
 
@@ -447,6 +449,17 @@ The personalization field of this hash is set to::
 
   "ZTxIdOrcActNHash"
 
+T.5: zsf_deposit_digest
+```````````````````````
+
+A BLAKE2b-256 hash of the following values ::
+
+   T.5a: zsf_deposit               (8-byte little-endian Zcash Sustainability Fund deposit amount)
+
+The personalization field of this hash is set to::
+
+  "ZTxIdZsfDepositHash"
+
 Signature Digest
 ================
 
@@ -464,7 +477,8 @@ described in detail below::
     ├── header_digest
     ├── transparent_sig_digest
     ├── sapling_digest
-    └── orchard_digest
+    ├── orchard_digest
+    └── zsf_deposit_digest
 
 signature_digest
 ----------------
@@ -474,6 +488,7 @@ A BLAKE2b-256 hash of the following values ::
    S.2: transparent_sig_digest (32-byte hash output)
    S.3: sapling_digest         (32-byte hash output)
    S.4: orchard_digest         (32-byte hash output)
+   S.5: zsf_deposit_digest     (32-byte hash output)
 
 The personalization field of this hash is set to::
 
@@ -646,6 +661,10 @@ S.3: sapling_digest
 Identical to that specified for the transaction identifier.
 
 S.4: orchard_digest
+```````````````````
+Identical to that specified for the transaction identifier.
+
+S.5: zsf_deposit_digest
 ```````````````````
 Identical to that specified for the transaction identifier.
 


### PR DESCRIPTION
This includes `zsf_deposit` into the transaction id and signature digest calculations.

Needed by #703