### PR TITLE
Formatting and CSS improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,7 +138,7 @@ Index of ZIPs
     <tr> <td>317</td> <td class="left"><a href="zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
     <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318.rst">Associated Payload Encryption</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">320</span></td> <td class="left"><a class="reserved" href="zip-0320.rst">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Reserved</td>
+    <tr> <td>320</td> <td class="left"><a href="zip-0320.rst">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Draft</td>
     <tr> <td>321</td> <td class="left"><a href="zip-0321.rst">Payment Request URIs</a></td> <td>Proposed</td>
     <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322.rst">Generic Signed Message Format</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323.rst">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>

--- a/css/style.css
+++ b/css/style.css
@@ -41,6 +41,9 @@
   aside > p > a:hover {
     color: #00455c;
   }
+  blockquote {
+    background-color: #e0e0e0
+  }
 }
 
 @media (prefers-color-scheme: dark) {
@@ -90,6 +93,9 @@
   }
   aside > p > a:hover {
     color: #90ffff;
+  }
+  blockquote {
+    background-color: #202020
   }
 }
 
@@ -218,8 +224,8 @@ h8 {
 }
 
 blockquote {
-  margin: 0 1rem 1rem 1rem;
-  padding: 0;
+  margin: 0 1rem 1.5rem 1rem;
+  padding: 1rem 1rem 0 1rem;
   overflow-x: auto;
 }
 

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
   <tr> <td>317</td> <td class="left"><a href="zip-0317">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
   <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318">Associated Payload Encryption</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
-  <tr> <td><span class="reserved">320</span></td> <td class="left"><a class="reserved" href="zip-0320">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Reserved</td>
+  <tr> <td>320</td> <td class="left"><a href="zip-0320">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Draft</td>
   <tr> <td>321</td> <td class="left"><a href="zip-0321">Payment Request URIs</a></td> <td>Proposed</td>
   <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322">Generic Signed Message Format</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>

--- a/zip-0320.html
+++ b/zip-0320.html
@@ -98,22 +98,34 @@ console.log(t1)</pre>
                     <span class="math">\(\mathtt{0x04}\)</span>
                 , the value of which MUST be the 20-byte <strong>validating key hash</strong> of a Zcash P2PKH Address as defined in <a id="footnote-reference-16" class="footnote_reference" href="#protocol-transparentaddrencoding">10</a>.</p>
                 <p>The "Requirements for both Unified Addresses and Unified Viewing Keys" section of ZIP 316 <a id="footnote-reference-17" class="footnote_reference" href="#zip-0316-unified-requirements">7</a> will be modified as follows — the text:</p>
-                <pre>A Unified Address or Unified Viewing Key MUST contain at least one
-shielded Item (Typecodes :math:`\mathtt{0x02}` and :math:`\mathtt{0x03}`).
-The rationale is that the existing P2SH and P2PKH transparent-only
-address formats, and the existing P2PKH extended public key format,
-suffice for representing transparent Items and are already supported
-by the existing ecosystem.</pre>
+                <blockquote>
+                    <p>A Unified Address or Unified Viewing Key MUST contain at least one shielded Item (Typecodes
+                        <span class="math">\(\mathtt{0x02}\)</span>
+                     and
+                        <span class="math">\(\mathtt{0x03}\)</span>
+                    ). The rationale is that the existing P2SH and P2PKH transparent-only address formats, and the existing P2PKH extended public key format, suffice for representing transparent Items and are already supported by the existing ecosystem.</p>
+                </blockquote>
                 <p>will be replaced by:</p>
-                <pre>A Unified Address MUST contain at least one Receiver and any number
-of Metadata Items. The selection of Receivers is further restricted
-such that a Unified Address MUST **either**:
-* contain at least one shielded Receiver (Typecodes :math:`\mathtt{0x02}` and :math:`\mathtt{0x03}`),
-  and no Traceable P2PKH Receiver (Typecode :math:`\mathtt{0x04}`); **or**
-* contain **only** a Traceable P2PKH Receiver (Typecode :math:`\mathtt{0x04}`).
-
-A Unified Viewing Key MUST contain at least one shielded Item (Typecodes
-:math:`\mathtt{0x02}` and :math:`\mathtt{0x03}`).</pre>
+                <blockquote>
+                    <p>A Unified Address MUST contain at least one Receiver and any number of Metadata Items. The selection of Receivers is further restricted such that a Unified Address MUST <strong>either</strong>:</p>
+                    <ul>
+                        <li>contain at least one shielded Receiver (Typecodes
+                            <span class="math">\(\mathtt{0x02}\)</span>
+                         and
+                            <span class="math">\(\mathtt{0x03}\)</span>
+                        ), and no Traceable P2PKH Receiver (Typecode
+                            <span class="math">\(\mathtt{0x04}\)</span>
+                        ); <strong>or</strong></li>
+                        <li>contain <strong>only</strong> a Traceable P2PKH Receiver (Typecode
+                            <span class="math">\(\mathtt{0x04}\)</span>
+                        ).</li>
+                    </ul>
+                    <p>A Unified Viewing Key MUST contain at least one shielded Item (Typecodes
+                        <span class="math">\(\mathtt{0x02}\)</span>
+                     and
+                        <span class="math">\(\mathtt{0x03}\)</span>
+                    ).</p>
+                </blockquote>
                 <p>A Traceable Unified Address is produced from a Mainnet Zcash P2PKH address by executing the following steps:</p>
                 <ol type="1">
                     <li>Decode the address to a byte sequence using the Base58Check decoding algorithm <a id="footnote-reference-18" class="footnote_reference" href="#base58check">12</a>.</li>
@@ -193,127 +205,129 @@ expiry time: Mon Feb 13 2024 01:14:18 GMT</pre>
                     <li>Unified Address encoding is slightly more complex than the proposed TEX address encoding, and requires use of the F4Jumble encoding algorithm <a id="footnote-reference-24" class="footnote_reference" href="#f4jumble">13</a>. However, this can be readily mitigated by providing a purpose-built library for Traceable Unified Address encoding to Producers.</li>
                     <li>A Traceable Unified Address is somewhat longer than a TEX address, although not excessively so.</li>
                 </ul>
-                <table id="bcp14" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>1</th>
-                            <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="binance-delisting" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>2</th>
-                            <td><a href="https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954">Zcash Community Forum thread "Important: Potential Binance Delisting"</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="hanh-profile" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>3</th>
-                            <td>'Zcash Community Forum user @hanh &lt;<a href="https://forum.zcashcommunity.com/u/hanh/summary">https://forum.zcashcommunity.com/u/hanh/summary</a>&gt;'_</td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="hanh-suggestion" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>4</th>
-                            <td>'Ywallet developer @hanh's proposal &lt;<a href="https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954/112">https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954/112</a>&gt;'_</td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="zip-0316-terminology" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>5</th>
-                            <td><a href="zip-0316#terminology">ZIP 316: Unified Addresses and Unified Viewing Keys — Terminology</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="zip-0316-unified-addresses" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>6</th>
-                            <td><a href="zip-0316#encoding-of-unified-addresses">ZIP 316: Unified Addresses and Unified Viewing Keys — Encoding of Unified Addresses</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="zip-0316-unified-requirements" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>7</th>
-                            <td><a href="zip-0316#requirements-for-both-unified-addresses-and-unified-viewing-keys">ZIP 316: Unified Addresses and Unified Viewing Keys — Requirements for both Unified Addresses and Unified Viewing Keys</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="zip-0316-address-expiry" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>8</th>
-                            <td><a href="zip-0316#address-expiration-metadata">ZIP 316: Unified Addresses and Unified Viewing Keys — Address Expiration Metadata</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="protocol-networks" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>9</th>
-                            <td><a href="protocol/protocol.pdf#networks">Zcash Protocol Specification, Version 2023.4.0. Section 3.12: Mainnet and Testnet</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="protocol-transparentaddrencoding" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>10</th>
-                            <td><a href="protocol/protocol.pdf#transparentaddrencoding">Zcash Protocol Specification, Version 2023.4.0. Section 5.6.1.1 Transparent Addresses</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="binance-address-expiry" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>11</th>
-                            <td><a href="https://forum.zcashcommunity.com/t/unified-address-expiration/46564/6">Zcash Community Forum post describing motivations for address expiry</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="base58check" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>12</th>
-                            <td><a href="https://en.bitcoin.it/wiki/Base58Check_encoding">Base58Check encoding — Bitcoin Wiki</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="f4jumble" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>13</th>
-                            <td><a href="zip-0316#jumbling">ZIP 316: F4Jumble encoding</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="bip-0350" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>14</th>
-                            <td><a href="https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki">BIP 350: Bech32m format for v1+ witness addresses</a></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table id="zcash-address-wasm" class="footnote">
-                    <tbody>
-                        <tr>
-                            <th>15</th>
-                            <td><a href="https://github.com/nuttycom/zcash_address_wasm">zcash_address_wasm: Proof-of-concept library for Traceable Unified Address Encoding</a></td>
-                        </tr>
-                    </tbody>
-                </table>
             </section>
+        </section>
+        <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <table id="bcp14" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>1</th>
+                        <td><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="binance-delisting" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>2</th>
+                        <td><a href="https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954">Zcash Community Forum thread "Important: Potential Binance Delisting"</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="hanh-profile" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>3</th>
+                        <td><a href="https://forum.zcashcommunity.com/u/hanh/summary">Zcash Community Forum user @hanh</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="hanh-suggestion" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>4</th>
+                        <td><a href="https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954/112">Ywallet developer @hanh's proposal</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0316-terminology" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>5</th>
+                        <td><a href="zip-0316#terminology">ZIP 316: Unified Addresses and Unified Viewing Keys — Terminology</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0316-unified-addresses" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>6</th>
+                        <td><a href="zip-0316#encoding-of-unified-addresses">ZIP 316: Unified Addresses and Unified Viewing Keys — Encoding of Unified Addresses</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0316-unified-requirements" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>7</th>
+                        <td><a href="zip-0316#requirements-for-both-unified-addresses-and-unified-viewing-keys">ZIP 316: Unified Addresses and Unified Viewing Keys — Requirements for both Unified Addresses and Unified Viewing Keys</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0316-address-expiry" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
+                        <td><a href="zip-0316#address-expiration-metadata">ZIP 316: Unified Addresses and Unified Viewing Keys — Address Expiration Metadata</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol-networks" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>9</th>
+                        <td><a href="protocol/protocol.pdf#networks">Zcash Protocol Specification, Version 2023.4.0. Section 3.12: Mainnet and Testnet</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol-transparentaddrencoding" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>10</th>
+                        <td><a href="protocol/protocol.pdf#transparentaddrencoding">Zcash Protocol Specification, Version 2023.4.0. Section 5.6.1.1 Transparent Addresses</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="binance-address-expiry" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>11</th>
+                        <td><a href="https://forum.zcashcommunity.com/t/unified-address-expiration/46564/6">Zcash Community Forum post describing motivations for address expiry</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="base58check" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>12</th>
+                        <td><a href="https://en.bitcoin.it/wiki/Base58Check_encoding">Base58Check encoding — Bitcoin Wiki</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="f4jumble" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>13</th>
+                        <td><a href="zip-0316#jumbling">ZIP 316: Unified Addresses and Unified Viewing Keys — Jumbling</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="bip-0350" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>14</th>
+                        <td><a href="https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki">BIP 350: Bech32m format for v1+ witness addresses</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zcash-address-wasm" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>15</th>
+                        <td><a href="https://github.com/nuttycom/zcash_address_wasm">zcash_address_wasm: Proof-of-concept library for Traceable Unified Address Encoding</a></td>
+                    </tr>
+                </tbody>
+            </table>
         </section>
     </section>
 </body>

--- a/zip-0320.rst
+++ b/zip-0320.rst
@@ -187,7 +187,7 @@ in [#protocol-transparentaddrencoding]_.
 
 The "Requirements for both Unified Addresses and Unified Viewing Keys" section
 of ZIP 316 [#zip-0316-unified-requirements]_ will be modified as follows — the
-text::
+text:
 
   A Unified Address or Unified Viewing Key MUST contain at least one
   shielded Item (Typecodes :math:`\mathtt{0x02}` and :math:`\mathtt{0x03}`).
@@ -196,13 +196,15 @@ text::
   suffice for representing transparent Items and are already supported
   by the existing ecosystem.
 
-will be replaced by::
+will be replaced by:
 
   A Unified Address MUST contain at least one Receiver and any number
   of Metadata Items. The selection of Receivers is further restricted 
   such that a Unified Address MUST **either**:
-  * contain at least one shielded Receiver (Typecodes :math:`\mathtt{0x02}` and :math:`\mathtt{0x03}`),
-    and no Traceable P2PKH Receiver (Typecode :math:`\mathtt{0x04}`); **or**
+
+  * contain at least one shielded Receiver (Typecodes :math:`\mathtt{0x02}`
+    and :math:`\mathtt{0x03}`), and no Traceable P2PKH Receiver (Typecode
+    :math:`\mathtt{0x04}`); **or**
   * contain **only** a Traceable P2PKH Receiver (Typecode :math:`\mathtt{0x04}`).
 
   A Unified Viewing Key MUST contain at least one shielded Item (Typecodes
@@ -344,10 +346,13 @@ Cons to Alternative 2
 - A Traceable Unified Address is somewhat longer than a TEX address, although
   not excessively so.
 
+References
+==========
+
 .. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
 .. [#binance-delisting] `Zcash Community Forum thread "Important: Potential Binance Delisting" <https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954>`_
-.. [#hanh-profile] 'Zcash Community Forum user @hanh <https://forum.zcashcommunity.com/u/hanh/summary>'_
-.. [#hanh-suggestion] 'Ywallet developer @hanh's proposal <https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954/112>'_
+.. [#hanh-profile] `Zcash Community Forum user @hanh <https://forum.zcashcommunity.com/u/hanh/summary>`_
+.. [#hanh-suggestion] `Ywallet developer @hanh's proposal <https://forum.zcashcommunity.com/t/important-potential-binance-delisting/45954/112>`_
 .. [#zip-0316-terminology] `ZIP 316: Unified Addresses and Unified Viewing Keys — Terminology <zip-0316#terminology>`_
 .. [#zip-0316-unified-addresses] `ZIP 316: Unified Addresses and Unified Viewing Keys — Encoding of Unified Addresses <zip-0316#encoding-of-unified-addresses>`_
 .. [#zip-0316-unified-requirements] `ZIP 316: Unified Addresses and Unified Viewing Keys — Requirements for both Unified Addresses and Unified Viewing Keys <zip-0316#requirements-for-both-unified-addresses-and-unified-viewing-keys>`_


### PR DESCRIPTION
* ZIP 320: use normal block quote for modified sections of ZIP 316 rather than a literal block.
* ZIP 320: add References heading.
* ZIP 320: fix incorrect markup in two references.
* CSS: adjust padding of block quotes and give them a grey background (light grey for light theme, dark grey for dark theme).
* Regenerate README and index.