### PR TITLE
Fix formatting of bulleted lists

### DIFF
--- a/zip-0316.rst
+++ b/zip-0316.rst
@@ -323,11 +323,13 @@ A Revision 0 UA/UVK is distinguished from a Revision 1 UA/UVK by its
 Human-Readable Part, as follows.
 
 Let *prefix* be:
+
 * “``u``”, if this is a UA/UVK prior to `Revision 1`_;
 * “``ur``”, if this is a UA/UVK from `Revision 1`_ onward.
 
 The Human-Readable Parts (as defined in [#bip-0350]_) of Unified
 Addresses are defined as:
+
 * *prefix*, for Unified Addresses on Mainnet;
 * *prefix* || “``test``”, for Unified Addresses on Testnet.
 


### PR DESCRIPTION
See how the extra line makes the bullets appear correctly where the blank lines are present, but the bullets show up as inline asterisks where there are no blank lines:

<img width="935" alt="image" src="https://github.com/zcash/zips/assets/3548/4efb9877-d7cb-4ab7-b53e-5d85fd5396d5">
