### PR TITLE
Remove specific author names related to prior work from the credits of dev fund proposals.

### DIFF
--- a/draft-noamchom67-manufacturing-consent.html
+++ b/draft-noamchom67-manufacturing-consent.html
@@ -9,16 +9,7 @@
         <pre>ZIP: ####
 Title: Manufacturing Consent; Re-Establishing a Dev Fund for ECC, ZF, ZCG, Qedit, FPF, and ZecHub
 Owner: Noam Chom &lt;noamchom1967@gmail.com&gt;
-ZIP-1014 Owners: Andrew Miller &lt;socrates1024@gmail.com&gt;
-        Zooko Wilcox &lt;zooko@electriccoin.co&gt;
-ZIP-1014 Original-Authors: Eran Tromer
-ZIP-1014 Credits: Matt Luongo
-         @aristarchus
-         @dontbeevil
-         Daira Emma Hopwood
-         George Tankersley
-         Josh Cincinnati
-         Andrew Miller
+Credits: The ZIP-1014 Authors
 Status: Active
 Category: Consensus Process
 Created: 2024-06-25

--- a/draft-noamchom67-manufacturing-consent.rst
+++ b/draft-noamchom67-manufacturing-consent.rst
@@ -3,16 +3,7 @@
   ZIP: ####
   Title: Manufacturing Consent; Re-Establishing a Dev Fund for ECC, ZF, ZCG, Qedit, FPF, and ZecHub
   Owner: Noam Chom <noamchom1967@gmail.com>
-  ZIP-1014 Owners: Andrew Miller <socrates1024@gmail.com>
-          Zooko Wilcox <zooko@electriccoin.co>
-  ZIP-1014 Original-Authors: Eran Tromer
-  ZIP-1014 Credits: Matt Luongo
-           @aristarchus
-           @dontbeevil
-           Daira Emma Hopwood
-           George Tankersley
-           Josh Cincinnati
-           Andrew Miller
+  Credits: The ZIP-1014 Authors
   Status: Active
   Category: Consensus Process
   Created: 2024-06-25

--- a/draft-zf-community-dev-fund-2-proposal.html
+++ b/draft-zf-community-dev-fund-2-proposal.html
@@ -9,14 +9,7 @@
         <pre>ZIP: Unassigned
 Title: Establishing a Hybrid Dev Fund for ZF, ZCG and a Dev Fund Reserve
 Owners: Jack Gavigan &lt;jack@zfnd.org&gt;
-Credits: Eran Tromer
-         Andrew Miller
-         Matt Luongo
-         @aristarchus
-         @dontbeevil
-         Daira Emma Hopwood
-         George Tankersley
-         Josh Cincinnati
+Credits: The ZIP 1014 Authors
 Status: Draft
 Category: Consensus Process
 Created: 2024-07-01

--- a/draft-zf-community-dev-fund-2-proposal.rst
+++ b/draft-zf-community-dev-fund-2-proposal.rst
@@ -3,14 +3,7 @@
   ZIP: Unassigned
   Title: Establishing a Hybrid Dev Fund for ZF, ZCG and a Dev Fund Reserve
   Owners: Jack Gavigan <jack@zfnd.org>
-  Credits: Eran Tromer
-           Andrew Miller
-           Matt Luongo
-           @aristarchus
-           @dontbeevil
-           Daira Emma Hopwood
-           George Tankersley
-           Josh Cincinnati
+  Credits: The ZIP 1014 Authors
   Status: Draft
   Category: Consensus Process
   Created: 2024-07-01


### PR DESCRIPTION
Zooko pointed out that including his name in any proposal could be misleading; in the interest of eliminating such issues I propose that only authors who have specifically requested inclusion in the credits for prior work be included.