### PR TITLE
Add separate tables for Released, Draft, and struck ZIPs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,155 @@ contents of this repository are released under the terms of the MIT
 license. See `COPYING <COPYING.rst>`__ for more information or see
 https://opensource.org/licenses/MIT .
 
+Released ZIPs
+-------------
+
+.. raw:: html
+
+  <embed><table>
+    <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+    <tr> <td>0</td> <td class="left"><a href="zips/zip-0000.rst">ZIP Process</a></td> <td>Active</td>
+    <tr> <td>32</td> <td class="left"><a href="zips/zip-0032.rst">Shielded Hierarchical Deterministic Wallets</a></td> <td>Final</td>
+    <tr> <td>143</td> <td class="left"><a href="zips/zip-0143.rst">Transaction Signature Validation for Overwinter</a></td> <td>Final</td>
+    <tr> <td>155</td> <td class="left"><a href="zips/zip-0155.rst">addrv2 message</a></td> <td>Proposed</td>
+    <tr> <td>173</td> <td class="left"><a href="zips/zip-0173.rst">Bech32 Format</a></td> <td>Final</td>
+    <tr> <td>200</td> <td class="left"><a href="zips/zip-0200.rst">Network Upgrade Mechanism</a></td> <td>Final</td>
+    <tr> <td>201</td> <td class="left"><a href="zips/zip-0201.rst">Network Peer Management for Overwinter</a></td> <td>Final</td>
+    <tr> <td>202</td> <td class="left"><a href="zips/zip-0202.rst">Version 3 Transaction Format for Overwinter</a></td> <td>Final</td>
+    <tr> <td>203</td> <td class="left"><a href="zips/zip-0203.rst">Transaction Expiry</a></td> <td>Final</td>
+    <tr> <td>205</td> <td class="left"><a href="zips/zip-0205.rst">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>206</td> <td class="left"><a href="zips/zip-0206.rst">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>207</td> <td class="left"><a href="zips/zip-0207.rst">Funding Streams</a></td> <td>Final</td>
+    <tr> <td>208</td> <td class="left"><a href="zips/zip-0208.rst">Shorter Block Target Spacing</a></td> <td>Final</td>
+    <tr> <td>209</td> <td class="left"><a href="zips/zip-0209.rst">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
+    <tr> <td>211</td> <td class="left"><a href="zips/zip-0211.rst">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
+    <tr> <td>212</td> <td class="left"><a href="zips/zip-0212.rst">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
+    <tr> <td>213</td> <td class="left"><a href="zips/zip-0213.rst">Shielded Coinbase</a></td> <td>Final</td>
+    <tr> <td>214</td> <td class="left"><a href="zips/zip-0214.rst">Consensus rules for a Zcash Development Fund</a></td> <td>Final</td>
+    <tr> <td>215</td> <td class="left"><a href="zips/zip-0215.rst">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
+    <tr> <td>216</td> <td class="left"><a href="zips/zip-0216.rst">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
+    <tr> <td>221</td> <td class="left"><a href="zips/zip-0221.rst">FlyClient - Consensus-Layer Changes</a></td> <td>Final</td>
+    <tr> <td>224</td> <td class="left"><a href="zips/zip-0224.rst">Orchard Shielded Protocol</a></td> <td>Final</td>
+    <tr> <td>225</td> <td class="left"><a href="zips/zip-0225.rst">Version 5 Transaction Format</a></td> <td>Final</td>
+    <tr> <td>239</td> <td class="left"><a href="zips/zip-0239.rst">Relay of Version 5 Transactions</a></td> <td>Final</td>
+    <tr> <td>243</td> <td class="left"><a href="zips/zip-0243.rst">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
+    <tr> <td>244</td> <td class="left"><a href="zips/zip-0244.rst">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
+    <tr> <td>250</td> <td class="left"><a href="zips/zip-0250.rst">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>251</td> <td class="left"><a href="zips/zip-0251.rst">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>252</td> <td class="left"><a href="zips/zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>300</td> <td class="left"><a href="zips/zip-0300.rst">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
+    <tr> <td>301</td> <td class="left"><a href="zips/zip-0301.rst">Zcash Stratum Protocol</a></td> <td>Final</td>
+    <tr> <td>308</td> <td class="left"><a href="zips/zip-0308.rst">Sprout to Sapling Migration</a></td> <td>Final</td>
+    <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>Revision 0: Final, Revision 1: Proposed</td>
+    <tr> <td>317</td> <td class="left"><a href="zips/zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
+    <tr> <td>320</td> <td class="left"><a href="zips/zip-0320.rst">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Proposed</td>
+    <tr> <td>321</td> <td class="left"><a href="zips/zip-0321.rst">Payment Request URIs</a></td> <td>Proposed</td>
+    <tr> <td>401</td> <td class="left"><a href="zips/zip-0401.rst">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
+    <tr> <td>1014</td> <td class="left"><a href="zips/zip-1014.rst">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
+  </table></embed>
+
+Draft ZIPs
+----------
+
+These are works-in-progress that have been assigned ZIP numbers. These will
+eventually become either Proposed (and thus Released), or one of Withdrawn,
+Rejected, or Obsolete.
+
+In some cases a ZIP number is reserved by the ZIP Editors before a draft is
+written.
+
+.. raw:: html
+
+  <embed><table>
+    <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+    <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zips/zip-0001.rst">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zips/zip-0002.rst">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zips/zip-0076.rst">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zips/zip-0204.rst">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zips/zip-0217.rst">Aggregate Signatures</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zips/zip-0219.rst">Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>Reserved</td>
+    <tr> <td>222</td> <td class="left"><a href="zips/zip-0222.rst">Transparent Zcash Extensions</a></td> <td>Draft</td>
+    <tr> <td>226</td> <td class="left"><a href="zips/zip-0226.rst">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td>
+    <tr> <td>227</td> <td class="left"><a href="zips/zip-0227.rst">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">228</span></td> <td class="left"><a class="reserved" href="zips/zip-0228.rst">Asset Swaps for Zcash Shielded Assets</a></td> <td>Reserved</td>
+    <tr> <td>230</td> <td class="left"><a href="zips/zip-0230.rst">Version 6 Transaction Format</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">231</span></td> <td class="left"><a class="reserved" href="zips/zip-0231.rst">Decouple Memos from Transaction Outputs</a></td> <td>Reserved</td>
+    <tr> <td>245</td> <td class="left"><a href="zips/zip-0245.rst">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">253</span></td> <td class="left"><a class="reserved" href="zips/zip-0253.rst">Deployment of the NU6 Network Upgrade</a></td> <td>Reserved</td>
+    <tr> <td>302</td> <td class="left"><a href="zips/zip-0302.rst">Standardized Memo Field Format</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zips/zip-0303.rst">Sprout Payment Disclosure</a></td> <td>Reserved</td>
+    <tr> <td>304</td> <td class="left"><a href="zips/zip-0304.rst">Sapling Address Signatures</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">305</span></td> <td class="left"><a class="reserved" href="zips/zip-0305.rst">Best Practices for Hardware Wallets supporting Sapling</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">306</span></td> <td class="left"><a class="reserved" href="zips/zip-0306.rst">Security Considerations for Anchor Selection</a></td> <td>Reserved</td>
+    <tr> <td>307</td> <td class="left"><a href="zips/zip-0307.rst">Light Client Protocol for Payment Detection</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zips/zip-0309.rst">Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>Reserved</td>
+    <tr> <td>310</td> <td class="left"><a href="zips/zip-0310.rst">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zips/zip-0311.rst">Sapling Payment Disclosure</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zips/zip-0312.rst">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zips/zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
+    <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zips/zip-0318.rst">Associated Payload Encryption</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zips/zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zips/zip-0322.rst">Generic Signed Message Format</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zips/zip-0323.rst">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>
+    <tr> <td>324</td> <td class="left"><a href="zips/zip-0324.rst">URI-Encapsulated Payments</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zips/zip-0332.rst">Wallet Recovery from zcashd HD Seeds</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zips/zip-0339.rst">Wallet Recovery Words</a></td> <td>Reserved</td>
+    <tr> <td>400</td> <td class="left"><a href="zips/zip-0400.rst">Wallet.dat format</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zips/zip-0402.rst">New Wallet Database Format</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zips/zip-0403.rst">Verification Behaviour of zcashd</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zips/zip-0416.rst">Support for Unified Addresses in zcashd</a></td> <td>Reserved</td>
+    <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td>
+    <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td>
+  </table></embed>
+
+Drafts without assigned ZIP numbers
+-----------------------------------
+
+These are works-in-progress, and may never be assigned ZIP numbers if their
+ideas become obsoleted or abandoned. Do not assume that these drafts will exist
+in perpetuity; instead assume that they will either move to a numbered ZIP, or
+be deleted.
+
+.. raw:: html
+
+  <embed><table>
+    <tr> <th>Title</th> </tr>
+    <tr> <td class="left"><a href="zips/draft-hopwood-coinbase-balance.rst">Blocks should balance exactly</a></td>
+    <tr> <td class="left"><a href="zips/draft-noamchom67-manufacturing-consent.rst">Manufacturing Consent; Re-Establishing a Dev Fund for ECC, ZF, ZCG, Qedit, FPF, and ZecHub</a></td>
+    <tr> <td class="left"><a href="zips/draft-nuttycom-funding-allocation.rst">Block Reward Allocation for Non-Direct Development Funding</a></td>
+    <tr> <td class="left"><a href="zips/draft-nuttycom-lockbox-streams.rst">Lockbox Funding Streams</a></td>
+    <tr> <td class="left"><a href="zips/draft-zf-community-dev-fund-2-proposal.rst">Establishing a Hybrid Dev Fund for ZF, ZCG and a Dev Fund Reserve</a></td>
+  </table></embed>
+
+Withdrawn, Rejected, or Obsolete ZIPs
+-------------------------------------
+
+.. raw:: html
+
+  <details>
+  <summary>Click to show/hide</summary>
+  <embed><table>
+    <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+    <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zips/zip-0210.rst">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
+    <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zips/zip-0220.rst">Zcash Shielded Assets</a></strike></td> <td>Withdrawn</td>
+    <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zips/zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zips/zip-1001.rst">Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zips/zip-1002.rst">Opt-in Donation Feature</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zips/zip-1003.rst">20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1004</strike></td> <td class="left"><strike><a href="zips/zip-1004.rst">Miner-Directed Dev Fund</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1005</strike></td> <td class="left"><strike><a href="zips/zip-1005.rst">Zcash Community Funding System</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1006</strike></td> <td class="left"><strike><a href="zips/zip-1006.rst">Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1007</strike></td> <td class="left"><strike><a href="zips/zip-1007.rst">Enforce Development Fund Commitments with a Legal Charter</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1008</strike></td> <td class="left"><strike><a href="zips/zip-1008.rst">Fund ECC for Two More Years</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1009</strike></td> <td class="left"><strike><a href="zips/zip-1009.rst">Five-Entity Strategic Council</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1010</strike></td> <td class="left"><strike><a href="zips/zip-1010.rst">Compromise Dev Fund Proposal With Diverse Funding Streams</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1011</strike></td> <td class="left"><strike><a href="zips/zip-1011.rst">Decentralize the Dev Fee</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1012</strike></td> <td class="left"><strike><a href="zips/zip-1012.rst">Dev Fund to ECC + ZF + Major Grants</a></strike></td> <td>Obsolete</td>
+    <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zips/zip-1013.rst">Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>Obsolete</td>
+  </table></embed>
+  </details>
+
 Index of ZIPs
 -------------
 
@@ -148,23 +297,4 @@ Index of ZIPs
     <tr> <td>1014</td> <td class="left"><a href="zips/zip-1014.rst">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
     <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td>
     <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td>
-  </table></embed>
-
-Drafts without assigned ZIP numbers
------------------------------------
-
-These are works-in-progress, and may never be assigned ZIP numbers if their
-ideas become obsoleted or abandoned. Do not assume that these drafts will exist
-in perpetuity; instead assume that they will either move to a numbered ZIP, or
-be deleted.
-
-.. raw:: html
-
-  <embed><table>
-    <tr> <th>Title</th> </tr>
-    <tr> <td class="left"><a href="zips/draft-hopwood-coinbase-balance.rst">Blocks should balance exactly</a></td>
-    <tr> <td class="left"><a href="zips/draft-noamchom67-manufacturing-consent.rst">Manufacturing Consent; Re-Establishing a Dev Fund for ECC, ZF, ZCG, Qedit, FPF, and ZecHub</a></td>
-    <tr> <td class="left"><a href="zips/draft-nuttycom-funding-allocation.rst">Block Reward Allocation for Non-Direct Development Funding</a></td>
-    <tr> <td class="left"><a href="zips/draft-nuttycom-lockbox-streams.rst">Lockbox Funding Streams</a></td>
-    <tr> <td class="left"><a href="zips/draft-zf-community-dev-fund-2-proposal.rst">Establishing a Hybrid Dev Fund for ZF, ZCG and a Dev Fund Reserve</a></td>
   </table></embed>

--- a/makeindex.sh
+++ b/makeindex.sh
@@ -2,7 +2,7 @@
 
 cat <<EndOfHeader
 
-Index of ZIPs
+Released ZIPs
 -------------
 
 .. raw:: html
@@ -12,12 +12,39 @@ Index of ZIPs
 EndOfHeader
 for zipfile in $(cat .zipfilelist.current); do
   zipfile=zips/$zipfile
-  echo Adding $zipfile to index. >/dev/stderr
-  if grep -E '^\s*Status:\s*Reserved' $zipfile >/dev/null; then
-    echo "    <tr> <td><span class=\"reserved\">`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</span></td> <td class=\"left\"><a class=\"reserved\" href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
-  elif grep -E '^\s*Status:\s*(Withdrawn|Rejected|Obsolete)' $zipfile >/dev/null; then
-    echo "    <tr> <td><strike>`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</strike></td> <td class=\"left\"><strike><a href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></strike></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  if grep -E '^\s*Status:\s*(Reserved|Draft|Withdrawn|Rejected|Obsolete)' $zipfile >/dev/null; then
+    # Handled below.
+    true
   else
+    echo Adding $zipfile to released index. >/dev/stderr
+    echo "    <tr> <td>`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</td> <td class=\"left\"><a href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  fi
+done
+cat <<EndOfDraftZipHeader
+  </table></embed>
+
+Draft ZIPs
+----------
+
+These are works-in-progress that have been assigned ZIP numbers. These will
+eventually become either Proposed (and thus Released), or one of Withdrawn,
+Rejected, or Obsolete.
+
+In some cases a ZIP number is reserved by the ZIP Editors before a draft is
+written.
+
+.. raw:: html
+
+  <embed><table>
+    <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+EndOfDraftZipHeader
+for zipfile in $(cat .zipfilelist.current); do
+  zipfile=zips/$zipfile
+  if grep -E '^\s*Status:\s*Reserved' $zipfile >/dev/null; then
+    echo Adding $zipfile to draft index. >/dev/stderr
+    echo "    <tr> <td><span class=\"reserved\">`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</span></td> <td class=\"left\"><a class=\"reserved\" href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  elif grep -E '^\s*Status:\s*Draft' $zipfile >/dev/null; then
+    echo Adding $zipfile to draft index. >/dev/stderr
     echo "    <tr> <td>`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</td> <td class=\"left\"><a href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
   fi
 done
@@ -47,3 +74,48 @@ EndOfDraftHeader
   done
   echo "  </table></embed>"
 fi
+
+cat <<EndOfStrikeHeader
+
+Withdrawn, Rejected, or Obsolete ZIPs
+-------------------------------------
+
+.. raw:: html
+
+  <details>
+  <summary>Click to show/hide</summary>
+  <embed><table>
+    <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+EndOfStrikeHeader
+for zipfile in $(cat .zipfilelist.current); do
+  zipfile=zips/$zipfile
+  if grep -E '^\s*Status:\s*(Withdrawn|Rejected|Obsolete)' $zipfile >/dev/null; then
+    echo Adding $zipfile to struck index. >/dev/stderr
+    echo "    <tr> <td><strike>`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</strike></td> <td class=\"left\"><strike><a href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></strike></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  fi
+done
+
+cat <<EndOfIndexHeader
+  </table></embed>
+  </details>
+
+Index of ZIPs
+-------------
+
+.. raw:: html
+
+  <embed><table>
+    <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+EndOfIndexHeader
+for zipfile in $(cat .zipfilelist.current); do
+  zipfile=zips/$zipfile
+  echo Adding $zipfile to index. >/dev/stderr
+  if grep -E '^\s*Status:\s*Reserved' $zipfile >/dev/null; then
+    echo "    <tr> <td><span class=\"reserved\">`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</span></td> <td class=\"left\"><a class=\"reserved\" href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  elif grep -E '^\s*Status:\s*(Withdrawn|Rejected|Obsolete)' $zipfile >/dev/null; then
+    echo "    <tr> <td><strike>`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</strike></td> <td class=\"left\"><strike><a href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></strike></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  else
+    echo "    <tr> <td>`basename $(basename $zipfile .rst) .md | sed -E 's@zip-0{0,3}@@'`</td> <td class=\"left\"><a href=\"`echo $zipfile`\">`grep '^\s*Title:' $zipfile | sed -E 's@\s*Title:\s*@@'`</a></td> <td>`grep '^\s*Status:' $zipfile | sed -E 's@\s*Status:\s*@@'`</td>"
+  fi
+done
+echo "  </table></embed>"

--- a/rendered/index.html
+++ b/rendered/index.html
@@ -27,6 +27,126 @@
         <section id="license"><h2><span class="section-heading">License</span><span class="section-anchor"> <a rel="bookmark" href="#license"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>Unless otherwise stated in this repository’s individual files, the contents of this repository are released under the terms of the MIT license. See <a href="COPYING">COPYING</a> for more information or see <a href="https://opensource.org/licenses/MIT">https://opensource.org/licenses/MIT</a> .</p>
         </section>
+        <section id="released-zips"><h2><span class="section-heading">Released ZIPs</span><span class="section-anchor"> <a rel="bookmark" href="#released-zips"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+        <embed><table>
+  <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+  <tr> <td>0</td> <td class="left"><a href="zip-0000">ZIP Process</a></td> <td>Active</td>
+  <tr> <td>32</td> <td class="left"><a href="zip-0032">Shielded Hierarchical Deterministic Wallets</a></td> <td>Final</td>
+  <tr> <td>143</td> <td class="left"><a href="zip-0143">Transaction Signature Validation for Overwinter</a></td> <td>Final</td>
+  <tr> <td>155</td> <td class="left"><a href="zip-0155">addrv2 message</a></td> <td>Proposed</td>
+  <tr> <td>173</td> <td class="left"><a href="zip-0173">Bech32 Format</a></td> <td>Final</td>
+  <tr> <td>200</td> <td class="left"><a href="zip-0200">Network Upgrade Mechanism</a></td> <td>Final</td>
+  <tr> <td>201</td> <td class="left"><a href="zip-0201">Network Peer Management for Overwinter</a></td> <td>Final</td>
+  <tr> <td>202</td> <td class="left"><a href="zip-0202">Version 3 Transaction Format for Overwinter</a></td> <td>Final</td>
+  <tr> <td>203</td> <td class="left"><a href="zip-0203">Transaction Expiry</a></td> <td>Final</td>
+  <tr> <td>205</td> <td class="left"><a href="zip-0205">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
+  <tr> <td>206</td> <td class="left"><a href="zip-0206">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
+  <tr> <td>207</td> <td class="left"><a href="zip-0207">Funding Streams</a></td> <td>Final</td>
+  <tr> <td>208</td> <td class="left"><a href="zip-0208">Shorter Block Target Spacing</a></td> <td>Final</td>
+  <tr> <td>209</td> <td class="left"><a href="zip-0209">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
+  <tr> <td>211</td> <td class="left"><a href="zip-0211">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
+  <tr> <td>212</td> <td class="left"><a href="zip-0212">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
+  <tr> <td>213</td> <td class="left"><a href="zip-0213">Shielded Coinbase</a></td> <td>Final</td>
+  <tr> <td>214</td> <td class="left"><a href="zip-0214">Consensus rules for a Zcash Development Fund</a></td> <td>Final</td>
+  <tr> <td>215</td> <td class="left"><a href="zip-0215">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
+  <tr> <td>216</td> <td class="left"><a href="zip-0216">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
+  <tr> <td>221</td> <td class="left"><a href="zip-0221">FlyClient - Consensus-Layer Changes</a></td> <td>Final</td>
+  <tr> <td>224</td> <td class="left"><a href="zip-0224">Orchard Shielded Protocol</a></td> <td>Final</td>
+  <tr> <td>225</td> <td class="left"><a href="zip-0225">Version 5 Transaction Format</a></td> <td>Final</td>
+  <tr> <td>239</td> <td class="left"><a href="zip-0239">Relay of Version 5 Transactions</a></td> <td>Final</td>
+  <tr> <td>243</td> <td class="left"><a href="zip-0243">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
+  <tr> <td>244</td> <td class="left"><a href="zip-0244">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
+  <tr> <td>250</td> <td class="left"><a href="zip-0250">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
+  <tr> <td>251</td> <td class="left"><a href="zip-0251">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
+  <tr> <td>252</td> <td class="left"><a href="zip-0252">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
+  <tr> <td>300</td> <td class="left"><a href="zip-0300">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
+  <tr> <td>301</td> <td class="left"><a href="zip-0301">Zcash Stratum Protocol</a></td> <td>Final</td>
+  <tr> <td>308</td> <td class="left"><a href="zip-0308">Sprout to Sapling Migration</a></td> <td>Final</td>
+  <tr> <td>316</td> <td class="left"><a href="zip-0316">Unified Addresses and Unified Viewing Keys</a></td> <td>Revision 0: Final, Revision 1: Proposed</td>
+  <tr> <td>317</td> <td class="left"><a href="zip-0317">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
+  <tr> <td>320</td> <td class="left"><a href="zip-0320">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Proposed</td>
+  <tr> <td>321</td> <td class="left"><a href="zip-0321">Payment Request URIs</a></td> <td>Proposed</td>
+  <tr> <td>401</td> <td class="left"><a href="zip-0401">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
+  <tr> <td>1014</td> <td class="left"><a href="zip-1014">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
+</table></embed></section>
+        <section id="draft-zips"><h2><span class="section-heading">Draft ZIPs</span><span class="section-anchor"> <a rel="bookmark" href="#draft-zips"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>These are works-in-progress that have been assigned ZIP numbers. These will eventually become either Proposed (and thus Released), or one of Withdrawn, Rejected, or Obsolete.</p>
+            <p>In some cases a ZIP number is reserved by the ZIP Editors before a draft is written.</p>
+        <embed><table>
+  <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+  <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217">Aggregate Signatures</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zip-0219">Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>Reserved</td>
+  <tr> <td>222</td> <td class="left"><a href="zip-0222">Transparent Zcash Extensions</a></td> <td>Draft</td>
+  <tr> <td>226</td> <td class="left"><a href="zip-0226">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td>
+  <tr> <td>227</td> <td class="left"><a href="zip-0227">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">228</span></td> <td class="left"><a class="reserved" href="zip-0228">Asset Swaps for Zcash Shielded Assets</a></td> <td>Reserved</td>
+  <tr> <td>230</td> <td class="left"><a href="zip-0230">Version 6 Transaction Format</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">231</span></td> <td class="left"><a class="reserved" href="zip-0231">Decouple Memos from Transaction Outputs</a></td> <td>Reserved</td>
+  <tr> <td>245</td> <td class="left"><a href="zip-0245">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">253</span></td> <td class="left"><a class="reserved" href="zip-0253">Deployment of the NU6 Network Upgrade</a></td> <td>Reserved</td>
+  <tr> <td>302</td> <td class="left"><a href="zip-0302">Standardized Memo Field Format</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zip-0303">Sprout Payment Disclosure</a></td> <td>Reserved</td>
+  <tr> <td>304</td> <td class="left"><a href="zip-0304">Sapling Address Signatures</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">305</span></td> <td class="left"><a class="reserved" href="zip-0305">Best Practices for Hardware Wallets supporting Sapling</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">306</span></td> <td class="left"><a class="reserved" href="zip-0306">Security Considerations for Anchor Selection</a></td> <td>Reserved</td>
+  <tr> <td>307</td> <td class="left"><a href="zip-0307">Light Client Protocol for Payment Detection</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zip-0309">Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>Reserved</td>
+  <tr> <td>310</td> <td class="left"><a href="zip-0310">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311">Sapling Payment Disclosure</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
+  <tr> <td>315</td> <td class="left"><a href="zip-0315">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zip-0318">Associated Payload Encryption</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zip-0319">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zip-0322">Generic Signed Message Format</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zip-0323">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>
+  <tr> <td>324</td> <td class="left"><a href="zip-0324">URI-Encapsulated Payments</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zip-0332">Wallet Recovery from zcashd HD Seeds</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zip-0339">Wallet Recovery Words</a></td> <td>Reserved</td>
+  <tr> <td>400</td> <td class="left"><a href="zip-0400">Wallet.dat format</a></td> <td>Draft</td>
+  <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zip-0402">New Wallet Database Format</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zip-0403">Verification Behaviour of zcashd</a></td> <td>Reserved</td>
+  <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zip-0416">Support for Unified Addresses in zcashd</a></td> <td>Reserved</td>
+  <tr> <td>guide-markdown</td> <td class="left"><a href="zip-guide-markdown">{Something Short and To the Point}</a></td> <td>Draft</td>
+  <tr> <td>guide</td> <td class="left"><a href="zip-guide">{Something Short and To the Point}</a></td> <td>Draft</td>
+</table></embed></section>
+        <section id="drafts-without-assigned-zip-numbers"><h2><span class="section-heading">Drafts without assigned ZIP numbers</span><span class="section-anchor"> <a rel="bookmark" href="#drafts-without-assigned-zip-numbers"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>These are works-in-progress, and may never be assigned ZIP numbers if their ideas become obsoleted or abandoned. Do not assume that these drafts will exist in perpetuity; instead assume that they will either move to a numbered ZIP, or be deleted.</p>
+        <embed><table>
+  <tr> <th>Title</th> </tr>
+  <tr> <td class="left"><a href="draft-hopwood-coinbase-balance">Blocks should balance exactly</a></td>
+  <tr> <td class="left"><a href="draft-noamchom67-manufacturing-consent">Manufacturing Consent; Re-Establishing a Dev Fund for ECC, ZF, ZCG, Qedit, FPF, and ZecHub</a></td>
+  <tr> <td class="left"><a href="draft-nuttycom-funding-allocation">Block Reward Allocation for Non-Direct Development Funding</a></td>
+  <tr> <td class="left"><a href="draft-nuttycom-lockbox-streams">Lockbox Funding Streams</a></td>
+  <tr> <td class="left"><a href="draft-zf-community-dev-fund-2-proposal">Establishing a Hybrid Dev Fund for ZF, ZCG and a Dev Fund Reserve</a></td>
+</table></embed></section>
+        <section id="withdrawn-rejected-or-obsolete-zips"><h2><span class="section-heading">Withdrawn, Rejected, or Obsolete ZIPs</span><span class="section-anchor"> <a rel="bookmark" href="#withdrawn-rejected-or-obsolete-zips"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+        <details>
+<summary>Click to show/hide</summary>
+<embed><table>
+  <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
+  <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zip-0210">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
+  <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zip-0220">Zcash Shielded Assets</a></strike></td> <td>Withdrawn</td>
+  <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zip-0313">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zip-1001">Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zip-1002">Opt-in Donation Feature</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zip-1003">20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1004</strike></td> <td class="left"><strike><a href="zip-1004">Miner-Directed Dev Fund</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1005</strike></td> <td class="left"><strike><a href="zip-1005">Zcash Community Funding System</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1006</strike></td> <td class="left"><strike><a href="zip-1006">Development Fund of 10% to a 2-of-3 Multisig with Community-Involved Third Entity</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1007</strike></td> <td class="left"><strike><a href="zip-1007">Enforce Development Fund Commitments with a Legal Charter</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1008</strike></td> <td class="left"><strike><a href="zip-1008">Fund ECC for Two More Years</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1009</strike></td> <td class="left"><strike><a href="zip-1009">Five-Entity Strategic Council</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1010</strike></td> <td class="left"><strike><a href="zip-1010">Compromise Dev Fund Proposal With Diverse Funding Streams</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1011</strike></td> <td class="left"><strike><a href="zip-1011">Decentralize the Dev Fee</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1012</strike></td> <td class="left"><strike><a href="zip-1012">Dev Fund to ECC + ZF + Major Grants</a></strike></td> <td>Obsolete</td>
+  <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zip-1013">Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>Obsolete</td>
+</table></embed>
+</details></section>
         <section id="index-of-zips"><h2><span class="section-heading">Index of ZIPs</span><span class="section-anchor"> <a rel="bookmark" href="#index-of-zips"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
         <embed><table>
   <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
@@ -123,16 +243,6 @@
   <tr> <td>1014</td> <td class="left"><a href="zip-1014">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
   <tr> <td>guide-markdown</td> <td class="left"><a href="zip-guide-markdown">{Something Short and To the Point}</a></td> <td>Draft</td>
   <tr> <td>guide</td> <td class="left"><a href="zip-guide">{Something Short and To the Point}</a></td> <td>Draft</td>
-</table></embed></section>
-        <section id="drafts-without-assigned-zip-numbers"><h2><span class="section-heading">Drafts without assigned ZIP numbers</span><span class="section-anchor"> <a rel="bookmark" href="#drafts-without-assigned-zip-numbers"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>These are works-in-progress, and may never be assigned ZIP numbers if their ideas become obsoleted or abandoned. Do not assume that these drafts will exist in perpetuity; instead assume that they will either move to a numbered ZIP, or be deleted.</p>
-        <embed><table>
-  <tr> <th>Title</th> </tr>
-  <tr> <td class="left"><a href="draft-hopwood-coinbase-balance">Blocks should balance exactly</a></td>
-  <tr> <td class="left"><a href="draft-noamchom67-manufacturing-consent">Manufacturing Consent; Re-Establishing a Dev Fund for ECC, ZF, ZCG, Qedit, FPF, and ZecHub</a></td>
-  <tr> <td class="left"><a href="draft-nuttycom-funding-allocation">Block Reward Allocation for Non-Direct Development Funding</a></td>
-  <tr> <td class="left"><a href="draft-nuttycom-lockbox-streams">Lockbox Funding Streams</a></td>
-  <tr> <td class="left"><a href="draft-zf-community-dev-fund-2-proposal">Establishing a Hybrid Dev Fund for ZF, ZCG and a Dev Fund Reserve</a></td>
 </table></embed></section>
     </section>
 </body>


### PR DESCRIPTION
These make it easier to determine what is currently part of the Zcash ecosystem, and what is still in progress. The original by-number index is preserved at the bottom for reference.