### PR TITLE
ZIP 302: Abandon `0xF5`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,10 @@ written.
     <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
     <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zips/zip-0001.rst">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zips/zip-0002.rst">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
+    <tr> <td>68</td> <td class="left"><a href="zips/zip-0068.rst">Relative lock-time using consensus-enforced sequence numbers</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zips/zip-0076.rst">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
+    <tr> <td>112</td> <td class="left"><a href="zips/zip-0112.rst">CHECKSEQUENCEVERIFY</a></td> <td>Draft</td>
+    <tr> <td>113</td> <td class="left"><a href="zips/zip-0113.rst">Median Time Past as endpoint for lock-time calculations</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zips/zip-0204.rst">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zips/zip-0217.rst">Aggregate Signatures</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zips/zip-0219.rst">Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>Reserved</td>
@@ -131,7 +134,7 @@ written.
     <tr> <td>307</td> <td class="left"><a href="zips/zip-0307.rst">Light Client Protocol for Payment Detection</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zips/zip-0309.rst">Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>Reserved</td>
     <tr> <td>310</td> <td class="left"><a href="zips/zip-0310.rst">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
-    <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zips/zip-0311.rst">Sapling Payment Disclosure</a></td> <td>Reserved</td>
+    <tr> <td>311</td> <td class="left"><a href="zips/zip-0311.rst">Zcash Payment Disclosures</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zips/zip-0312.rst">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zips/zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
     <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
@@ -208,7 +211,10 @@ Index of ZIPs
     <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zips/zip-0001.rst">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zips/zip-0002.rst">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
     <tr> <td>32</td> <td class="left"><a href="zips/zip-0032.rst">Shielded Hierarchical Deterministic Wallets</a></td> <td>Final</td>
+    <tr> <td>68</td> <td class="left"><a href="zips/zip-0068.rst">Relative lock-time using consensus-enforced sequence numbers</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zips/zip-0076.rst">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
+    <tr> <td>112</td> <td class="left"><a href="zips/zip-0112.rst">CHECKSEQUENCEVERIFY</a></td> <td>Draft</td>
+    <tr> <td>113</td> <td class="left"><a href="zips/zip-0113.rst">Median Time Past as endpoint for lock-time calculations</a></td> <td>Draft</td>
     <tr> <td>143</td> <td class="left"><a href="zips/zip-0143.rst">Transaction Signature Validation for Overwinter</a></td> <td>Final</td>
     <tr> <td>155</td> <td class="left"><a href="zips/zip-0155.rst">addrv2 message</a></td> <td>Proposed</td>
     <tr> <td>173</td> <td class="left"><a href="zips/zip-0173.rst">Bech32 Format</a></td> <td>Final</td>

--- a/rendered/index.html
+++ b/rendered/index.html
@@ -76,7 +76,10 @@
   <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
   <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
+  <tr> <td>68</td> <td class="left"><a href="zip-0068">Relative lock-time using consensus-enforced sequence numbers</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
+  <tr> <td>112</td> <td class="left"><a href="zip-0112">CHECKSEQUENCEVERIFY</a></td> <td>Draft</td>
+  <tr> <td>113</td> <td class="left"><a href="zip-0113">Median Time Past as endpoint for lock-time calculations</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217">Aggregate Signatures</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">219</span></td> <td class="left"><a class="reserved" href="zip-0219">Disabling Addition of New Value to the Sapling Chain Value Pool</a></td> <td>Reserved</td>
@@ -96,7 +99,7 @@
   <tr> <td>307</td> <td class="left"><a href="zip-0307">Light Client Protocol for Payment Detection</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">309</span></td> <td class="left"><a class="reserved" href="zip-0309">Blind Off-chain Lightweight Transactions (BOLT)</a></td> <td>Reserved</td>
   <tr> <td>310</td> <td class="left"><a href="zip-0310">Security Properties of Sapling Viewing Keys</a></td> <td>Draft</td>
-  <tr> <td><span class="reserved">311</span></td> <td class="left"><a class="reserved" href="zip-0311">Sapling Payment Disclosure</a></td> <td>Reserved</td>
+  <tr> <td>311</td> <td class="left"><a href="zip-0311">Zcash Payment Disclosures</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">312</span></td> <td class="left"><a class="reserved" href="zip-0312">Shielded Multisignatures using FROST</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zip-0314">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
   <tr> <td>315</td> <td class="left"><a href="zip-0315">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
@@ -154,7 +157,10 @@
   <tr> <td><span class="reserved">1</span></td> <td class="left"><a class="reserved" href="zip-0001">Network Upgrade Policy and Scheduling</a></td> <td>Reserved</td>
   <tr> <td><span class="reserved">2</span></td> <td class="left"><a class="reserved" href="zip-0002">Design Considerations for Network Upgrades</a></td> <td>Reserved</td>
   <tr> <td>32</td> <td class="left"><a href="zip-0032">Shielded Hierarchical Deterministic Wallets</a></td> <td>Final</td>
+  <tr> <td>68</td> <td class="left"><a href="zip-0068">Relative lock-time using consensus-enforced sequence numbers</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">76</span></td> <td class="left"><a class="reserved" href="zip-0076">Transaction Signature Validation before Overwinter</a></td> <td>Reserved</td>
+  <tr> <td>112</td> <td class="left"><a href="zip-0112">CHECKSEQUENCEVERIFY</a></td> <td>Draft</td>
+  <tr> <td>113</td> <td class="left"><a href="zip-0113">Median Time Past as endpoint for lock-time calculations</a></td> <td>Draft</td>
   <tr> <td>143</td> <td class="left"><a href="zip-0143">Transaction Signature Validation for Overwinter</a></td> <td>Final</td>
   <tr> <td>155</td> <td class="left"><a href="zip-0155">addrv2 message</a></td> <td>Proposed</td>
   <tr> <td>173</td> <td class="left"><a href="zip-0173">Bech32 Format</a></td> <td>Final</td>

--- a/rendered/zip-0068.html
+++ b/rendered/zip-0068.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ZIP 68: Relative lock-time using consensus-enforced sequence numbers</title>
+    <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="css/style.css"></head>
+<body>
+    <section>
+        <pre>ZIP: 68
+Title: Relative lock-time using consensus-enforced sequence numbers
+Credits: Mark Friedenbach &lt;mark@friedenbach.org&gt;
+         BtcDrak &lt;btcdrak@gmail.com&gt;
+         Nicolas Dorier &lt;nicolas.dorier@gmail.com&gt;
+         kinoshitajona &lt;kinoshitajona@gmail.com&gt;
+Category: Consensus
+Status: Draft
+Created: 2016-06-06</pre>
+        <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+            <p>The "Median Time Past" of a block in this document is to be interpreted as described in <a id="footnote-reference-2" class="footnote_reference" href="#zip-0113">4</a>.</p>
+        </section>
+        <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This ZIP introduces relative lock-time (RLT) consensus-enforced semantics of the sequence number field, to enable a signed transaction input to remain invalid for a defined period of time after confirmation of its corresponding outpoint.</p>
+        </section>
+        <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>Zcash transactions have a sequence number field for each input, inherited from Bitcoin. The original idea in Bitcoin appears to have been that a transaction in the mempool would be replaced by using the same input with a higher sequence value. Although this was not properly implemented, it assumes miners would prefer higher sequence numbers even if the lower ones were more profitable to mine. However, a miner acting on profit motives alone would break that assumption completely. The change described by this ZIP repurposes the sequence number for new use cases without breaking existing functionality. It also leaves room for future expansion and other use cases.</p>
+            <p>The transaction <code>nLockTime</code> is used to prevent the mining of a transaction until a certain date. <code>nSequence</code> will be repurposed to prevent mining of a transaction until a certain age of the spent output in blocks or timespan. This, among other uses, allows bi-directional payment channels as used in <a id="footnote-reference-3" class="footnote_reference" href="#deployable-lightning">5</a> and <a id="footnote-reference-4" class="footnote_reference" href="#zip-0112">3</a>.</p>
+        </section>
+        <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This specification defines the meaning of sequence numbers for transactions in blocks after this proposal has activated.</p>
+            <p>If bit (1 &lt;&lt; 31) of the sequence number is set, then no consensus meaning is applied to the sequence number and can be included in any block under all currently possible circumstances.</p>
+            <p>If bit (1 &lt;&lt; 31) of the sequence number is not set, then the sequence number is interpreted as an encoded relative lock-time.</p>
+            <p>The sequence number encoding MUST be interpreted as follows:</p>
+            <p>Bit (1 &lt;&lt; 22) determines if the relative lock-time is time-based or block based: If the bit is set, the relative lock-time specifies a timespan in units of 32 seconds granularity. The timespan starts from the Median Time Past of the output’s previous block, and ends at the Median Time Past of the previous block. If the bit is not set, the relative lock-time specifies a number of blocks.</p>
+            <p>Note: the 64-second time unit differs from Bitcoin's BIP 68, which uses a 512-second time unit.</p>
+            <p>The flag (1 &lt;&lt; 22) is the highest order bit in a 3-byte signed integer for use in Zcash scripts as a 3-byte <code>PUSHDATA</code> with <code>OP_CHECKSEQUENCEVERIFY</code> <a id="footnote-reference-5" class="footnote_reference" href="#zip-0112">3</a>.</p>
+            <p>This specification only interprets 22 bits of the sequence number as relative lock-time, so a mask of <code>0x003FFFFF</code> MUST be applied to the sequence field to extract the relative lock-time. The 22-bit specification allows for over 8.5 years of relative lock-time.</p>
+            <figure class="align-center" align="center">
+                <img src="assets/images/zip-0068-encoding.png" alt="" />
+                <figcaption>A 32-bit field with 'Disable Flag' at bit (1 &lt;&lt; 31), 'Type Flag' at bit (1 &lt;&lt; 22), and 'Value' in the low 22 bits.</figcaption>
+            </figure>
+            <p>For time-based relative lock-time, 64-second granularity was chosen because the block target spacing for Zcash, after activation of the Blossom network upgrade, is 75 seconds. So when using block-based or time-based, roughly the same amount of time can be encoded with the available number of bits. Converting from a sequence number to seconds is performed by multiplying by 64.</p>
+            <p>When the relative lock-time is time-based, it is interpreted as a minimum block-time constraint over the input's age. A relative time-based lock-time of zero indicates an input which can be included in any block. More generally, a relative time-based lock-time n can be included into any block produced 64 * n seconds after the mining date of the output it is spending, or any block thereafter. The mining date of the output is equal to the Median Time Past of the previous block that mined it.</p>
+            <p>The block produced time is equal to the Median Time Past of its previous block.</p>
+            <p>When the relative lock-time is block-based, it is interpreted as a minimum block-height constraint over the input's age. A relative block-based lock-time of zero indicates an input that can be included in any block. More generally, a relative block lock-time n MAY be included n blocks after the mining date of the output it is spending, or any block thereafter.</p>
+            <p>The new rules are not applied to the <code>nSequence</code> field of the input of the coinbase transaction.</p>
+        </section>
+        <section id="reference-implementation"><h2><span class="section-heading">Reference Implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <!-- highlight::c++
+enum {
+    /* Interpret sequence numbers as relative lock-time constraints. */
+    LOCKTIME_VERIFY_SEQUENCE = (1 &lt;&lt; 0),
+};
+/* Setting nSequence to this value for every input in a transaction
+ * disables nLockTime. */
+static const uint32_t SEQUENCE_FINAL = 0xffffffff;
+/* Below flags apply in the context of ZIP 68. */
+/* If this flag set, CTxIn::nSequence is NOT interpreted as a
+ * relative lock-time. */
+static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 &lt;&lt; 31);
+/* If CTxIn::nSequence encodes a relative lock-time and this flag
+ * is set, the relative lock-time has units of 512 seconds,
+ * otherwise it specifies blocks with a granularity of 1. */
+static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 &lt;&lt; 22);
+/* If CTxIn::nSequence encodes a relative lock-time, this mask is
+ * applied to extract that lock-time from the sequence field. */
+static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x003fffff;
+/* In order to use the same number of bits to encode roughly the
+ * same wall-clock duration, and because blocks are naturally
+ * limited to occur every 75s on average after Blossom activation,
+ * the minimum granularity for time-based relative lock-time is
+ * fixed at 64 seconds.
+ * Converting from CTxIn::nSequence to seconds is performed by
+ * multiplying by 64, or equivalently shifting up by 6 bits. */
+static const int SEQUENCE_LOCKTIME_GRANULARITY = 6;
+/**
+ * Calculates the block height and previous block's Median Time Past at
+ * which the transaction will be considered final in the context of ZIP 68.
+ * Also removes from the vector of input heights any entries which did not
+ * correspond to sequence locked inputs as they do not affect the calculation.
+ */
+static std::pair&lt;int, int64_t&gt; CalculateSequenceLocks(const CTransaction &amp;tx, int flags, std::vector&lt;int&gt;* prevHeights, const CBlockIndex&amp; block)
+{
+    assert(prevHeights-&gt;size() == tx.vin.size());
+    // Will be set to the equivalent height- and time-based nLockTime
+    // values that would be necessary to satisfy all relative lock-
+    // time constraints given our view of block chain history.
+    // The semantics of nLockTime are the last invalid height/time, so
+    // use -1 to have the effect of any height or time being valid.
+    int nMinHeight = -1;
+    int64_t nMinTime = -1;
+    // tx.nVersion is signed integer so requires cast to unsigned otherwise
+    // we would be doing a signed comparison and half the range of nVersion
+    // wouldn't support ZIP 68.
+    bool fEnforceZIP68 = static_cast&lt;uint32_t&gt;(tx.nVersion) &gt;= 2
+                      &amp;&amp; flags &amp; LOCKTIME_VERIFY_SEQUENCE;
+    // Do not enforce sequence numbers as a relative lock time
+    // unless we have been instructed to
+    if (!fEnforceZIP68) {
+        return std::make_pair(nMinHeight, nMinTime);
+    }
+    for (size_t txinIndex = 0; txinIndex &lt; tx.vin.size(); txinIndex++) {
+        const CTxIn&amp; txin = tx.vin[txinIndex];
+        // Sequence numbers with the most significant bit set are not
+        // treated as relative lock-times, nor are they given any
+        // consensus-enforced meaning at this point.
+        if (txin.nSequence &amp; CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) {
+            // The height of this input is not relevant for sequence locks
+            (*prevHeights)[txinIndex] = 0;
+            continue;
+        }
+        int nCoinHeight = (*prevHeights)[txinIndex];
+        if (txin.nSequence &amp; CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG) {
+            int64_t nCoinTime = block.GetAncestor(std::max(nCoinHeight-1, 0))-&gt;GetMedianTimePast();
+            // NOTE: Subtract 1 to maintain nLockTime semantics
+            // ZIP 68 relative lock times have the semantics of calculating
+            // the first block or time at which the transaction would be
+            // valid. When calculating the effective block time or height
+            // for the entire transaction, we switch to using the
+            // semantics of nLockTime which is the last invalid block
+            // time or height.  Thus we subtract 1 from the calculated
+            // time or height.
+            // Time-based relative lock-times are measured from the
+            // smallest allowed timestamp of the block containing the
+            // txout being spent, which is the Median Time Past of the
+            // block prior.
+            nMinTime = std::max(nMinTime, nCoinTime + (int64_t)((txin.nSequence &amp; CTxIn::SEQUENCE_LOCKTIME_MASK) &lt;&lt; CTxIn::SEQUENCE_LOCKTIME_GRANULARITY) - 1);
+        } else {
+            nMinHeight = std::max(nMinHeight, nCoinHeight + (int)(txin.nSequence &amp; CTxIn::SEQUENCE_LOCKTIME_MASK) - 1);
+        }
+    }
+    return std::make_pair(nMinHeight, nMinTime);
+}
+static bool EvaluateSequenceLocks(const CBlockIndex&amp; block, std::pair&lt;int, int64_t&gt; lockPair)
+{
+    assert(block.pprev);
+    int64_t nBlockTime = block.pprev-&gt;GetMedianTimePast();
+    if (lockPair.first &gt;= block.nHeight || lockPair.second &gt;= nBlockTime)
+        return false;
+    return true;
+}
+bool SequenceLocks(const CTransaction &amp;tx, int flags, std::vector&lt;int&gt;* prevHeights, const CBlockIndex&amp; block)
+{
+    return EvaluateSequenceLocks(block, CalculateSequenceLocks(tx, flags, prevHeights, block));
+}
+bool CheckSequenceLocks(const CTransaction &amp;tx, int flags)
+{
+    AssertLockHeld(cs_main);
+    AssertLockHeld(mempool.cs);
+    CBlockIndex* tip = chainActive.Tip();
+    CBlockIndex index;
+    index.pprev = tip;
+    // CheckSequenceLocks() uses chainActive.Height()+1 to evaluate
+    // height based locks because when SequenceLocks() is called within
+    // ConnectBlock(), the height of the block *being*
+    // evaluated is what is used.
+    // Thus if we want to know if a transaction can be part of the
+    // *next* block, we need to use one more than chainActive.Height()
+    index.nHeight = tip-&gt;nHeight + 1;
+    // pcoinsTip contains the UTXO set for chainActive.Tip()
+    CCoinsViewMemPool viewMemPool(pcoinsTip, mempool);
+    std::vector&lt;int&gt; prevheights;
+    prevheights.resize(tx.vin.size());
+    for (size_t txinIndex = 0; txinIndex &lt; tx.vin.size(); txinIndex++) {
+        const CTxIn&amp; txin = tx.vin[txinIndex];
+        CCoins coins;
+        if (!viewMemPool.GetCoins(txin.prevout.hash, coins)) {
+            return error("%s: Missing input", __func__);
+        }
+        if (coins.nHeight == MEMPOOL_HEIGHT) {
+            // Assume all mempool transaction confirm in the next block
+            prevheights[txinIndex] = tip-&gt;nHeight + 1;
+        } else {
+            prevheights[txinIndex] = coins.nHeight;
+        }
+    }
+    std::pair&lt;int, int64_t&gt; lockPair = CalculateSequenceLocks(tx, flags, &amp;prevheights, index);
+    return EvaluateSequenceLocks(index, lockPair);
+} -->
+        </section>
+        <section id="acknowledgments"><h2><span class="section-heading">Acknowledgments</span><span class="section-anchor"> <a rel="bookmark" href="#acknowledgments"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This ZIP is based on BIP 68, authored by Mark Friedenbach, BtcDrak, Nicolas Dorier, and kinoshitajona.</p>
+            <p>Credit goes to Gregory Maxwell for providing a succinct and clear description of the behavior of this change, which became the basis of the BIP text.</p>
+        </section>
+        <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>At the time of writing it has not been decided which network upgrade (if any) will implement this proposal.</p>
+            <p>This ZIP is designed to be deployed simultaneously with <a id="footnote-reference-6" class="footnote_reference" href="#zip-0112">3</a> and <a id="footnote-reference-7" class="footnote_reference" href="#zip-0113">4</a>.</p>
+        </section>
+        <section id="compatibility"><h2><span class="section-heading">Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The only use of sequence numbers by the zcashd reference client software is to disable checking the <code>nLockTime</code> constraints in a transaction. The semantics of that application are preserved by this ZIP.</p>
+            <p>As can be seen from the specification section, a number of bits are undefined by this ZIP to allow for other use cases by setting bit (1 &lt;&lt; 31) as the remaining 31 bits have no meaning under this ZIP. Additionally, bits (1 &lt;&lt; 23) through (1 &lt;&lt; 30) inclusive have no meaning at all when bit (1 &lt;&lt; 31) is unset.</p>
+            <p>Unlike BIP 68 in Bitcoin, all of the low 22 bits are used for the value. This reflects the fact that blocks are more frequent (75 seconds instead of 600 seconds), and so more bits are needed to obtain approximately the same range of time.</p>
+            <p>The most efficient way to calculate sequence number from relative lock-time is with bit masks and shifts:</p>
+            <!-- hightlight::c++
+// 0 &lt;= nHeight &lt;= 4194303 blocks (~10 years at post-Blossom block target spacing)
+nSequence = nHeight;
+nHeight = nSequence &amp; 0x003fffff;
+// 0 &lt;= nTime &lt;= 268435392 seconds (~8.5 years)
+nSequence = (1 &lt;&lt; 22) | (nTime &gt;&gt; 6);
+nTime = (nSequence &amp; 0x003fffff) &lt;&lt; 6; -->
+        </section>
+        <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <table id="rfc2119" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>1</th>
+                        <td><a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="mailing-list" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>2</th>
+                        <td><a href="https://www.mail-archive.com/bitcoin-development@lists.sourceforge.net/msg07864.html">Bitcoin mailing list discussion</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0112" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>3</th>
+                        <td><a href="https://github.com/daira/zips/blob/op-csv/zip-0112.rst">ZIP 112: CHECKSEQUENCEVERIFY</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0113" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>4</th>
+                        <td><a href="https://github.com/daira/zips/blob/op-csv/zip-0113.rst">ZIP 113: Median Time Past as endpoint for lock-time calculations</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="deployable-lightning" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>5</th>
+                        <td><a href="https://github.com/ElementsProject/lightning/raw/master/doc/deployable-lightning.pdf">Reaching The Ground With Lightning (draft 0.2)</a></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+</html>

--- a/rendered/zip-0112.html
+++ b/rendered/zip-0112.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ZIP 112: CHECKSEQUENCEVERIFY</title>
+    <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="css/style.css"></head>
+<body>
+    <section>
+        <pre>ZIP: 112
+Title: CHECKSEQUENCEVERIFY
+Author: Daira Hopwood &lt;daira@electriccoin.co&gt;
+Credits: BtcDrak &lt;btcdrak@gmail.com&gt;
+         Mark Friedenbach &lt;mark@friedenbach.org&gt;
+         Eric Lombrozo &lt;elombrozo@gmail.com&gt;
+Category: Consensus
+Status: Draft
+Created: 2019-06-06
+License: MIT</pre>
+        <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The key word "MUST" in this document is to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+        </section>
+        <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This ZIP describes a new opcode (<code>CHECKSEQUENCEVERIFY</code>) for the Zcash scripting system, that in combination with ZIP 68 allows execution pathways of a script to be restricted based on the age of the output being spent.</p>
+        </section>
+        <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>ZIP 68 repurposes the transaction <code>nSequence</code> field meaning by giving sequence numbers new consensus-enforced semantics as a relative lock-time. However, there is no way to build Zcash scripts to make decisions based on this field.</p>
+            <p>By making the <code>nSequence</code> field accessible to script, it becomes possible to construct code pathways that only become accessible some minimum time after proof-of-publication. This enables a wide variety of applications in phased protocols such as escrow, payment channels, or bidirectional pegs.</p>
+        </section>
+        <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p><code>CHECKSEQUENCEVERIFY</code> redefines the existing <code>NOP3</code> opcode. When executed, if any of the following conditions are true, the script interpreter MUST terminate with an error:</p>
+            <ul>
+                <li>the stack is empty; or</li>
+                <li>the top item on the stack is less than 0; or</li>
+                <li>the top item on the stack has the disable flag (1 &lt;&lt; 31) unset; and any of the following hold:
+                    <ul>
+                        <li>the transaction version is less than 2; or</li>
+                        <li>the transaction input sequence number disable flag (1 &lt;&lt; 31) is set; or</li>
+                        <li>the relative lock-time type is not the same; or</li>
+                        <li>the top stack item is greater than the transaction input sequence (when masked according to <a id="footnote-reference-2" class="footnote_reference" href="#zip-0068">4</a>;</li>
+                    </ul>
+                </li>
+            </ul>
+            <p>Otherwise, script execution MUST continue as if a <code>NOP</code> had been executed.</p>
+            <p>ZIP 68 prevents a non-final transaction from being selected for inclusion in a block until the corresponding input has reached the specified age, as measured in block-height or block-time. By comparing the argument to <code>CHECKSEQUENCEVERIFY</code> against the <code>nSequence</code> field, we indirectly verify a desired minimum age of the the output being spent; until that relative age has been reached any script execution pathway including the <code>CHECKSEQUENCEVERIFY</code> will fail to validate, causing the transaction not to be selected for inclusion in a block.</p>
+        </section>
+        <section id="use-cases"><h2><span class="section-heading">Use cases</span><span class="section-anchor"> <a rel="bookmark" href="#use-cases"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <section id="contracts-with-expiration-deadlines"><h3><span class="section-heading">Contracts With Expiration Deadlines</span><span class="section-anchor"> <a rel="bookmark" href="#contracts-with-expiration-deadlines"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <section id="escrow-with-timeout"><h4><span class="section-heading">Escrow with Timeout</span><span class="section-anchor"> <a rel="bookmark" href="#escrow-with-timeout"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>An escrow that times out automatically 30 days after being funded can be established in the following way. Alice, Bob and Escrow create a 2-of-3 address with the following redeem script:</p>
+                    <pre>IF
+    2 &lt;Alice's pubkey&gt; &lt;Bob's pubkey&gt; &lt;Escrow's pubkey&gt; 3 CHECKMULTISIG
+ELSE
+    "30d" CHECKSEQUENCEVERIFY DROP
+    &lt;Alice's pubkey&gt; CHECKSIG
+ENDIF</pre>
+                    <p>At any time funds can be spent using signatures from any two of Alice, Bob or the Escrow.</p>
+                    <p>After 30 days Alice can sign alone.</p>
+                    <p>The clock does not start ticking until the payment to the escrow address confirms.</p>
+                </section>
+            </section>
+            <section id="retroactive-invalidation"><h3><span class="section-heading">Retroactive Invalidation</span><span class="section-anchor"> <a rel="bookmark" href="#retroactive-invalidation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>In many instances, we would like to create contracts that can be revoked in case of some future event. However, given the immutable nature of the block chain, it is practically impossible to retroactively invalidate a previous commitment that has already confirmed. The only mechanism we really have for retroactive invalidation is block chain reorganization which, for fundamental security reasons, is designed to be very hard and very expensive to do.</p>
+                <p>Despite this limitation, we do have a way to provide something functionally similar to retroactive invalidation while preserving irreversibility of past commitments using <code>CHECKSEQUENCEVERIFY</code>. By constructing scripts with multiple branches of execution where one or more of the branches are delayed we provide a time window in which someone can supply an invalidation condition that allows the output to be spent, effectively invalidating the would-be delayed branch and potentially discouraging another party from broadcasting the transaction in the first place. If the invalidation condition does not occur before the timeout, the delayed branch becomes spendable, honoring the original contract.</p>
+                <p>Some more specific applications of this idea:</p>
+                <section id="hash-time-locked-contracts"><h4><span class="section-heading">Hash Time-Locked Contracts</span><span class="section-anchor"> <a rel="bookmark" href="#hash-time-locked-contracts"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>Hash Time-Locked Contracts (HTLCs) provide a general mechanism for off-chain contract negotiation. An execution pathway can be made to require knowledge of a secret (a hash preimage) that can be presented within an invalidation time window. By sharing the secret it is possible to guarantee to the counterparty that the transaction will never be broadcast since this would allow the counterparty to claim the output immediately while one would have to wait for the time window to pass. If the secret has not been shared, the counterparty will be unable to use the instant pathway and the delayed pathway must be used instead.</p>
+                </section>
+                <section id="bidirectional-payment-channels"><h4><span class="section-heading">Bidirectional Payment Channels</span><span class="section-anchor"> <a rel="bookmark" href="#bidirectional-payment-channels"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>Scriptable relative locktime provides a predictable amount of time to respond in the event a counterparty broadcasts a revoked transaction: Absolute locktime necessitates closing the channel and reopening it when getting close to the timeout, whereas with relative locktime, the clock starts ticking the moment the transaction confirms in a block. It also provides a means to know exactly how long to wait (in number of blocks) before funds can be pulled out of the channel in the event of a noncooperative counterparty.</p>
+                </section>
+                <section id="lightning-network"><h4><span class="section-heading">Lightning Network</span><span class="section-anchor"> <a rel="bookmark" href="#lightning-network"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+                    <p>The lightning network protocol <a id="footnote-reference-3" class="footnote_reference" href="#lightning">6</a> extends the bidirectional payment channel idea to allow for payments to be routed over multiple bidirectional payment channel hops.</p>
+                    <p>These channels are based on an anchor transaction that requires a 2-of-2 multisig from Alice and Bob, and a series of revocable commitment transactions that spend the anchor transaction. The commitment transaction splits the funds from the anchor between Alice and Bob and the latest commitment transaction may be published by either party at any time, finalising the channel.</p>
+                    <p>Ideally then, a revoked commitment transaction would never be able to be successfully spent; and the latest commitment transaction would be able to be spent very quickly.</p>
+                    <p>To allow a commitment transaction to be effectively revoked, Alice and Bob have slightly different versions of the latest commitment transaction. In Alice's version, any outputs in the commitment transaction that pay Alice also include a forced delay, and an alternative branch that allows Bob to spend the output if he knows that transaction's revocation code. In Bob's version, payments to Bob are similarly encumbered. When Alice and Bob negotiate new balances and new commitment transactions, they also reveal the old revocation code, thus committing to not relaying the old transaction.</p>
+                    <p>A simple output, paying to Alice might then look like:</p>
+                    <pre>HASH160 &lt;revokehash&gt; EQUAL
+IF
+    &lt;Bob's pubkey&gt;
+ELSE
+    "24h" CHECKSEQUENCEVERIFY DROP
+    &lt;Alice's pubkey&gt;
+ENDIF
+CHECKSIG</pre>
+                    <p>This allows Alice to publish the latest commitment transaction at any time and spend the funds after 24 hours, but also ensures that if Alice relays a revoked transaction, that Bob has 24 hours to claim the funds.</p>
+                    <p>With <code>CHECKLOCKTIMEVERIFY</code>, this would look like:</p>
+                    <pre>HASH160 &lt;revokehash&gt; EQUAL
+IF
+    &lt;Bob's pubkey&gt;
+ELSE
+    "2015/12/15" CHECKLOCKTIMEVERIFY DROP
+    &lt;Alice's pubkey&gt;
+ENDIF
+CHECKSIG</pre>
+                    <p>This form of transaction would mean that if the anchor is unspent on 2015/12/16, Alice can use this commitment even if it has been revoked, simply by spending it immediately, giving no time for Bob to claim it.</p>
+                    <p>This means that the channel has a deadline that cannot be pushed back without hitting the blockchain; and also that funds may not be available until the deadline is hit. <code>CHECKSEQUENCEVERIFY</code> allows you to avoid making such a tradeoff.</p>
+                    <p>Hashed Time-Lock Contracts (HTLCs) make this slightly more complicated, since in principle they may pay either Alice or Bob, depending on whether Alice discovers a secret R, or a timeout is reached, but the same principle applies -- the branch paying Alice in Alice's commitment transaction gets a delay, and the entire output can be claimed by the other party if the revocation secret is known. With <code>CHECKSEQUENCEVERIFY</code>, a HTLC payable to Alice might look like the following in Alice's commitment transaction:</p>
+                    <pre>HASH160 DUP &lt;R-HASH&gt; EQUAL
+IF
+    "24h" CHECKSEQUENCEVERIFY
+    2DROP
+    &lt;Alice's pubkey&gt;
+ELSE
+    &lt;Commit-Revocation-Hash&gt; EQUAL
+    NOTIF
+        "2015/10/20 10:33" CHECKLOCKTIMEVERIFY DROP
+    ENDIF
+    &lt;Bob's pubkey&gt;
+ENDIF
+CHECKSIG</pre>
+                    <p>and correspondingly in Bob's commitment transaction:</p>
+                    <pre>HASH160 DUP &lt;R-HASH&gt; EQUAL
+SWAP &lt;Commit-Revocation-Hash&gt; EQUAL ADD
+IF
+    &lt;Alice's pubkey&gt;
+ELSE
+    "2015/10/20 10:33" CHECKLOCKTIMEVERIFY
+    "24h" CHECKSEQUENCEVERIFY
+    2DROP
+    &lt;Bob's pubkey&gt;
+ENDIF
+CHECKSIG</pre>
+                    <p>Note that both <code>CHECKSEQUENCEVERIFY</code> and <code>CHECKLOCKTIMEVERIFY</code> are used in the final branch above to ensure Bob cannot spend the output until after both the timeout is complete and Alice has had time to reveal the revocation secret.</p>
+                    <p>See also the 'Deployable Lightning' paper <a id="footnote-reference-4" class="footnote_reference" href="#deployable-lightning">5</a>.</p>
+                </section>
+            </section>
+            <section id="way-pegged-sidechains"><h3><span class="section-heading">2-Way Pegged Sidechains</span><span class="section-anchor"> <a rel="bookmark" href="#way-pegged-sidechains"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The 2-way pegged sidechain requires a new <code>REORGPROOFVERIFY</code> opcode, the semantics of which are outside the scope of this ZIP. <code>CHECKSEQUENCEVERIFY</code> is used to make sure that sufficient time has passed since the return peg was posted to publish a reorg proof:</p>
+                <pre>IF
+    lockTxHeight &lt;lockTxHash&gt; nlocktxOut [&lt;workAmount&gt;] reorgBounty Hash160(&lt;...&gt;) &lt;genesisHash&gt; REORGPROOFVERIFY
+ELSE
+    withdrawLockTime CHECKSEQUENCEVERIFY DROP HASH160 p2shWithdrawDest EQUAL
+ENDIF</pre>
+            </section>
+        </section>
+        <section id="reference-implementation"><h2><span class="section-heading">Reference Implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <!-- highlight::c++
+/* Below flags apply in the context of ZIP 68 */
+/* If this flag set, CTxIn::nSequence is NOT interpreted as a
+ * relative lock-time. */
+static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 &lt;&lt; 31);
+/* If CTxIn::nSequence encodes a relative lock-time and this flag
+ * is set, the relative lock-time has units of 512 seconds,
+ * otherwise it specifies blocks with a granularity of 1. */
+static const uint32_t SEQUENCE_LOCKTIME_TYPE_FLAG = (1 &lt;&lt; 22);
+/* If CTxIn::nSequence encodes a relative lock-time, this mask is
+ * applied to extract that lock-time from the sequence field. */
+static const uint32_t SEQUENCE_LOCKTIME_MASK = 0x0000ffff;
+case OP_NOP3:
+{
+    if (!(flags &amp; SCRIPT_VERIFY_CHECKSEQUENCEVERIFY)) {
+        // not enabled; treat as a NOP3
+        if (flags &amp; SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS) {
+            return set_error(serror, SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS);
+        }
+        break;
+    }
+    if (stack.size() &lt; 1)
+       return set_error(serror, SCRIPT_ERR_INVALID_STACK_OPERATION);
+    // Note that elsewhere numeric opcodes are limited to
+    // operands in the range -2**31+1 to 2**31-1, however it is
+    // legal for opcodes to produce results exceeding that
+    // range. This limitation is implemented by CScriptNum's
+    // default 4-byte limit.
+    //
+    // Thus as a special case we tell CScriptNum to accept up
+    // to 5-byte bignums, which are good until 2**39-1, well
+    // beyond the 2**32-1 limit of the nSequence field itself.
+    const CScriptNum nSequence(stacktop(-1), fRequireMinimal, 5);
+    // In the rare event that the argument may be &lt; 0 due to
+    // some arithmetic being done first, you can always use
+    // 0 MAX CHECKSEQUENCEVERIFY.
+    if (nSequence &lt; 0)
+        return set_error(serror, SCRIPT_ERR_NEGATIVE_LOCKTIME);
+    // To provide for future soft-fork extensibility, if the
+    // operand has the disabled lock-time flag set,
+    // CHECKSEQUENCEVERIFY behaves as a NOP.
+    if ((nSequence &amp; CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG) != 0)
+        break;
+    // Compare the specified sequence number with the input.
+    if (!checker.CheckSequence(nSequence))
+        return set_error(serror, SCRIPT_ERR_UNSATISFIED_LOCKTIME);
+    break;
+}
+bool TransactionSignatureChecker::CheckSequence(const CScriptNum&amp; nSequence) const
+{
+    // Relative lock times are supported by comparing the passed
+    // in operand to the sequence number of the input.
+    const int64_t txToSequence = (int64_t)txTo-&gt;vin[nIn].nSequence;
+    // Fail if the transaction's version number is not set high
+    // enough to trigger ZIP 68 rules.
+    if (static_cast&lt;uint32_t&gt;(txTo-&gt;nVersion) &lt; 2)
+        return false;
+    // Sequence numbers with their most significant bit set are not
+    // consensus constrained. Testing that the transaction's sequence
+    // number do not have this bit set prevents using this property
+    // to get around a CHECKSEQUENCEVERIFY check.
+    if (txToSequence &amp; CTxIn::SEQUENCE_LOCKTIME_DISABLE_FLAG)
+        return false;
+    // Mask off any bits that do not have consensus-enforced meaning
+    // before doing the integer comparisons
+    const uint32_t nLockTimeMask = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | CTxIn::SEQUENCE_LOCKTIME_MASK;
+    const int64_t txToSequenceMasked = txToSequence &amp; nLockTimeMask;
+    const CScriptNum nSequenceMasked = nSequence &amp; nLockTimeMask;
+    // There are two kinds of nSequence: lock-by-blockheight
+    // and lock-by-blocktime, distinguished by whether
+    // nSequenceMasked &lt; CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG.
+    //
+    // We want to compare apples to apples, so fail the script
+    // unless the type of nSequenceMasked being tested is the same as
+    // the nSequenceMasked in the transaction.
+    if (!(
+        (txToSequenceMasked &lt;  CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG &amp;&amp; nSequenceMasked &lt;  CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG) ||
+        (txToSequenceMasked &gt;= CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG &amp;&amp; nSequenceMasked &gt;= CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG)
+    ))
+        return false;
+    // Now that we know we're comparing apples-to-apples, the
+    // comparison is a simple numeric one.
+    if (nSequenceMasked &gt; txToSequenceMasked)
+        return false;
+    return true;
+} -->
+        </section>
+        <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>At the time of writing it has not been decided which network upgrade (if any) will implement this proposal.</p>
+            <p>This ZIP must be deployed simultaneously with ZIP 68 <a id="footnote-reference-5" class="footnote_reference" href="#zip-0068">4</a>.</p>
+        </section>
+        <section id="acknowledgements"><h2><span class="section-heading">Acknowledgements</span><span class="section-anchor"> <a rel="bookmark" href="#acknowledgements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This ZIP is closely based on BIP 112, authored by BtcDrak.</p>
+            <p>Mark Friedenbach invented the application of sequence numbers to achieve relative lock-time, and wrote the reference implementation of <code>CHECKSEQUENCEVERIFY</code> for Bitcoin.</p>
+            <p>The Bitcoin reference implementation and BIP 112 was based heavily on work done by Peter Todd for the closely related BIP 65. Eric Lombrozo and Anthony Towns contributed example use cases.</p>
+        </section>
+        <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <table id="rfc2119" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>1</th>
+                        <td><a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>2</th>
+                        <td><a href="https://github.com/zcash/zips/blob/master/protocol/protocol.pdf">Zcash Protocol Specification, Version 2019.0.1 or later [Overwinter+Sapling]</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="bip-0065" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>3</th>
+                        <td><a href="https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki">BIP 65: OP_CHECKLOCKTIMEVERIFY</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0068" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>4</th>
+                        <td><a href="https://github.com/zcash/zips/blob/op-csv/zip-0068.rst">ZIP 68: Relative lock-time through consensus-enforced sequence numbers</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="deployable-lightning" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>5</th>
+                        <td><a href="https://github.com/ElementsProject/lightning/blob/master/doc/deployable-lightning.pdf">Deployable Lightning</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="lightning" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>6</th>
+                        <td><a href="http://lightning.network/lightning-network-paper.pdf">Lightning Network paper</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="htlcs" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>7</th>
+                        <td><a href="http://lists.linuxfoundation.org/pipermail/lightning-dev/2015-July/000021.html">HTLCs using OP_CHECKSEQUENCEVERIFY/OP_LOCKTIMEVERIFY and revocation hashes</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="scaling" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
+                        <td><a href="http://diyhpl.us/diyhpluswiki/transcripts/sf-bitcoin-meetup/2015-02-23-scaling-bitcoin-to-billions-of-transactions-per-day/">Scaling Bitcoin to Billions of Transactions Per Day</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="micropayments" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>9</th>
+                        <td><a href="https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2013-April/002433.html">Jeremy Spilman, Micropayment Channels</a></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+</html>

--- a/rendered/zip-0113.html
+++ b/rendered/zip-0113.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ZIP 113: Median Time Past as endpoint for lock-time calculations</title>
+    <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1"><link rel="stylesheet" href="css/style.css"></head>
+<body>
+    <section>
+        <pre>ZIP: 113
+Title: Median Time Past as endpoint for lock-time calculations
+Author: Daira Hopwood &lt;daira@electriccoin.co&gt;
+Credits: Thomas Kerin &lt;me@thomaskerin.io&gt;
+         Mark Friedenbach &lt;mark@friedenbach.org&gt;
+         Gregory Maxwell
+Category: Consensus
+Status: Draft
+Created: 2019-06-07
+License: MIT</pre>
+        <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>The key words "MUST" and "MAY" in this document are to be interpreted as described in RFC 2119. <a id="footnote-reference-1" class="footnote_reference" href="#rfc2119">1</a></p>
+        </section>
+        <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This ZIP is a proposal to redefine the semantics used in determining a time-locked transaction's eligibility for inclusion in a block. The median of the last PoWMedianBlockSpan (11) blocks is used instead of the block's timestamp, ensuring that it increases monotonically with each block.</p>
+        </section>
+        <section id="motivation"><h2><span class="section-heading">Motivation</span><span class="section-anchor"> <a rel="bookmark" href="#motivation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>At present, transactions are excluded from inclusion in a block if the present time or block height is less than or equal to that specified in the locktime. Since the consensus rules do not mandate strict ordering of block timestamps, this has the unfortunate outcome of creating a perverse incentive for miners to lie about the time of their blocks in order to collect more fees by including transactions that by wall clock determination have not yet matured.</p>
+            <p>This ZIP proposes comparing the locktime against the median of the past PoWMedianBlockSpan blocks' timestamps, rather than the timestamp of the block including the transaction. Existing consensus rules guarantee this value to monotonically advance, thereby removing the capability for miners to claim more transaction fees by lying about the timestamps of their block.</p>
+            <p>This proposal seeks to ensure reliable behaviour in locktime calculations as required by <a id="footnote-reference-2" class="footnote_reference" href="#bip-0065">3</a> (CHECKLOCKTIMEVERIFY) and matching the behavior of <a id="footnote-reference-3" class="footnote_reference" href="#zip-0112">5</a> (CHECKSEQUENCEVERIFY). This also matches the use of Median Time Past in difficulty adjustment as specified in section 7.6.3 of <a id="footnote-reference-4" class="footnote_reference" href="#protocol">2</a>.</p>
+        </section>
+        <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>Let PoWMedianBlockSpan be as defined in <a id="footnote-reference-5" class="footnote_reference" href="#protocol">2</a> section 5.3, and let the median function be as defined in <a id="footnote-reference-6" class="footnote_reference" href="#protocol">2</a> section 7.6.3.</p>
+            <p>The Median Time Past of a block is specified as the median of the timestamps of the prior PoWMedianBlockSpan blocks, as calculated by MedianTime(height) in <a id="footnote-reference-7" class="footnote_reference" href="#protocol">2</a> section 7.6.3.</p>
+            <p>The values for transaction locktime remain unchanged. The difference is only in the calculation determining whether a transaction can be included. After activation of this ZIP, lock-time constraints of a transaction MUST be checked according to the Median Time Past of the transaction's block.</p>
+            <p>[FIXME make this a proper specification, independent of the zcashd implementation.]</p>
+            <p>Lock-time constraints are checked by the consensus method <code>IsFinalTx()</code>. This method takes the block time as one parameter. This ZIP proposes that after activation calls to <code>IsFinalTx()</code> within consensus code use the return value of <code>GetMedianTimePast(pindexPrev)</code> instead.</p>
+            <p>The new rule applies to all transactions, including the coinbase transaction.</p>
+        </section>
+        <section id="reference-implementation"><h2><span class="section-heading">Reference Implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This will be based on <a href="https://github.com/bitcoin/bitcoin/pull/6566">Bitcoin PR 6566</a>.</p>
+        </section>
+        <section id="acknowledgements"><h2><span class="section-heading">Acknowledgements</span><span class="section-anchor"> <a rel="bookmark" href="#acknowledgements"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>This ZIP is based on BIP 113, authored by Thomas Kerin and Mark Friedenbach.</p>
+            <p>Mark Friedenbach designed and authored the reference implementation for Bitcoin.</p>
+            <p>Gregory Maxwell came up with the original idea, in #bitcoin-wizards on <a href="https://download.wpsoftware.net/bitcoin/wizards/2013/07/13-07-16.log">2013-07-16</a> and <a href="https://download.wpsoftware.net/bitcoin/wizards/2013/07/13-07-17.log">2013-07-17</a>.</p>
+        </section>
+        <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>At the time of writing it has not been decided which network upgrade (if any) will implement this proposal.</p>
+            <p>This ZIP is designed to be deployed simultaneously with <a id="footnote-reference-8" class="footnote_reference" href="#zip-0068">4</a> and <a id="footnote-reference-9" class="footnote_reference" href="#zip-0112">5</a>.</p>
+        </section>
+        <section id="compatibility"><h2><span class="section-heading">Compatibility</span><span class="section-anchor"> <a rel="bookmark" href="#compatibility"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <p>At the post-Blossom block target spacing of 75 seconds, transactions generated using time-based lock-time will take approximately 7.5 minutes longer to confirm than would be expected under the old rules. This is not known to introduce any compatibility concerns with existing protocols. This delay is less than in Bitcoin due to the faster block target spacing in Zcash.</p>
+        </section>
+        <section id="references"><h2><span class="section-heading">References</span><span class="section-anchor"> <a rel="bookmark" href="#references"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
+            <table id="rfc2119" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>1</th>
+                        <td><a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="protocol" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>2</th>
+                        <td><a href="https://github.com/zcash/zips/blob/master/protocol/blossom.pdf">Zcash Protocol Specification, Version 2019.0.1 or later [Overwinter+Sapling+Blossom]</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="bip-0065" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>3</th>
+                        <td><a href="https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki">BIP 65: OP_CHECKLOCKTIMEVERIFY</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0068" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>4</th>
+                        <td><a href="https://github.com/daira/zips/blob/op-csv/zip-0068.rst">ZIP 68: Consensus-enforced transaction replacement signaled via sequence numbers</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0112" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>5</th>
+                        <td><a href="https://github.com/daira/zips/blob/op-csv/zip-0112.rst">ZIP 112: CHECKSEQUENCEVERIFY</a></td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </section>
+</body>
+</html>

--- a/rendered/zip-0302.html
+++ b/rendered/zip-0302.html
@@ -31,21 +31,21 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/105">https://githu
             <p>This ZIP refines the specification of the third case.</p>
             <p>The following specification constrains a party, called the "reader", that interprets the contents of a memo. It does not define consensus requirements.</p>
             <ul>
-                <li>If the first byte (byte 0) has a value of 0xF4 or smaller, then the reader MUST:
+                <li>If the first byte (byte 0) has a value of <code>0xF4</code> or smaller, then the reader MUST:
                     <ul>
                         <li>strip any trailing zero bytes</li>
                         <li>decode it as a UTF-8 string (if decoding fails then report an error).</li>
                     </ul>
                 </li>
-                <li>If the first byte has a value of 0xF6, and the remaining 511 bytes are 0x00, then the user supplied no memo, and the encrypted memo field is to be treated as empty.</li>
+                <li>If the first byte has a value of <code>0xF6</code>, and the remaining 511 bytes are <code>0x00</code>, then the user supplied no memo, and the encrypted memo field is to be treated as empty.</li>
                 <li>If the memo matches any of these patterns, then this memo is from the future, because these ranges are reserved for future updates to this specification:
                     <ul>
-                        <li>The first byte has a value of 0xF5.</li>
-                        <li>The first byte has a value of 0xF6, and the remaining 511 bytes are not all 0x00.</li>
-                        <li>The first byte has a value between 0xF7 and 0xFE inclusive.</li>
+                        <li>The first byte has a value of <code>0xF6</code>, and the remaining 511 bytes are not all <code>0x00</code>.</li>
+                        <li>The first byte has a value between <code>0xF7</code> and <code>0xFE</code> inclusive.</li>
                     </ul>
                 </li>
-                <li>If the first byte has a value of 0xFF then the reader should not make any other assumption about the memo. In order to put arbitrary data into a memo field (that might have some private non-standard structure), the value of the first byte SHOULD be set to 0xFF; the remaining 511 bytes are then unconstrained.</li>
+                <li>If the first byte has a value of <code>0xFF</code> then the reader should not make any other assumption about the memo. In order to put arbitrary data into a memo field (that might have some private non-standard structure), the value of the first byte SHOULD be set to 0xFF; the remaining 511 bytes are then unconstrained.</li>
+                <li>If the first byte has a value of <code>0xF5</code>, then the reader should not make any other assumption about the memo. This value was used ambiguously in the past by private agreement; applications SHOULD prefer <code>0xFF</code> which is unambiguously for this purpose.</li>
             </ul>
         </section>
         <section id="rationale"><h2><span class="section-heading">Rationale</span><span class="section-anchor"> <a rel="bookmark" href="#rationale"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
@@ -54,10 +54,10 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/105">https://githu
                 <p>The usage of the memo field is by agreement between the sender and recipient of the note. The memo field SHOULD be encoded either as:</p>
                 <ul>
                     <li>a UTF-8 human-readable string [Unicode], padded by appending zero bytes; or</li>
-                    <li>an arbitrary sequence of 512 bytes starting with a byte value of 0xF5 or greater, which is therefore not a valid UTF-8 string.</li>
+                    <li>an arbitrary sequence of 512 bytes starting with a byte value of <code>0xF5</code> or greater, which is therefore not a valid UTF-8 string.</li>
                 </ul>
-                <p>In the former case, wallet software is expected to strip any trailing zero bytes and then display the resulting UTF-8 string to the recipient user, where applicable. Incorrect UTF-8-encoded byte sequences should be displayed as replacement characters (U+FFFD).</p>
-                <p>In the latter case, the contents of the memo field SHOULD NOT be displayed. A start byte of 0xF5 is reserved for use by automated software by private agreement. A start byte of 0xF6 or greater is reserved for use in future Zcash protocol extensions.</p>
+                <p>In the former case, wallet software is expected to strip any trailing zero bytes and then display the resulting UTF-8 string to the recipient user, where applicable. Incorrect UTF-8-encoded byte sequences should be displayed as replacement characters (<code>U+FFFD</code>).</p>
+                <p>In the latter case, the contents of the memo field SHOULD NOT be displayed. A start byte of <code>0xF5</code> is reserved for use by automated software by private agreement. A start byte of <code>0xF6</code> or greater is reserved for use in future Zcash protocol extensions.</p>
             </blockquote>
             <p>See issue <a href="https://github.com/zcash/zcash/issues/1849">#1849</a> for further discussion.</p>
         </section>

--- a/zips/zip-0302.rst
+++ b/zips/zip-0302.rst
@@ -25,7 +25,7 @@ memo values carrying different types of data. Users and third-party services ben
 standardized formatting rules that define the type and length of the data contained within.
 
 Specification
-===============
+=============
 
 Section 5.5 of the Zcash protocol specification [#protocol]_ defines three cases
 for the encoding of a memo field:
@@ -40,28 +40,29 @@ This ZIP refines the specification of the third case.
 The following specification constrains a party, called the "reader", that interprets the
 contents of a memo. It does not define consensus requirements.
 
-+ If the first byte (byte 0) has a value of 0xF4 or smaller, then the reader MUST:
++ If the first byte (byte 0) has a value of ``0xF4`` or smaller, then the reader MUST:
 
      + strip any trailing zero bytes
      + decode it as a UTF-8 string (if decoding fails then report an error).
 
-+ If the first byte has a value of 0xF6, and the remaining 511 bytes are 0x00, then the user
-  supplied no memo, and the encrypted memo field is to be treated as empty.
++ If the first byte has a value of ``0xF6``, and the remaining 511 bytes are ``0x00``,
+  then the user supplied no memo, and the encrypted memo field is to be treated as empty.
 
 + If the memo matches any of these patterns, then this memo is from the future, because
   these ranges are reserved for future updates to this specification:
 
-     + The first byte has a value of 0xF5.
-     + The first byte has a value of 0xF6, and the remaining 511 bytes are not all 0x00.
-     + The first byte has a value between 0xF7 and 0xFE inclusive.
+     + The first byte has a value of ``0xF5``.
+     + The first byte has a value of ``0xF6``, and the remaining 511 bytes are not all
+       ``0x00``.
+     + The first byte has a value between ``0xF7`` and ``0xFE`` inclusive.
 
-+ If the first byte has a value of 0xFF then the reader should not make any other
++ If the first byte has a value of ``0xFF`` then the reader should not make any other
   assumption about the memo. In order to put arbitrary data into a memo field (that
   might have some private non-standard structure), the value of the first byte SHOULD
   be set to 0xFF; the remaining 511 bytes are then unconstrained.
 
 Rationale
-===========
+=========
 
 The new protocol specification is an improvement over the current memo field content
 specification that was in the protocol spec up to version 2020.1.0, which stated:
@@ -70,24 +71,25 @@ specification that was in the protocol spec up to version 2020.1.0, which stated
     note. The memo field SHOULD be encoded either as:
 
     + a UTF-8 human-readable string [Unicode], padded by appending zero bytes; or
-    + an arbitrary sequence of 512 bytes starting with a byte value of 0xF5 or greater,
-      which is therefore not a valid UTF-8 string.
+    + an arbitrary sequence of 512 bytes starting with a byte value of ``0xF5`` or
+      greater, which is therefore not a valid UTF-8 string.
 
     In the former case, wallet software is expected to strip any trailing zero bytes and
     then display the resulting UTF-8 string to the recipient user, where applicable.
     Incorrect UTF-8-encoded byte sequences should be displayed as replacement characters
-    (U+FFFD).
+    (``U+FFFD``).
 
     In the latter case, the contents of the memo field SHOULD NOT be displayed. A start
-    byte of 0xF5 is reserved for use by automated software by private agreement. A start
-    byte of 0xF6 or greater is reserved for use in future Zcash protocol extensions.
+    byte of ``0xF5`` is reserved for use by automated software by private agreement. A
+    start byte of ``0xF6`` or greater is reserved for use in future Zcash protocol
+    extensions.
 
 See issue `#1849`_ for further discussion.
 
 .. _`#1849`: https://github.com/zcash/zcash/issues/1849
 
 Backwards Compatibility
-===========================
+=======================
 
 Encrypted memo field contents sent without the standardized format proposed here will be
 interpreted according to the specification set out in older versions of the protocol spec.

--- a/zips/zip-0302.rst
+++ b/zips/zip-0302.rst
@@ -51,7 +51,6 @@ contents of a memo. It does not define consensus requirements.
 + If the memo matches any of these patterns, then this memo is from the future, because
   these ranges are reserved for future updates to this specification:
 
-     + The first byte has a value of ``0xF5``.
      + The first byte has a value of ``0xF6``, and the remaining 511 bytes are not all
        ``0x00``.
      + The first byte has a value between ``0xF7`` and ``0xFE`` inclusive.
@@ -60,6 +59,10 @@ contents of a memo. It does not define consensus requirements.
   assumption about the memo. In order to put arbitrary data into a memo field (that
   might have some private non-standard structure), the value of the first byte SHOULD
   be set to 0xFF; the remaining 511 bytes are then unconstrained.
+
++ If the first byte has a value of ``0xF5``, then the reader should not make any other
+  assumption about the memo. This value was used ambiguously in the past by private
+  agreement; applications SHOULD prefer ``0xFF`` which is unambiguously for this purpose.
 
 Rationale
 =========


### PR DESCRIPTION
Per the decision almost 2 years ago documented in https://github.com/zcash/zips/pull/638#issuecomment-1325704976.