### PR TITLE
Fix redirect for ZIP 2001

### DIFF
--- a/rendered/_config.yml
+++ b/rendered/_config.yml
@@ -1,5 +1,0 @@
-theme: jekyll-theme-tactile
-url: "https://zips.z.cash"
-markdown: GFM
-gems:
-  - jekyll-redirect-from

--- a/rendered/draft-nuttycom-lockbox-streams.html
+++ b/rendered/draft-nuttycom-lockbox-streams.html
@@ -1,3 +1,10 @@
----
-redirect_to: "https://zips.z.cash/zip-2001"
----
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ZIP 2001: Lockbox Funding Streams (redirect)</title>
+    <meta http-equiv="refresh" content="0; zip-2001">
+</head>
+<body>
+    <p>This draft was assigned <a href="zip-2001">ZIP number 2001</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
`_config.yml` is deleted as it did not work, indicating that Jinja is not being used at all for the ZIPs repo rendering.