### PR TITLE
NU6 final specification clarifications

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,25 +66,26 @@ Released ZIPs
     <tr> <td>203</td> <td class="left"><a href="zips/zip-0203.rst">Transaction Expiry</a></td> <td>Final</td>
     <tr> <td>205</td> <td class="left"><a href="zips/zip-0205.rst">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
     <tr> <td>206</td> <td class="left"><a href="zips/zip-0206.rst">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>207</td> <td class="left"><a href="zips/zip-0207.rst">Funding Streams</a></td> <td>Final</td>
+    <tr> <td>207</td> <td class="left"><a href="zips/zip-0207.rst">Funding Streams</a></td> <td>[Pre-NU6] Final, [NU6] Implemented (zcashd and zebrad)</td>
     <tr> <td>208</td> <td class="left"><a href="zips/zip-0208.rst">Shorter Block Target Spacing</a></td> <td>Final</td>
     <tr> <td>209</td> <td class="left"><a href="zips/zip-0209.rst">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
     <tr> <td>211</td> <td class="left"><a href="zips/zip-0211.rst">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
     <tr> <td>212</td> <td class="left"><a href="zips/zip-0212.rst">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
     <tr> <td>213</td> <td class="left"><a href="zips/zip-0213.rst">Shielded Coinbase</a></td> <td>Final</td>
-    <tr> <td>214</td> <td class="left"><a href="zips/zip-0214.rst">Consensus rules for a Zcash Development Fund</a></td> <td>Revision 0: Final, Revision 1: Draft</td>
+    <tr> <td>214</td> <td class="left"><a href="zips/zip-0214.rst">Consensus rules for a Zcash Development Fund</a></td> <td>[Revision 0] Final, [Revision 1] Implemented (zcashd and zebrad)</td>
     <tr> <td>215</td> <td class="left"><a href="zips/zip-0215.rst">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
     <tr> <td>216</td> <td class="left"><a href="zips/zip-0216.rst">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
     <tr> <td>221</td> <td class="left"><a href="zips/zip-0221.rst">FlyClient - Consensus-Layer Changes</a></td> <td>Final</td>
     <tr> <td>224</td> <td class="left"><a href="zips/zip-0224.rst">Orchard Shielded Protocol</a></td> <td>Final</td>
     <tr> <td>225</td> <td class="left"><a href="zips/zip-0225.rst">Version 5 Transaction Format</a></td> <td>Final</td>
+    <tr> <td>236</td> <td class="left"><a href="zips/zip-0236.rst">Blocks should balance exactly</a></td> <td>Implemented (zcashd and zebrad)</td>
     <tr> <td>239</td> <td class="left"><a href="zips/zip-0239.rst">Relay of Version 5 Transactions</a></td> <td>Final</td>
     <tr> <td>243</td> <td class="left"><a href="zips/zip-0243.rst">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
     <tr> <td>244</td> <td class="left"><a href="zips/zip-0244.rst">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
     <tr> <td>250</td> <td class="left"><a href="zips/zip-0250.rst">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
     <tr> <td>251</td> <td class="left"><a href="zips/zip-0251.rst">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
     <tr> <td>252</td> <td class="left"><a href="zips/zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>253</td> <td class="left"><a href="zips/zip-0253.md">Deployment of the NU6 Network Upgrade</a></td> <td>Proposed</td>
+    <tr> <td>253</td> <td class="left"><a href="zips/zip-0253.md">Deployment of the NU6 Network Upgrade</a></td> <td>Implemented (zcashd and zebrad)</td>
     <tr> <td>300</td> <td class="left"><a href="zips/zip-0300.rst">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
     <tr> <td>301</td> <td class="left"><a href="zips/zip-0301.rst">Zcash Stratum Protocol</a></td> <td>Final</td>
     <tr> <td>308</td> <td class="left"><a href="zips/zip-0308.rst">Sprout to Sapling Migration</a></td> <td>Final</td>
@@ -95,7 +96,7 @@ Released ZIPs
     <tr> <td>401</td> <td class="left"><a href="zips/zip-0401.rst">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
     <tr> <td>1014</td> <td class="left"><a href="zips/zip-1014.rst">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
     <tr> <td>1015</td> <td class="left"><a href="zips/zip-1015.rst">Block Reward Allocation for Non-Direct Development Funding</a></td> <td>Proposed</td>
-    <tr> <td>2001</td> <td class="left"><a href="zips/zip-2001.rst">Lockbox Funding Streams</a></td> <td>Proposed</td>
+    <tr> <td>2001</td> <td class="left"><a href="zips/zip-2001.rst">Lockbox Funding Streams</a></td> <td>Implemented (zcashd and zebrad)</td>
   </table></embed>
 
 Draft ZIPs
@@ -129,7 +130,6 @@ written.
     <tr> <td><span class="reserved">231</span></td> <td class="left"><a class="reserved" href="zips/zip-0231.rst">Decouple Memos from Transaction Outputs</a></td> <td>Reserved</td>
     <tr> <td>233</td> <td class="left"><a href="zips/zip-0233.md">Establish the Zcash Sustainability Fund on the Protocol Level</a></td> <td>Draft</td>
     <tr> <td>234</td> <td class="left"><a href="zips/zip-0234.md">Smooth Out The Block Subsidy Issuance</a></td> <td>Draft</td>
-    <tr> <td>236</td> <td class="left"><a href="zips/zip-0236.rst">Blocks should balance exactly</a></td> <td>Draft</td>
     <tr> <td>245</td> <td class="left"><a href="zips/zip-0245.rst">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
     <tr> <td>302</td> <td class="left"><a href="zips/zip-0302.rst">Standardized Memo Field Format</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zips/zip-0303.rst">Sprout Payment Disclosure</a></td> <td>Reserved</td>
@@ -228,14 +228,14 @@ Index of ZIPs
     <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zips/zip-0204.rst">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
     <tr> <td>205</td> <td class="left"><a href="zips/zip-0205.rst">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
     <tr> <td>206</td> <td class="left"><a href="zips/zip-0206.rst">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>207</td> <td class="left"><a href="zips/zip-0207.rst">Funding Streams</a></td> <td>Final</td>
+    <tr> <td>207</td> <td class="left"><a href="zips/zip-0207.rst">Funding Streams</a></td> <td>[Pre-NU6] Final, [NU6] Implemented (zcashd and zebrad)</td>
     <tr> <td>208</td> <td class="left"><a href="zips/zip-0208.rst">Shorter Block Target Spacing</a></td> <td>Final</td>
     <tr> <td>209</td> <td class="left"><a href="zips/zip-0209.rst">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
     <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zips/zip-0210.rst">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
     <tr> <td>211</td> <td class="left"><a href="zips/zip-0211.rst">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
     <tr> <td>212</td> <td class="left"><a href="zips/zip-0212.rst">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
     <tr> <td>213</td> <td class="left"><a href="zips/zip-0213.rst">Shielded Coinbase</a></td> <td>Final</td>
-    <tr> <td>214</td> <td class="left"><a href="zips/zip-0214.rst">Consensus rules for a Zcash Development Fund</a></td> <td>Revision 0: Final, Revision 1: Draft</td>
+    <tr> <td>214</td> <td class="left"><a href="zips/zip-0214.rst">Consensus rules for a Zcash Development Fund</a></td> <td>[Revision 0] Final, [Revision 1] Implemented (zcashd and zebrad)</td>
     <tr> <td>215</td> <td class="left"><a href="zips/zip-0215.rst">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
     <tr> <td>216</td> <td class="left"><a href="zips/zip-0216.rst">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
     <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zips/zip-0217.rst">Aggregate Signatures</a></td> <td>Reserved</td>
@@ -252,7 +252,7 @@ Index of ZIPs
     <tr> <td><span class="reserved">231</span></td> <td class="left"><a class="reserved" href="zips/zip-0231.rst">Decouple Memos from Transaction Outputs</a></td> <td>Reserved</td>
     <tr> <td>233</td> <td class="left"><a href="zips/zip-0233.md">Establish the Zcash Sustainability Fund on the Protocol Level</a></td> <td>Draft</td>
     <tr> <td>234</td> <td class="left"><a href="zips/zip-0234.md">Smooth Out The Block Subsidy Issuance</a></td> <td>Draft</td>
-    <tr> <td>236</td> <td class="left"><a href="zips/zip-0236.rst">Blocks should balance exactly</a></td> <td>Draft</td>
+    <tr> <td>236</td> <td class="left"><a href="zips/zip-0236.rst">Blocks should balance exactly</a></td> <td>Implemented (zcashd and zebrad)</td>
     <tr> <td>239</td> <td class="left"><a href="zips/zip-0239.rst">Relay of Version 5 Transactions</a></td> <td>Final</td>
     <tr> <td>243</td> <td class="left"><a href="zips/zip-0243.rst">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
     <tr> <td>244</td> <td class="left"><a href="zips/zip-0244.rst">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
@@ -260,7 +260,7 @@ Index of ZIPs
     <tr> <td>250</td> <td class="left"><a href="zips/zip-0250.rst">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
     <tr> <td>251</td> <td class="left"><a href="zips/zip-0251.rst">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
     <tr> <td>252</td> <td class="left"><a href="zips/zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>253</td> <td class="left"><a href="zips/zip-0253.md">Deployment of the NU6 Network Upgrade</a></td> <td>Proposed</td>
+    <tr> <td>253</td> <td class="left"><a href="zips/zip-0253.md">Deployment of the NU6 Network Upgrade</a></td> <td>Implemented (zcashd and zebrad)</td>
     <tr> <td>300</td> <td class="left"><a href="zips/zip-0300.rst">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
     <tr> <td>301</td> <td class="left"><a href="zips/zip-0301.rst">Zcash Stratum Protocol</a></td> <td>Final</td>
     <tr> <td>302</td> <td class="left"><a href="zips/zip-0302.rst">Standardized Memo Field Format</a></td> <td>Draft</td>
@@ -308,7 +308,7 @@ Index of ZIPs
     <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zips/zip-1013.rst">Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>Obsolete</td>
     <tr> <td>1014</td> <td class="left"><a href="zips/zip-1014.rst">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
     <tr> <td>1015</td> <td class="left"><a href="zips/zip-1015.rst">Block Reward Allocation for Non-Direct Development Funding</a></td> <td>Proposed</td>
-    <tr> <td>2001</td> <td class="left"><a href="zips/zip-2001.rst">Lockbox Funding Streams</a></td> <td>Proposed</td>
+    <tr> <td>2001</td> <td class="left"><a href="zips/zip-2001.rst">Lockbox Funding Streams</a></td> <td>Implemented (zcashd and zebrad)</td>
     <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td>
     <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td>
   </table></embed>

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -3555,12 +3555,22 @@ The computation of \transactionIDs\nufive{ and \wtxids} is described in \crossre
 \nufive{For more detail on the distinction between these two identifiers and when to
 use each of them, see \cite{ZIP-239} and \cite{ZIP-244}.}
 
-\vspace{2ex}
+\vspace{1ex}
 \defining{\xTransparentInputs} to a \transaction insert value into a \defining{\transparentTxValuePool}
 associated with the \transaction, and \defining{\transparentOutputs} remove value from this pool.
-As in \Bitcoin, the remaining value in the \transparentTxValuePool of a non-coinbase
-\transaction is available to miners as a fee. The remaining value in the \transparentTxValuePool
-of a \coinbaseTransaction is destroyed.
+The effect of \Sprout \joinSplitTransfers\sapling{,\notnufive{ and} \Sapling \spendTransfers and
+\outputTransfers}\nufive{, and \Orchard \actionTransfers} on the \transparentTxValuePool are specified
+in \crossref{sproutbalance}\sapling{,\notnufive{ and} \crossref{saplingbalance}}\nufive{, and
+\crossref{orchardbalance}} respectively.
+
+As in \Bitcoin, the remaining value in the \transparentTxValuePool of a non-coinbase \transaction
+is available to miners as a fee. That is, the sum of those values for non-coinbase \transactions
+in each \block is treated as an implicit input to the \transparentTxValuePool balance of the
+\block's \coinbaseTransaction (in addition to the implicit input created by issuance).
+
+The remaining value in the \transparentTxValuePool of \coinbaseTransactions\nusix{ in \blocks
+prior to \NUSix} is destroyed. \nusix{From \NUSix, this remaining value is required to be zero;
+that is, all of the available balance \MUST be consumed by outputs of the \coinbaseTransaction.}
 
 \vspace{-1ex}
 \consensusrule{
@@ -4655,6 +4665,7 @@ in an \outputDescription.}
 
 \nufive{
 \vspace{2ex}
+\introsection
 Let $\ScalarLength{Orchard}$ be as defined in \crossref{constants}.
 
 Let $\GroupP$, $\ellP$, $\ParamP{q}$, and $\ParamP{r}$ be as defined in \crossref{pallasandvesta}.
@@ -14990,6 +15001,19 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 
 \intropart
 \lsection{Change History}{changehistory}
+
+
+\historyentry{Unreleased}{}
+
+\begin{itemize}
+\nusix{
+    \item Clarify \crossref{transactions} taking into account \NUSix consensus changes from \cite{ZIP-236}.
+} %nusix
+\notnusix{
+    \item No changes before \NUSix.
+} %notnusix
+\end{itemize}
+
 
 \historyentry{2024.5.1}{2024-09-26}
 

--- a/rendered/index.html
+++ b/rendered/index.html
@@ -41,25 +41,26 @@
   <tr> <td>203</td> <td class="left"><a href="zip-0203">Transaction Expiry</a></td> <td>Final</td>
   <tr> <td>205</td> <td class="left"><a href="zip-0205">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
   <tr> <td>206</td> <td class="left"><a href="zip-0206">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>207</td> <td class="left"><a href="zip-0207">Funding Streams</a></td> <td>Final</td>
+  <tr> <td>207</td> <td class="left"><a href="zip-0207">Funding Streams</a></td> <td>[Pre-NU6] Final, [NU6] Implemented (zcashd and zebrad)</td>
   <tr> <td>208</td> <td class="left"><a href="zip-0208">Shorter Block Target Spacing</a></td> <td>Final</td>
   <tr> <td>209</td> <td class="left"><a href="zip-0209">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
   <tr> <td>211</td> <td class="left"><a href="zip-0211">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
   <tr> <td>212</td> <td class="left"><a href="zip-0212">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
   <tr> <td>213</td> <td class="left"><a href="zip-0213">Shielded Coinbase</a></td> <td>Final</td>
-  <tr> <td>214</td> <td class="left"><a href="zip-0214">Consensus rules for a Zcash Development Fund</a></td> <td>Revision 0: Final, Revision 1: Draft</td>
+  <tr> <td>214</td> <td class="left"><a href="zip-0214">Consensus rules for a Zcash Development Fund</a></td> <td>[Revision 0] Final, [Revision 1] Implemented (zcashd and zebrad)</td>
   <tr> <td>215</td> <td class="left"><a href="zip-0215">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
   <tr> <td>216</td> <td class="left"><a href="zip-0216">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
   <tr> <td>221</td> <td class="left"><a href="zip-0221">FlyClient - Consensus-Layer Changes</a></td> <td>Final</td>
   <tr> <td>224</td> <td class="left"><a href="zip-0224">Orchard Shielded Protocol</a></td> <td>Final</td>
   <tr> <td>225</td> <td class="left"><a href="zip-0225">Version 5 Transaction Format</a></td> <td>Final</td>
+  <tr> <td>236</td> <td class="left"><a href="zip-0236">Blocks should balance exactly</a></td> <td>Implemented (zcashd and zebrad)</td>
   <tr> <td>239</td> <td class="left"><a href="zip-0239">Relay of Version 5 Transactions</a></td> <td>Final</td>
   <tr> <td>243</td> <td class="left"><a href="zip-0243">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
   <tr> <td>244</td> <td class="left"><a href="zip-0244">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
   <tr> <td>250</td> <td class="left"><a href="zip-0250">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
   <tr> <td>251</td> <td class="left"><a href="zip-0251">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
   <tr> <td>252</td> <td class="left"><a href="zip-0252">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>253</td> <td class="left"><a href="zip-0253">Deployment of the NU6 Network Upgrade</a></td> <td>Proposed</td>
+  <tr> <td>253</td> <td class="left"><a href="zip-0253">Deployment of the NU6 Network Upgrade</a></td> <td>Implemented (zcashd and zebrad)</td>
   <tr> <td>300</td> <td class="left"><a href="zip-0300">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
   <tr> <td>301</td> <td class="left"><a href="zip-0301">Zcash Stratum Protocol</a></td> <td>Final</td>
   <tr> <td>308</td> <td class="left"><a href="zip-0308">Sprout to Sapling Migration</a></td> <td>Final</td>
@@ -70,7 +71,7 @@
   <tr> <td>401</td> <td class="left"><a href="zip-0401">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
   <tr> <td>1014</td> <td class="left"><a href="zip-1014">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
   <tr> <td>1015</td> <td class="left"><a href="zip-1015">Block Reward Allocation for Non-Direct Development Funding</a></td> <td>Proposed</td>
-  <tr> <td>2001</td> <td class="left"><a href="zip-2001">Lockbox Funding Streams</a></td> <td>Proposed</td>
+  <tr> <td>2001</td> <td class="left"><a href="zip-2001">Lockbox Funding Streams</a></td> <td>Implemented (zcashd and zebrad)</td>
 </table></embed></section>
         <section id="draft-zips"><h2><span class="section-heading">Draft ZIPs</span><span class="section-anchor"> <a rel="bookmark" href="#draft-zips"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>These are works-in-progress that have been assigned ZIP numbers. These will eventually become either Proposed (and thus Released), or one of Withdrawn, Rejected, or Obsolete.</p>
@@ -94,7 +95,6 @@
   <tr> <td><span class="reserved">231</span></td> <td class="left"><a class="reserved" href="zip-0231">Decouple Memos from Transaction Outputs</a></td> <td>Reserved</td>
   <tr> <td>233</td> <td class="left"><a href="zip-0233">Establish the Zcash Sustainability Fund on the Protocol Level</a></td> <td>Draft</td>
   <tr> <td>234</td> <td class="left"><a href="zip-0234">Smooth Out The Block Subsidy Issuance</a></td> <td>Draft</td>
-  <tr> <td>236</td> <td class="left"><a href="zip-0236">Blocks should balance exactly</a></td> <td>Draft</td>
   <tr> <td>245</td> <td class="left"><a href="zip-0245">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
   <tr> <td>302</td> <td class="left"><a href="zip-0302">Standardized Memo Field Format</a></td> <td>Draft</td>
   <tr> <td><span class="reserved">303</span></td> <td class="left"><a class="reserved" href="zip-0303">Sprout Payment Disclosure</a></td> <td>Reserved</td>
@@ -174,14 +174,14 @@
   <tr> <td><span class="reserved">204</span></td> <td class="left"><a class="reserved" href="zip-0204">Zcash P2P Network Protocol</a></td> <td>Reserved</td>
   <tr> <td>205</td> <td class="left"><a href="zip-0205">Deployment of the Sapling Network Upgrade</a></td> <td>Final</td>
   <tr> <td>206</td> <td class="left"><a href="zip-0206">Deployment of the Blossom Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>207</td> <td class="left"><a href="zip-0207">Funding Streams</a></td> <td>Final</td>
+  <tr> <td>207</td> <td class="left"><a href="zip-0207">Funding Streams</a></td> <td>[Pre-NU6] Final, [NU6] Implemented (zcashd and zebrad)</td>
   <tr> <td>208</td> <td class="left"><a href="zip-0208">Shorter Block Target Spacing</a></td> <td>Final</td>
   <tr> <td>209</td> <td class="left"><a href="zip-0209">Prohibit Negative Shielded Chain Value Pool Balances</a></td> <td>Final</td>
   <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zip-0210">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
   <tr> <td>211</td> <td class="left"><a href="zip-0211">Disabling Addition of New Value to the Sprout Chain Value Pool</a></td> <td>Final</td>
   <tr> <td>212</td> <td class="left"><a href="zip-0212">Allow Recipient to Derive Ephemeral Secret from Note Plaintext</a></td> <td>Final</td>
   <tr> <td>213</td> <td class="left"><a href="zip-0213">Shielded Coinbase</a></td> <td>Final</td>
-  <tr> <td>214</td> <td class="left"><a href="zip-0214">Consensus rules for a Zcash Development Fund</a></td> <td>Revision 0: Final, Revision 1: Draft</td>
+  <tr> <td>214</td> <td class="left"><a href="zip-0214">Consensus rules for a Zcash Development Fund</a></td> <td>[Revision 0] Final, [Revision 1] Implemented (zcashd and zebrad)</td>
   <tr> <td>215</td> <td class="left"><a href="zip-0215">Explicitly Defining and Modifying Ed25519 Validation Rules</a></td> <td>Final</td>
   <tr> <td>216</td> <td class="left"><a href="zip-0216">Require Canonical Jubjub Point Encodings</a></td> <td>Final</td>
   <tr> <td><span class="reserved">217</span></td> <td class="left"><a class="reserved" href="zip-0217">Aggregate Signatures</a></td> <td>Reserved</td>
@@ -198,7 +198,7 @@
   <tr> <td><span class="reserved">231</span></td> <td class="left"><a class="reserved" href="zip-0231">Decouple Memos from Transaction Outputs</a></td> <td>Reserved</td>
   <tr> <td>233</td> <td class="left"><a href="zip-0233">Establish the Zcash Sustainability Fund on the Protocol Level</a></td> <td>Draft</td>
   <tr> <td>234</td> <td class="left"><a href="zip-0234">Smooth Out The Block Subsidy Issuance</a></td> <td>Draft</td>
-  <tr> <td>236</td> <td class="left"><a href="zip-0236">Blocks should balance exactly</a></td> <td>Draft</td>
+  <tr> <td>236</td> <td class="left"><a href="zip-0236">Blocks should balance exactly</a></td> <td>Implemented (zcashd and zebrad)</td>
   <tr> <td>239</td> <td class="left"><a href="zip-0239">Relay of Version 5 Transactions</a></td> <td>Final</td>
   <tr> <td>243</td> <td class="left"><a href="zip-0243">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
   <tr> <td>244</td> <td class="left"><a href="zip-0244">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
@@ -206,7 +206,7 @@
   <tr> <td>250</td> <td class="left"><a href="zip-0250">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
   <tr> <td>251</td> <td class="left"><a href="zip-0251">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
   <tr> <td>252</td> <td class="left"><a href="zip-0252">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
-  <tr> <td>253</td> <td class="left"><a href="zip-0253">Deployment of the NU6 Network Upgrade</a></td> <td>Proposed</td>
+  <tr> <td>253</td> <td class="left"><a href="zip-0253">Deployment of the NU6 Network Upgrade</a></td> <td>Implemented (zcashd and zebrad)</td>
   <tr> <td>300</td> <td class="left"><a href="zip-0300">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
   <tr> <td>301</td> <td class="left"><a href="zip-0301">Zcash Stratum Protocol</a></td> <td>Final</td>
   <tr> <td>302</td> <td class="left"><a href="zip-0302">Standardized Memo Field Format</a></td> <td>Draft</td>
@@ -254,7 +254,7 @@
   <tr> <td><strike>1013</strike></td> <td class="left"><strike><a href="zip-1013">Keep It Simple, Zcashers: 10% to ECC, 10% to ZF</a></strike></td> <td>Obsolete</td>
   <tr> <td>1014</td> <td class="left"><a href="zip-1014">Establishing a Dev Fund for ECC, ZF, and Major Grants</a></td> <td>Active</td>
   <tr> <td>1015</td> <td class="left"><a href="zip-1015">Block Reward Allocation for Non-Direct Development Funding</a></td> <td>Proposed</td>
-  <tr> <td>2001</td> <td class="left"><a href="zip-2001">Lockbox Funding Streams</a></td> <td>Proposed</td>
+  <tr> <td>2001</td> <td class="left"><a href="zip-2001">Lockbox Funding Streams</a></td> <td>Implemented (zcashd and zebrad)</td>
   <tr> <td>guide-markdown</td> <td class="left"><a href="zip-guide-markdown">{Something Short and To the Point}</a></td> <td>Draft</td>
   <tr> <td>guide</td> <td class="left"><a href="zip-guide">{Something Short and To the Point}</a></td> <td>Draft</td>
 </table></embed></section>

--- a/rendered/zip-0207.html
+++ b/rendered/zip-0207.html
@@ -11,7 +11,7 @@
 Title: Funding Streams
 Owners: Jack Grigg &lt;str4d@electriccoin.co&gt;
         Daira-Emma Hopwood &lt;daira-emma@electriccoin.co&gt;
-Status: Final
+Status: [Pre-NU6] Final, [NU6] Implemented (zcashd and zebrad)
 Category: Consensus
 Created: 2019-01-04
 License: MIT</pre>

--- a/rendered/zip-0214.html
+++ b/rendered/zip-0214.html
@@ -10,7 +10,7 @@
 Title: Consensus rules for a Zcash Development Fund
 Owners: Daira-Emma Hopwood &lt;daira-emma@electriccoin.co&gt;
         Kris Nuttycombe &lt;kris@nutty.land&gt;
-Status: Revision 0: Final, Revision 1: Draft
+Status: [Revision 0] Final, [Revision 1] Implemented (zcashd and zebrad)
 Category: Consensus
 Created: 2020-02-28
 License: MIT

--- a/rendered/zip-0236.html
+++ b/rendered/zip-0236.html
@@ -11,7 +11,7 @@ Title: Blocks should balance exactly
 Owners: Daira-Emma Hopwood &lt;daira-emma@electriccoin.co&gt;
 Credits: Jack Grigg
          Kris Nuttycombe
-Status: Draft
+Status: Implemented (zcashd and zebrad)
 Category: Consensus
 Created: 2024-07-02
 License: MIT

--- a/rendered/zip-0236.html
+++ b/rendered/zip-0236.html
@@ -18,7 +18,7 @@ License: MIT
 Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/864">https://github.com/zcash/zips/issues/864</a>&gt;</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The key word "MUST" in this document is to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, it appears in all capitals.</p>
-            <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">5</a></p>
+            <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">6</a></p>
             <p>The terms "Testnet" and "Mainnet" are to be interpreted as described in section 3.12 of the Zcash Protocol Specification. <a id="footnote-reference-3" class="footnote_reference" href="#protocol-networks">4</a></p>
             <p>The character § is used when referring to sections of the Zcash Protocol Specification <a id="footnote-reference-4" class="footnote_reference" href="#protocol">2</a>.</p>
         </section>
@@ -44,29 +44,31 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/864">https://g
             <p>This consensus change is not intended to prevent other methods of provably removing ZEC from the circulating supply, such as sending it to an address for which it would be demonstrably infeasible to find the spending key.</p>
         </section>
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>From the activation block of this ZIP onward, coinbase transactions MUST claim all of the available miner subsidy plus fees in their block. More specifically, the following paragraph and consensus rule in § 3.4 "Transactions and Treestates" of the Zcash Protocol Specification <a id="footnote-reference-5" class="footnote_reference" href="#protocol-transactions">3</a>:</p>
-            <blockquote>
-                <p>Transparent inputs to a transaction insert value into a transparent transaction value pool associated with the transaction, and transparent outputs remove value from this pool. As in Bitcoin, the remaining value in the transparent transaction value pool of a non-coinbase transaction is available to miners as a fee. The remaining value in the transparent transaction value pool of a coinbase transaction is destroyed.</p>
-                <p><strong>Consensus rule:</strong> The remaining value in the transparent transaction value pool MUST be nonnegative.</p>
-            </blockquote>
-            <p>is modified to become:</p>
-            <blockquote>
-                <p>Transparent inputs to a transaction insert value into a transparent transaction value pool associated with the transaction, and transparent outputs remove value from this pool. The effect of Sapling Spends and Outputs, and of Orchard Actions on the transaction value pool are specified in § 4.13 and § 4.14 respectively.</p>
-                <p>As in Bitcoin, the remaining value in the transparent transaction value pool of a non-coinbase transaction is available to miners as a fee. That is, the sum of those values for non-coinbase transactions in each block is treated as an implicit input to the transaction value balance of the block's coinbase transaction (in addition to the implicit input created by issuance).</p>
-                <p>The remaining value in the transparent transaction value pool of coinbase transactions in blocks prior to NU6 is destroyed. From activation of NU6, this remaining value is required to be zero; that is, all of the available balance MUST be consumed by outputs of the coinbase transaction.</p>
-                <p><strong>Consensus rules:</strong></p>
-                <ul>
-                    <li>The remaining value in the transparent transaction value pool of a non-coinbase transaction MUST be nonnegative.</li>
-                    <li>[Pre-NU6] The remaining value in the transparent transaction value pool of a coinbase transaction MUST be nonnegative.</li>
-                    <li>[NU6 onward] The remaining value in the transparent transaction value pool of a coinbase transaction MUST be zero.</li>
-                </ul>
-            </blockquote>
-            <p>where "NU6" is to be replaced by the designation of the network upgrade in which this ZIP will be activated.</p>
-            <p>Note that the differences in the first two paragraphs of the above replacement text are clarifications of the protocol, rather than consensus changes. Those could be made independently of this ZIP.</p>
-            <p>This change applies identically to Mainnet and Testnet.</p>
+            <p>From the activation block of this ZIP onward, coinbase transactions MUST claim all of the available miner subsidy plus fees in their block.</p>
+            <section id="changes-to-the-zcash-protocol-specification"><h3><span class="section-heading">Changes to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changes-to-the-zcash-protocol-specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+                <p>The following sentence in § 3.4 ‘Transactions and Treestates’ <a id="footnote-reference-5" class="footnote_reference" href="#protocol-transactions">3</a>:</p>
+                <blockquote>
+                    <p>The remaining value in the transparent transaction value pool of a coinbase transaction is destroyed.</p>
+                </blockquote>
+                <p>is clarified as follows:</p>
+                <blockquote>
+                    <p>The remaining value in the transparent transaction value pool of coinbase transactions in blocks prior to NU6 is destroyed. From activation of NU6, this remaining value is required to be zero; that is, all of the available balance MUST be consumed by outputs of the coinbase transaction.</p>
+                </blockquote>
+                <p>In § 7.1.2 ‘Transaction Consensus Rules’ <a id="footnote-reference-6" class="footnote_reference" href="#protocol-txnconsensus">5</a> as modified by <a id="footnote-reference-7" class="footnote_reference" href="#zip-2001">8</a>, replace:</p>
+                <blockquote>
+                    <p>The total output value of a coinbase transaction MUST NOT be greater than its total input value.</p>
+                </blockquote>
+                <p>with</p>
+                <blockquote>
+                    <p>[Pre-NU6] The total output value of a coinbase transaction MUST NOT be greater than its total input value.</p>
+                    <p>[NU6 onward] The total output value of a coinbase transaction MUST be equal to its total input value.</p>
+                </blockquote>
+                <p>These changes apply identically to Mainnet and Testnet.</p>
+            </section>
         </section>
         <section id="deployment"><h2><span class="section-heading">Deployment</span><span class="section-anchor"> <a rel="bookmark" href="#deployment"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>This ZIP is proposed to be deployed with NU6. <a id="footnote-reference-6" class="footnote_reference" href="#zip-0253">6</a></p>
+            <p>This ZIP is to be deployed with NU6. <a id="footnote-reference-8" class="footnote_reference" href="#zip-0253">7</a></p>
+            <p>The wording change to § 7.1.2 depends on <a id="footnote-reference-9" class="footnote_reference" href="#zip-2001">8</a> which is also to be deployed with NU6. <a id="footnote-reference-10" class="footnote_reference" href="#zip-0253">7</a></p>
         </section>
         <section id="reference-implementation"><h2><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#reference-implementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <ul>
@@ -110,10 +112,18 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/864">https://g
                     </tr>
                 </tbody>
             </table>
-            <table id="zip-0200" class="footnote">
+            <table id="protocol-txnconsensus" class="footnote">
                 <tbody>
                     <tr>
                         <th>5</th>
+                        <td><a href="protocol/protocol.pdf#txnconsensus">Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1.2: Transaction Consensus Rules</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-0200" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>6</th>
                         <td><a href="zip-0200">ZIP 200: Network Upgrade Mechanism</a></td>
                     </tr>
                 </tbody>
@@ -121,8 +131,16 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/864">https://g
             <table id="zip-0253" class="footnote">
                 <tbody>
                     <tr>
-                        <th>6</th>
+                        <th>7</th>
                         <td><a href="zip-0253">ZIP 253: Deployment of the NU6 Network Upgrade</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="zip-2001" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>8</th>
+                        <td><a href="zip-2001">ZIP 2001: Lockbox Funding Streams</a></td>
                     </tr>
                 </tbody>
             </table>

--- a/rendered/zip-0253.html
+++ b/rendered/zip-0253.html
@@ -10,7 +10,7 @@
 <pre><code>ZIP: 253
 Title: Deployment of the NU6 Network Upgrade
 Owners: Arya &lt;arya@zfnd.org&gt;
-Status: Proposed
+Status: Implemented (zcashd and zebrad)
 Category: Consensus / Network
 Created: 2024-07-17
 License: MIT
@@ -103,7 +103,7 @@ formats as NU5 transactions. This does not imply that transactions are
 valid across the NU6 activation, since signatures MUST use the
 appropriate consensus branch ID.</p>
 <h1 id="references">References</h1>
-<aside id="footnotes" class="footnotes footnotes-end-of-document"
+<section id="footnotes" class="footnotes footnotes-end-of-document"
 role="doc-endnotes">
 <hr />
 <ol>
@@ -147,6 +147,6 @@ role="doc-backlink">↩︎</a></p></li>
 Mechanism</a><a href="#fnref12" class="footnote-back"
 role="doc-backlink">↩︎</a></p></li>
 </ol>
-</aside>
+</section>
 </body>
 </html>

--- a/rendered/zip-2001.html
+++ b/rendered/zip-2001.html
@@ -12,7 +12,7 @@ Title: Lockbox Funding Streams
 Owners: Kris Nuttycombe &lt;kris@nutty.land&gt;
 Credits: Daira-Emma Hopwood &lt;daira-emma@electriccoin.co&gt;
          Jack Grigg &lt;jack@electriccoin.co&gt;
-Status: Proposed
+Status: Implemented (zcashd and zebrad)
 Category: Consensus
 Created: 2024-07-02
 License: MIT

--- a/rendered/zip-guide-markdown.html
+++ b/rendered/zip-guide-markdown.html
@@ -212,7 +212,7 @@ to ZIPs or the protocol spec.</p>
 <p>{This section is entirely optional; if present, it usually gives
 links to zcashd or zebrad PRs.}</p>
 <h1 id="references">References</h1>
-<aside id="footnotes" class="footnotes footnotes-end-of-document"
+<section id="footnotes" class="footnotes footnotes-end-of-document"
 role="doc-endnotes">
 <hr />
 <ol>
@@ -249,6 +249,6 @@ Hunting of the Snark</a>. Lewis Carroll, with illustrations by Henry
 Holiday. MacMillan and Co. London. March 29, 1876.<a href="#fnref9"
 class="footnote-back" role="doc-backlink">↩︎</a></p></li>
 </ol>
-</aside>
+</section>
 </body>
 </html>

--- a/zips/zip-0207.rst
+++ b/zips/zip-0207.rst
@@ -4,7 +4,7 @@
   Title: Funding Streams
   Owners: Jack Grigg <str4d@electriccoin.co>
           Daira-Emma Hopwood <daira-emma@electriccoin.co>
-  Status: Final
+  Status: [Pre-NU6] Final, [NU6] Implemented (zcashd and zebrad)
   Category: Consensus
   Created: 2019-01-04
   License: MIT

--- a/zips/zip-0214.rst
+++ b/zips/zip-0214.rst
@@ -4,7 +4,7 @@
   Title: Consensus rules for a Zcash Development Fund
   Owners: Daira-Emma Hopwood <daira-emma@electriccoin.co>
           Kris Nuttycombe <kris@nutty.land>
-  Status: Revision 0: Final, Revision 1: Draft
+  Status: [Revision 0] Final, [Revision 1] Implemented (zcashd and zebrad)
   Category: Consensus
   Created: 2020-02-28
   License: MIT

--- a/zips/zip-0236.rst
+++ b/zips/zip-0236.rst
@@ -5,7 +5,7 @@
   Owners: Daira-Emma Hopwood <daira-emma@electriccoin.co>
   Credits: Jack Grigg
            Kris Nuttycombe
-  Status: Draft
+  Status: Implemented (zcashd and zebrad)
   Category: Consensus
   Created: 2024-07-02
   License: MIT

--- a/zips/zip-0236.rst
+++ b/zips/zip-0236.rst
@@ -93,61 +93,47 @@ Specification
 =============
 
 From the activation block of this ZIP onward, coinbase transactions MUST claim all
-of the available miner subsidy plus fees in their block. More specifically, the
-following paragraph and consensus rule in § 3.4 "Transactions and Treestates" of
-the Zcash Protocol Specification [#protocol-transactions]_:
+of the available miner subsidy plus fees in their block.
 
-  Transparent inputs to a transaction insert value into a transparent transaction
-  value pool associated with the transaction, and transparent outputs remove value
-  from this pool. As in Bitcoin, the remaining value in the transparent transaction
-  value pool of a non-coinbase transaction is available to miners as a fee. The
-  remaining value in the transparent transaction value pool of a coinbase transaction
-  is destroyed.
+Changes to the Zcash Protocol Specification
+-------------------------------------------
 
-  **Consensus rule:** The remaining value in the transparent transaction value pool
-  MUST be nonnegative.
+The following sentence in § 3.4 ‘Transactions and Treestates’ [#protocol-transactions]_:
 
-is modified to become:
+  The remaining value in the transparent transaction value pool of a coinbase
+  transaction is destroyed.
 
-  Transparent inputs to a transaction insert value into a transparent transaction
-  value pool associated with the transaction, and transparent outputs remove value
-  from this pool. The effect of Sapling Spends and Outputs, and of Orchard Actions
-  on the transaction value pool are specified in § 4.13 and § 4.14 respectively.
-
-  As in Bitcoin, the remaining value in the transparent transaction value pool of
-  a non-coinbase transaction is available to miners as a fee. That is, the sum of
-  those values for non-coinbase transactions in each block is treated as an implicit
-  input to the transaction value balance of the block's coinbase transaction (in
-  addition to the implicit input created by issuance).
+is clarified as follows:
 
   The remaining value in the transparent transaction value pool of coinbase transactions
   in blocks prior to NU6 is destroyed. From activation of NU6, this remaining value
   is required to be zero; that is, all of the available balance MUST be consumed by
   outputs of the coinbase transaction.
 
-  **Consensus rules:**
+In § 7.1.2 ‘Transaction Consensus Rules’ [#protocol-txnconsensus]_ as modified by
+[#zip-2001]_, replace:
 
-  * The remaining value in the transparent transaction value pool of a non-coinbase
-    transaction MUST be nonnegative.
-  * [Pre-NU6] The remaining value in the transparent transaction value pool of a
-    coinbase transaction MUST be nonnegative.
-  * [NU6 onward] The remaining value in the transparent transaction value pool of
-    a coinbase transaction MUST be zero.
+  The total output value of a coinbase transaction MUST NOT be greater than its
+  total input value.
 
-where "NU6" is to be replaced by the designation of the network upgrade in which
-this ZIP will be activated.
+with
 
-Note that the differences in the first two paragraphs of the above replacement text
-are clarifications of the protocol, rather than consensus changes. Those could be
-made independently of this ZIP.
+  [Pre-NU6] The total output value of a coinbase transaction MUST NOT be greater
+  than its total input value.
 
-This change applies identically to Mainnet and Testnet.
+  [NU6 onward] The total output value of a coinbase transaction MUST be equal to
+  its total input value.
+
+These changes apply identically to Mainnet and Testnet.
 
 
 Deployment
 ==========
 
-This ZIP is proposed to be deployed with NU6. [#zip-0253]_
+This ZIP is to be deployed with NU6. [#zip-0253]_
+
+The wording change to § 7.1.2 depends on [#zip-2001]_ which is also to be deployed
+with NU6. [#zip-0253]_
 
 
 Reference implementation
@@ -171,5 +157,7 @@ References
 .. [#protocol] `Zcash Protocol Specification, Version 2024.5.1 or later <protocol/protocol.pdf>`_
 .. [#protocol-transactions] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.4: Transactions and Treestates <protocol/protocol.pdf#transactions>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 3.12: Mainnet and Testnet <protocol/protocol.pdf#networks>`_
+.. [#protocol-txnconsensus] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 7.1.2: Transaction Consensus Rules <protocol/protocol.pdf#txnconsensus>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#zip-0253] `ZIP 253: Deployment of the NU6 Network Upgrade <zip-0253.rst>`_
+.. [#zip-2001] `ZIP 2001: Lockbox Funding Streams <zip-2001.rst>`_

--- a/zips/zip-0253.md
+++ b/zips/zip-0253.md
@@ -2,7 +2,7 @@
     ZIP: 253
     Title: Deployment of the NU6 Network Upgrade
     Owners: Arya <arya@zfnd.org>
-    Status: Proposed
+    Status: Implemented (zcashd and zebrad)
     Category: Consensus / Network
     Created: 2024-07-17
     License: MIT

--- a/zips/zip-2001.rst
+++ b/zips/zip-2001.rst
@@ -5,7 +5,7 @@
   Owners: Kris Nuttycombe <kris@nutty.land>
   Credits: Daira-Emma Hopwood <daira-emma@electriccoin.co>
            Jack Grigg <jack@electriccoin.co>
-  Status: Proposed
+  Status: Implemented (zcashd and zebrad)
   Category: Consensus
   Created: 2024-07-02
   License: MIT


### PR DESCRIPTION
* [protocol spec] Clarify section 3.4 taking into account NU6 consensus changes from ZIP 236.
* [ZIP 236] Make the specified changes consistent with the actual changes to the protocol spec.
* Mark ZIPs 207 (changes for NU6), 214 (changes for NU6), 236, 253, and 2001 as Implemented in zcashd and zebrad.