### PR TITLE
ZIP 317: Add a requirement that we neglected to mention

### DIFF
--- a/rendered/zip-0317.html
+++ b/rendered/zip-0317.html
@@ -41,6 +41,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/631">https://githu
                 <li>The fee for a transaction should scale linearly with the number of inputs and/or outputs.</li>
                 <li>Users should not be penalised for sending transactions constructed with padding of inputs and outputs to reduce information leakage. (The default policy employed by zcashd and the mobile SDKs pads to two inputs and two outputs for each shielded pool used by the transaction).</li>
                 <li>Users should be able to spend a small number of UTXOs or notes with value below the marginal fee per input.</li>
+                <li>The conventional fee should not leak private information used in constructing the transaction; that is, it should be computable from only the public data of the transaction.</li>
             </ul>
         </section>
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>

--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -75,6 +75,9 @@ Requirements
   two inputs and two outputs for each shielded pool used by the transaction).
 * Users should be able to spend a small number of UTXOs or notes with value
   below the marginal fee per input.
+* The conventional fee should not leak private information used in
+  constructing the transaction; that is, it should be computable from only
+  the public data of the transaction.
 
 
 Specification


### PR DESCRIPTION
We had this requirement explicitly in mind for the existing design:

* The conventional fee should not leak private information used in constructing the transaction; that is, it should be computable from only the public data of the transaction.