### PR TITLE
Complete the removal of the restriction on Revision 1 UAs having only a Transparent address

### DIFF
--- a/rendered/zip-0316.html
+++ b/rendered/zip-0316.html
@@ -310,7 +310,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/482">https://g
                         <span class="math">\(\mathtt{0x02}\)</span>
                      and
                         <span class="math">\(\mathtt{0x03}\)</span>
-                    ). This requirement is dropped for <a href="#revision-1">Revision 1</a> UA/UVKs.</li>
+                    ). This requirement is dropped for <a href="#revision-1">Revision 1</a> UA/UVKs; however, a <a href="#revision-1">Revision 1</a> UA/UVK MUST contain at least one non-Metadata Item.</li>
                     <li>The
                         <span class="math">\(\mathtt{typecode}\)</span>
                      and
@@ -322,7 +322,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/482">https://g
                     <li>For Transparent Addresses, the Receiver Encoding does not include the first two bytes of a raw encoding.</li>
                     <li>There is intentionally no Typecode defined for a Sprout Shielded Payment Address or Sprout Incoming Viewing Key. Since it is no longer possible (since activation of ZIP 211 in the Canopy network upgrade <a id="footnote-reference-21" class="footnote_reference" href="#zip-0211">25</a>) to send funds into the Sprout chain value pool, this would not be generally useful.</li>
                     <li>With the exception of MUST-understand Metadata Items, Consumers MUST ignore constituent Items with Typecodes they do not recognise.</li>
-                    <li>Consumers MUST reject Unified Addresses/Viewing Keys in which the same Typecode appears more than once, or that include both P2SH and P2PKH Transparent Addresses, or that contain only a Transparent Address.</li>
+                    <li>Consumers MUST reject Unified Addresses/Viewing Keys in which the same Typecode appears more than once, or that include both P2SH and P2PKH Transparent Addresses, or that contain only Metadata Items.</li>
                     <li>Consumers MUST reject Unified Addresses/Viewing Keys in which <em>any</em> constituent Item does not meet the validation requirements of its encoding, as specified in this ZIP and the Zcash Protocol Specification <a id="footnote-reference-22" class="footnote_reference" href="#protocol">2</a>.</li>
                     <li>Consumers MUST reject Unified Addresses/Viewing Keys in which the constituent Items are not ordered in ascending Typecode order. Note that this is different to priority order, and does not affect which Receiver in a Unified Address should be used by a Sender.</li>
                     <li>There MUST NOT be additional bytes at the end of the raw encoding that cannot be interpreted as specified above.</li>
@@ -597,7 +597,7 @@ c^{n+m}}{q}.\)</span>
                      of length
                         <span class="math">\(\ell_M\)</span>
                      bytes such that
-                        <span class="math">\(48 \leq \ell_M \leq \ell^\mathsf{MAX}_M,\)</span>
+                        <span class="math">\(38 \leq \ell_M \leq \ell^\mathsf{MAX}_M,\)</span>
                      define
                         <span class="math">\(\mathsf{F4Jumble}(M)\)</span>
                      by:</p>

--- a/zips/zip-0316.rst
+++ b/zips/zip-0316.rst
@@ -527,7 +527,8 @@ Requirements for both Unified Addresses and Unified Viewing Keys
 * A `Revision 0`_ Unified Address or Unified Viewing Key MUST contain
   at least one shielded Item (Typecodes :math:`\mathtt{0x02}` and
   :math:`\mathtt{0x03}`). This requirement is dropped for `Revision 1`_
-  UA/UVKs.
+  UA/UVKs; however, a `Revision 1`_ UA/UVK MUST contain at least one
+  non-Metadata Item.
 
 * The :math:`\mathtt{typecode}` and :math:`\mathtt{length}` fields are
   encoded as :math:`\mathtt{compactSize}.` [#Bitcoin-CompactSize]_
@@ -553,8 +554,7 @@ Requirements for both Unified Addresses and Unified Viewing Keys
 
 * Consumers MUST reject Unified Addresses/Viewing Keys in which the
   same Typecode appears more than once, or that include both P2SH and
-  P2PKH Transparent Addresses, or that contain only a Transparent
-  Address.
+  P2PKH Transparent Addresses, or that contain only Metadata Items.
 
 * Consumers MUST reject Unified Addresses/Viewing Keys in which *any*
   constituent Item does not meet the validation requirements of its
@@ -1073,7 +1073,7 @@ For the instantiation using BLAKE2b defined below,
 :math:`\ell^\mathsf{MAX}_M = 4194368.`
 
 Given input :math:`M` of length :math:`\ell_M` bytes such that
-:math:`48 \leq \ell_M \leq \ell^\mathsf{MAX}_M,` define
+:math:`38 \leq \ell_M \leq \ell^\mathsf{MAX}_M,` define
 :math:`\mathsf{F4Jumble}(M)` by:
 
 * let :math:`\ell_L = \mathsf{min}(\ell_H, \mathsf{floor}(\ell_M/2))`


### PR DESCRIPTION
#797 intended to remove the restriction on Revision 1 UA/UVKs having only a Transparent address, but we missed parts of it. Also we should require that a UA/UVK does not only consist of Metadata Items.