### PR TITLE
[ZIP 325] Add note about Zashi's poor choice of a private-use subject string

### DIFF
--- a/rendered/css/style.css
+++ b/rendered/css/style.css
@@ -25,7 +25,15 @@
     background-color: #a0a0ff;
     color: #111519;
   }
+  div.note + p {
+    background-color: #a0a0ff;
+    color: #111519;
+  }
   aside.note::before {
+    background-color: #5858ff;
+    color: #000000;
+  }
+  div.note::after {
     background-color: #5858ff;
     color: #000000;
   }
@@ -34,14 +42,35 @@
     color: #111519;
     font-weight: 500;
   }
+  div.warning + p {
+    background-color: #ffb090;
+    color: #111519;
+    font-weight: 500;
+  }
   aside.warning::before {
+    background-color: #ff7050;
+    font-weight: 600;
+  }
+  div.warning::after {
     background-color: #ff7050;
     font-weight: 600;
   }
   aside > p > a, a:visited {
     color: #0077a1;
   }
+  div.note + p > a, a:visited {
+    color: #0077a1;
+  }
+  div.warning + p > a, a:visited {
+    color: #0077a1;
+  }
   aside > p > a:hover {
+    color: #00455c;
+  }
+  div.note + p > a:hover {
+    color: #00455c;
+  }
+  div.warning + p > a:hover {
     color: #00455c;
   }
   blockquote {
@@ -89,10 +118,22 @@
     background-color: #6060e0;
     color: #ffffff;
   }
+  div.note + p {
+    background-color: #6060e0;
+    color: #ffffff;
+  }
   aside.note::before {
     background-color: #3030e0;
   }
+  div.note::after {
+    background-color: #3030e0;
+  }
   aside.warning {
+    background-color: #e08060;
+    color: #ffffff;
+    font-weight: 700;
+  }
+  div.warning + p {
     background-color: #e08060;
     color: #ffffff;
     font-weight: 700;
@@ -101,10 +142,26 @@
     background-color: #e05030;
     font-weight: 800;
   }
+  div.warning::after {
+    background-color: #e05030;
+    font-weight: 800;
+  }
   aside > p > a, a:visited {
     color: #50e7f4;
   }
+  div.note + p > a, a:visited {
+    color: #50e7f4;
+  }
+  div.warning + p > a, a:visited {
+    color: #50e7f4;
+  }
   aside > p > a:hover {
+    color: #90ffff;
+  }
+  div.note + p > a:hover {
+    color: #90ffff;
+  }
+  div.warning + p > a:hover {
     color: #90ffff;
   }
   blockquote {
@@ -122,21 +179,77 @@ aside {
   padding-bottom: 0;
   margin-bottom: 1.5rem;
 }
-aside::before {
+div.note + p {
+  padding-top: 4.4rem;
+  padding-left: 0.15rem;
+  padding-right: 0.15rem;
+  padding-bottom: 1.4rem;
+  margin-top: -2.25rem;
+  margin-bottom: 1.5rem;
+}
+div.warning + p {
+  padding-top: 4.4rem;
+  padding-left: 0.15rem;
+  padding-right: 0.15rem;
+  padding-bottom: 1.4rem;
+  margin-top: -2.25rem;
+  margin-bottom: 1.5rem;
+}
+aside.note::before {
   font-size: 130%;
   padding-top: 0.2rem;
   padding-left: 1rem;
   padding-right: 0.2rem;
   padding-bottom: 0.3rem;
   margin-bottom: 1.2rem;
+  content: "Note";
 }
-aside.note::before {
+div.note::after {
+  width: 96.7%;
+  display: inline-block;
+  font-size: 130%;
+  padding-top: 0.2rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  padding-bottom: 0.3rem;
+  margin-top: 0.2rem;
+  margin-left: 0.2rem;
+  margin-right: 0.2rem;
+  margin-bottom: -0.4rem;
   content: "Note";
 }
 aside.warning::before {
+  font-size: 130%;
+  padding-top: 0.2rem;
+  padding-left: 1rem;
+  padding-right: 0.2rem;
+  padding-bottom: 0.3rem;
+  margin-bottom: 1.2rem;
+  content: "Warning";
+}
+div.warning::after {
+  width: 97.8%;
+  display: inline-block;
+  font-size: 130%;
+  padding-top: 0.2rem;
+  padding-left: 1rem;
+  padding-right: 0.2rem;
+  padding-bottom: 0.3rem;
+  margin-top: 0.2rem;
+  margin-left: 0.2rem;
+  margin-right: 0.2rem;
+  margin-bottom: -0.4rem;
   content: "Warning";
 }
 aside > p {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+div.note + p {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+div.warning + p {
   padding-left: 1rem;
   padding-right: 1rem;
 }

--- a/rendered/zip-0325.html
+++ b/rendered/zip-0325.html
@@ -94,10 +94,15 @@ tree:</p>
 <li> <span class="math">\(m_{\mathsf{metadata}} / 325' / \mathsf{coinType}' / \mathsf{account}'\)</span> - Account Metadata Key
 
 <ul>
-<li><span class="math">\(\ldots / 0'\)</span> - Account-level Inherent Metadata Key</li>
+<li> <span class="math">\(\ldots / 0'\)</span> - Account-level Inherent Metadata Key
+
+<ul>
 <li> <span class="math">\(\ldots / \ldots\)</span> - (Reserved for future updates to this ZIP)</li>
 <li> <span class="math">\(\ldots / (\mathtt{0x7FFFFFFF}', \mathsf{PrivateUseSubject})\)</span> - Private-use Inherent Metadata Key</li>
-<li><span class="math">\(\ldots / 1'\)</span> - Account-level External Metadata Key</li>
+</ul></li>
+<li> <span class="math">\(\ldots / 1'\)</span> - Account-level External Metadata Key
+
+<ul>
 <li> <span class="math">\(\ldots / (0', \mathsf{FVKTypedItem})\)</span> - Imported UFVK Metadata Key
 
 <ul>
@@ -105,7 +110,8 @@ tree:</p>
 <li><span class="math">\(\ldots / (\mathtt{0x7FFFFFFF}', \mathsf{PrivateUseSubject})\)</span> - Private-use External Metadata Key</li>
 </ul></li>
 <li> <span class="math">\(\ldots / \ldots\)</span> - (Reserved for future updates to this ZIP)</li>
-<li><span class="math">\(\ldots / \ldots\)</span> - (Reserved for future updates to this ZIP)</li>
+</ul></li>
+<li> <span class="math">\(\ldots / \ldots\)</span> - (Reserved for future updates to this ZIP)</li>
 </ul></li>
 </ul>
 
@@ -196,16 +202,15 @@ most 252 bytes that identifies the desired private-use context.</li>
 <li>Return <span class="math">\(\mathsf{CKDreg}(K, \mathtt{0x7FFFFFFF}, \mathsf{PrivateUseSubject})\)</span></li>
 </ul>
 
-<p>:::warning
-It is the responsibility of wallet developers to ensure that they do not use
+<div class=warning></div>
+
+<p>It is the responsibility of wallet developers to ensure that they do not use
 colliding <span class="math">\(\mathsf{PrivateUseSubject}\)</span> values, and to analyse their private use for
 any security risks related to potential cross-protocol attacks (in the event that
 two wallet developers happen to select a colliding <span class="math">\(\mathsf{PrivateUseSubject}\)</span>).
 Wallet developers that are unwilling to accept these risks SHOULD propose new
 standardised metadata protocols instead, to benefit from ecosystem coordination
-and review.
-:::
-</p>
+and review.</p>
 
 <h1 id="referenceimplementation"><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#referenceimplementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h1>
 

--- a/rendered/zip-0325.html
+++ b/rendered/zip-0325.html
@@ -214,7 +214,7 @@ and review.</p>
 
 <div class="note"></div>
 
-<p>Zashi uses the string <span class="math">\(\texttt{“metadata”}\)</span> for <span class="math">\(\mathsf{PrivateUseSubject}\)</span>.
+<p>Zashi uses the string <span class="math">\(\texttt{“metadata”}\)</span> for one of its <span class="math">\(\mathsf{PrivateUseSubject}\)</span> use cases.
 This is an example of a bad choice of private-use name, since it does not include
 a wallet-specific prefix such as <span class="math">\(\texttt{“Zashi”}\)</span>, or a version number.</p>
 

--- a/rendered/zip-0325.html
+++ b/rendered/zip-0325.html
@@ -212,6 +212,12 @@ Wallet developers that are unwilling to accept these risks SHOULD propose new
 standardised metadata protocols instead, to benefit from ecosystem coordination
 and review.</p>
 
+<div class="note"></div>
+
+<p>Zashi uses the string <span class="math">\(\texttt{“metadata”}\)</span> for <span class="math">\(\mathsf{PrivateUseSubject}\)</span>.
+This is an example of a bad choice of private-use name, since it does not include
+a wallet-specific prefix such as <span class="math">\(\texttt{“Zashi”}\)</span>, or a version number.</p>
+
 <h1 id="referenceimplementation"><span class="section-heading">Reference implementation</span><span class="section-anchor"> <a rel="bookmark" href="#referenceimplementation"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h1>
 
 <ul>

--- a/rendered/zip-guide-markdown.html
+++ b/rendered/zip-guide-markdown.html
@@ -166,26 +166,23 @@ ZIP editors will catch any inconsistencies in review.</p>
 
 <h2 id="notesandwarnings"><span class="section-heading">Notes and warnings</span><span class="section-anchor"> <a rel="bookmark" href="#notesandwarnings"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
-<p>:::info
-&#8220;<code>.. note::</code>&#8221; in reStructuredText, or &#8220;<code>:::info</code>&#8221; (terminated by
-&#8220;<code>:::</code>&#8221;) in Markdown, can be used for an aside from the main text.
-</p>
+<div class="note"></div>
 
-<dl>
-<dt>The rendering of notes is colourful and may be distracting, so they should</dt>
-<dt>only be used for important points.</dt>
-<dd>::</dd>
+<p>&#8220;<code>.. note::</code>&#8221; in reStructuredText or &#8220;<code>&lt;div class=&quot;note&quot;&gt;&lt;/div&gt;</code>&#8221; in Markdown
+(followed by a blank line in either case), can be used for an aside from the main
+text. The rendering of notes is colourful and may be distracting, so they should
+only be used for important points.</p>
 
-<dd>::warning
-&#8220;<code>.. warning::</code>&#8221; in reStructuredText, or &#8220;<code>:::warning</code>&#8221; (terminated by
-&#8220;<code>:::</code>&#8221;) in Markdown, can be used for warnings.</dd>
+<div class="warning"></div>
 
-<dt>Warnings should be used very sparingly — for example to signal that a</dt>
-<dt>entire specification, or part of it, may be inapplicable or could cause</dt>
-<dt>significant interoperability or security problems. In most cases, a &#8220;MUST&#8221;</dt>
-<dt>or &#8220;SHOULD&#8221; conformance requirement is more appropriate.</dt>
-<dd>::</dd>
-</dl>
+<p>&#8220;<code>.. warning::</code>&#8221; in reStructuredText or &#8220;<code>&lt;div class=&quot;warning&quot;&gt;&lt;/div&gt;</code>&#8221; in
+Markdown (followed by a blank line in either case), can be used for warnings.
+Warnings should be used very sparingly — for example to signal that a
+entire specification, or part of it, may be inapplicable or could cause
+significant interoperability or security problems. In most cases, a &#8220;MUST&#8221;
+or &#8220;SHOULD&#8221; conformance requirement is more appropriate.</p>
+
+<p>In Markdown, notes and warnings can currently only be a single paragraph.</p>
 
 <h2 id="validmarkup"><span class="section-heading">Valid markup</span><span class="section-anchor"> <a rel="bookmark" href="#validmarkup"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 

--- a/rendered/zip-guide.html
+++ b/rendered/zip-guide.html
@@ -91,13 +91,14 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/253">https://githu
             </section>
             <section id="notes-and-warnings"><h3><span class="section-heading">Notes and warnings</span><span class="section-anchor"> <a rel="bookmark" href="#notes-and-warnings"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <aside class="note">
-                    <p>"<code>.. note::</code>" in reStructuredText, or "<code>:::info</code>" (terminated by "<code>:::</code>") in Markdown, can be used for an aside from the main text.</p>
+                    <p>"<code>.. note::</code>" in reStructuredText or "<code>&lt;div class="note"&gt;&lt;/div&gt;</code>" in Markdown (followed by a blank line in either case), can be used for an aside from the main text.</p>
                     <p>The rendering of notes is colourful and may be distracting, so they should only be used for important points.</p>
                 </aside>
                 <aside class="warning">
-                    <p>"<code>.. warning::</code>" in reStructuredText, or "<code>:::warning</code>" (terminated by "<code>:::</code>") in Markdown, can be used for warnings.</p>
+                    <p>"<code>.. warning::</code>" in reStructuredText, or "<code>&lt;div class="warning"&gt;&lt;/div&gt;</code>" in Markdown (followed by a blank line in either case), can be used for warnings.</p>
                     <p>Warnings should be used very sparingly — for example to signal that a entire specification, or part of it, may be inapplicable or could cause significant interoperability or security problems. In most cases, a "MUST" or "SHOULD" conformance requirement is more appropriate.</p>
                 </aside>
+                <p>In Markdown, notes and warnings can currently only be a single paragraph.</p>
             </section>
             <section id="valid-markup"><h3><span class="section-heading">Valid markup</span><span class="section-anchor"> <a rel="bookmark" href="#valid-markup"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>This is optional before publishing a PR, but to check whether a document is valid reStructuredText or Markdown, first install <code>docutils</code> and <code>rst2html5</code>, and build <code>MultiMarkdown-6</code>. E.g. on Debian-based distros:</p>

--- a/zips/zip-0325.md
+++ b/zips/zip-0325.md
@@ -183,7 +183,7 @@ and review.
 
 <div class="note"></div>
 
-Zashi uses the string $\texttt{“metadata”}$ for $\mathsf{PrivateUseSubject}$.
+Zashi uses the string $\texttt{“metadata”}$ for one of its $\mathsf{PrivateUseSubject}$ use cases.
 This is an example of a bad choice of private-use name, since it does not include
 a wallet-specific prefix such as $\texttt{“Zashi”}$, or a version number.
 

--- a/zips/zip-0325.md
+++ b/zips/zip-0325.md
@@ -78,16 +78,16 @@ tree:
 The tree has the following general structure, specified in more detail below:
 
 - $m_{\mathsf{metadata}}$: Metadata Key tree
-  - $m_{\mathsf{metadata}} / 325' / \mathsf{coinType}' / \mathsf{account}'$ - Account Metadata Key
-    - $\ldots / 0'$ - Account-level Inherent Metadata Key
+   - $m_{\mathsf{metadata}} / 325' / \mathsf{coinType}' / \mathsf{account}'$ - Account Metadata Key
+      - $\ldots / 0'$ - Account-level Inherent Metadata Key
+         - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
+         - $\ldots / (\mathtt{0x7FFFFFFF}', \mathsf{PrivateUseSubject})$ - Private-use Inherent Metadata Key
+      - $\ldots / 1'$ - Account-level External Metadata Key
+         - $\ldots / (0', \mathsf{FVKTypedItem})$ - Imported UFVK Metadata Key
+            - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
+            - $\ldots / (\mathtt{0x7FFFFFFF}', \mathsf{PrivateUseSubject})$ - Private-use External Metadata Key
+         - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
       - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
-      - $\ldots / (\mathtt{0x7FFFFFFF}', \mathsf{PrivateUseSubject})$ - Private-use Inherent Metadata Key
-    - $\ldots / 1'$ - Account-level External Metadata Key
-      - $\ldots / (0', \mathsf{FVKTypedItem})$ - Imported UFVK Metadata Key
-        - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
-        - $\ldots / (\mathtt{0x7FFFFFFF}', \mathsf{PrivateUseSubject})$ - Private-use External Metadata Key
-      - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
-    - $\ldots / \ldots$ - (Reserved for future updates to this ZIP)
 
 Non-leaf keys in the key tree MUST NOT be used directly to encrypt metadata.
 Encryption keys are leaves in this key tree. The sole exception to this is
@@ -171,7 +171,8 @@ valid hardened child index) within its key tree for this purpose.
   most 252 bytes that identifies the desired private-use context.
 - Return $\mathsf{CKDreg}(K, \mathtt{0x7FFFFFFF}, \mathsf{PrivateUseSubject})$
 
-:::warning
+<div class=warning></div>
+
 It is the responsibility of wallet developers to ensure that they do not use
 colliding $\mathsf{PrivateUseSubject}$ values, and to analyse their private use for
 any security risks related to potential cross-protocol attacks (in the event that
@@ -179,7 +180,6 @@ two wallet developers happen to select a colliding $\mathsf{PrivateUseSubject}$)
 Wallet developers that are unwilling to accept these risks SHOULD propose new
 standardised metadata protocols instead, to benefit from ecosystem coordination
 and review.
-:::
 
 
 # Reference implementation

--- a/zips/zip-0325.md
+++ b/zips/zip-0325.md
@@ -181,6 +181,11 @@ Wallet developers that are unwilling to accept these risks SHOULD propose new
 standardised metadata protocols instead, to benefit from ecosystem coordination
 and review.
 
+<div class="note"></div>
+
+Zashi uses the string $\texttt{“metadata”}$ for $\mathsf{PrivateUseSubject}$.
+This is an example of a bad choice of private-use name, since it does not include
+a wallet-specific prefix such as $\texttt{“Zashi”}$, or a version number.
 
 # Reference implementation
 

--- a/zips/zip-guide-markdown.md
+++ b/zips/zip-guide-markdown.md
@@ -156,23 +156,23 @@ ZIP editors will catch any inconsistencies in review.
 
 ## Notes and warnings
 
-:::info
-"`.. note::`" in reStructuredText, or "`:::info`" (terminated by
-"``:::``") in Markdown, can be used for an aside from the main text.
+<div class="note"></div>
 
-The rendering of notes is colourful and may be distracting, so they should
+"`.. note::`" in reStructuredText or "`<div class="note"></div>`" in Markdown
+(followed by a blank line in either case), can be used for an aside from the main
+text. The rendering of notes is colourful and may be distracting, so they should
 only be used for important points.
-:::
 
-:::warning
-"`.. warning::`" in reStructuredText, or "`:::warning`" (terminated by
-"`:::`") in Markdown, can be used for warnings.
+<div class="warning"></div>
 
+"`.. warning::`" in reStructuredText or "`<div class="warning"></div>`" in
+Markdown (followed by a blank line in either case), can be used for warnings.
 Warnings should be used very sparingly — for example to signal that a
 entire specification, or part of it, may be inapplicable or could cause
 significant interoperability or security problems. In most cases, a "MUST"
 or "SHOULD" conformance requirement is more appropriate.
-:::
+
+In Markdown, notes and warnings can currently only be a single paragraph.
 
 ## Valid markup
 

--- a/zips/zip-guide.rst
+++ b/zips/zip-guide.rst
@@ -167,20 +167,23 @@ Notes and warnings
 ------------------
 
 .. note::
-    "``.. note::``" in reStructuredText, or "``:::info``" (terminated by
-    "``:::``") in Markdown, can be used for an aside from the main text.
+    "``.. note::``" in reStructuredText or "``<div class="note"></div>``" in
+    Markdown (followed by a blank line in either case), can be used for an aside
+    from the main text.
 
     The rendering of notes is colourful and may be distracting, so they should
     only be used for important points.
 
 .. warning::
-    "``.. warning::``" in reStructuredText, or "``:::warning``" (terminated by
-    "``:::``") in Markdown, can be used for warnings.
+    "``.. warning::``" in reStructuredText, or "``<div class="warning"></div>``"
+    in Markdown (followed by a blank line in either case), can be used for warnings.
 
     Warnings should be used very sparingly — for example to signal that a
     entire specification, or part of it, may be inapplicable or could cause
     significant interoperability or security problems. In most cases, a "MUST"
     or "SHOULD" conformance requirement is more appropriate.
+
+In Markdown, notes and warnings can currently only be a single paragraph.
 
 Valid markup
 ------------


### PR DESCRIPTION
This also fixes the rendering of notes and warnings for Markdown ZIPs.