### PR TITLE
[ZIP 0] Privacy Implications section and other updates

### DIFF
--- a/rendered/zip-0000.html
+++ b/rendered/zip-0000.html
@@ -26,7 +26,7 @@ Created: 2019-02-16
 License: BSD-2-Clause</pre>
         <section id="terminology"><h2><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", "RECOMMENDED", "OPTIONAL", and "REQUIRED" in this document are to be interpreted as described in BCP 14 <a id="footnote-reference-1" class="footnote_reference" href="#bcp14">1</a> when, and only when, they appear in all capitals.</p>
-            <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">3</a></p>
+            <p>The term "network upgrade" in this document is to be interpreted as described in ZIP 200. <a id="footnote-reference-2" class="footnote_reference" href="#zip-0200">2</a></p>
         </section>
         <section id="abstract"><h2><span class="section-heading">Abstract</span><span class="section-anchor"> <a rel="bookmark" href="#abstract"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>A Zcash Improvement Proposal (ZIP) is a design document providing information to the Zcash community, or describing a new feature for Zcash or its processes or environment. The ZIP should provide a concise technical specification of the feature and a rationale for the feature.</p>
@@ -37,9 +37,9 @@ License: BSD-2-Clause</pre>
         <section id="zip-workflow"><h2><span class="section-heading">ZIP Workflow</span><span class="section-anchor"> <a rel="bookmark" href="#zip-workflow"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The ZIP process begins with a new idea for Zcash. Each potential ZIP must have Owners — one or more people who write the ZIP using the style and format described below, shepherd the discussions in the appropriate forums, and attempt to build community consensus around the idea. The ZIP Owners should first attempt to ascertain whether the idea is ZIP-able. Small enhancements or patches to a particular piece of software often don't require standardisation between multiple projects; these don't need a ZIP and should be injected into the relevant project-specific development workflow with a patch submission to the applicable issue tracker. Additionally, many ideas have been brought forward for changing Zcash that have been rejected for various reasons. The first step should be to search past discussions to see if an idea has been considered before, and if so, what issues arose in its progression. After investigating past work, the best way to proceed is by posting about the new idea to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum</a>.</p>
             <p>Vetting an idea publicly before going as far as writing a ZIP is meant to save both the potential Owners and the wider community time. Asking the Zcash community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the internet does not always do the trick). It also helps to make sure the idea is applicable to the entire community and not just the Owners. Just because an idea sounds good to the Owners does not mean it will work for most people in most areas where Zcash is used.</p>
-            <p>Once the Owners have asked the Zcash community as to whether an idea has any chance of acceptance, a draft ZIP should be presented to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum</a>. This gives the Owners a chance to flesh out the draft ZIP to make it properly formatted, of high quality, and to address additional concerns about the proposal. Following a discussion, the proposal should be submitted to the ZIPs git repository <a id="footnote-reference-3" class="footnote_reference" href="#zips-repo">8</a> as a pull request. This draft must be written in ZIP style as described below, and named with an alias such as <code>draft-zatoshizakamoto-42millionzec</code> until the ZIP Editors have assigned it a ZIP number (Owners MUST NOT self-assign ZIP numbers).</p>
-            <p>ZIP Owners are responsible for collecting community feedback on both the initial idea and the ZIP before submitting it for review. However, wherever possible, long open-ended discussions on forums should be avoided.</p>
-            <p>It is highly recommended that a single ZIP contain a single key proposal or new idea. The more focused the ZIP, the more successful it tends to be. If in doubt, split your ZIP into several well-focused ones.</p>
+            <p>Once the Owners have asked the Zcash community as to whether an idea has any chance of acceptance, a ZIP draft should be presented to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum</a>. This gives the Owners a chance to flesh out the ZIP draft to make it properly formatted, of high quality, and to address additional concerns about the proposal. Following a discussion, the proposal should be submitted to the ZIPs git repository <a id="footnote-reference-3" class="footnote_reference" href="#zips-repo">7</a> as a pull request. This draft must be written in ZIP style as described below, and named with an alias such as <code>draft-zatoshizakamoto-42millionzec</code> until the ZIP Editors have assigned it a ZIP number (Owners MUST NOT self-assign ZIP numbers).</p>
+            <p>ZIP Owners are responsible for collecting community feedback on both the initial idea and the ZIP draft before submitting it for review. However, wherever possible, long open-ended discussions on forums should be avoided.</p>
+            <p>It is highly recommended that a single ZIP contain a single key proposal or new idea. The more focused the ZIP, the more successful it tends to be. If in doubt, split your ZIP draft into several well-focused ones.</p>
             <p>When the ZIP draft is complete, the ZIP Editors will assign the ZIP a number (if that has not already been done) and one or more Categories, and merge the pull request to the ZIPs git repository. The ZIP Editors will not unreasonably reject a ZIP. Reasons for rejecting ZIPs include duplication of effort, disregard for formatting rules, being too unfocused or too broad, being technically unsound, not providing proper motivation or not in keeping with the Zcash philosophy. For a ZIP to be accepted it must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement. The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.</p>
             <p>The ZIP Owners may update the draft as necessary in the git repository. Updates to drafts should also be submitted by the Owners as pull requests.</p>
             <section id="zip-numbering-conventions"><h3><span class="section-heading">ZIP Numbering Conventions</span><span class="section-anchor"> <a rel="bookmark" href="#zip-numbering-conventions"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -89,24 +89,25 @@ License: BSD-2-Clause</pre>
             </section>
             <section id="zip-editor-responsibilities"><h3><span class="section-heading">ZIP Editor Responsibilities</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-responsibilities"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The ZIP Editors subscribe to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum.</a></p>
-                <p>Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git repository <a id="footnote-reference-4" class="footnote_reference" href="#zips-repo">8</a>. It SHOULD NOT contain a ZIP number unless one had already been assigned by the ZIP Editors. The pull request SHOULD initially be marked as a Draft. The ZIP content SHOULD be submitted in reStructuredText <a id="footnote-reference-5" class="footnote_reference" href="#rst">5</a> or Markdown <a id="footnote-reference-6" class="footnote_reference" href="#markdown">6</a> format. Generating HTML for a ZIP is OPTIONAL.</p>
-                <p>For each new ZIP that comes in, the ZIP Editors SHOULD:</p>
+                <p>Each new ZIP draft SHOULD be submitted as a "pull request" to the ZIPs git repository <a id="footnote-reference-4" class="footnote_reference" href="#zips-repo">7</a>. It SHOULD NOT contain a ZIP number unless one had already been assigned by the ZIP Editors. The ZIP content SHOULD be submitted in reStructuredText <a id="footnote-reference-5" class="footnote_reference" href="#rst">4</a> or Markdown <a id="footnote-reference-6" class="footnote_reference" href="#markdown">5</a> format, and the Status field MUST initially be set to Draft. Generating HTML for a ZIP is OPTIONAL.</p>
+                <p>For each new ZIP draft that is received, the ZIP Editors SHOULD:</p>
                 <ul>
-                    <li>Read the ZIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.</li>
+                    <li>Read the ZIP draft to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted. See <a href="#reviewing-a-zip">Reviewing a ZIP</a> below for further detail.</li>
                     <li>Check that the Title, Category, and other metadata fields accurately describe the content.</li>
-                    <li>Ensure that the ZIP draft has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-7" class="footnote_reference" href="#zips-repo">8</a>. In some cases it may also be appropriate for it to be sent to the Zcash Community Forum.</li>
-                    <li>Ensure that motivation and backward compatibility have been addressed, if applicable.</li>
+                    <li>Ensure that a PR has been created for the ZIP draft in the ZIPs git repository <a id="footnote-reference-7" class="footnote_reference" href="#zips-repo">7</a>.</li>
+                    <li>Ensure that the existence of the draft has been announced on the Zcash Community Forum and the <cite>#zips</cite> channel of the Zcash R&amp;D Discord.</li>
                     <li>Check that the licensing terms are acceptable for ZIPs.</li>
                 </ul>
                 <p>For proposals to revise an existing ZIP, the ZIP Editors SHOULD:</p>
                 <ul>
-                    <li>Read the proposed modification to check if it is ready: sound, complete, and non-disruptive to the ZIP's existing deployments if any.</li>
+                    <li>Read the proposed modification to check if it is ready: sound, complete, and non-disruptive to the ZIP's existing deployments if any. See <a href="#reviewing-a-zip">Reviewing a ZIP</a> below for further detail.</li>
                     <li>If the proposed changes primarily affect already-deployed aspects of the Zcash consensus protocol, they SHOULD be specified in an "Update ZIP" describing the changes to be made, rather than directly as a pull request modifying the existing ZIP(s) or the Zcash Protocol Specification. At the discretion of the ZIP Editors, this might not be needed for compatible changes or clarifications.</li>
                     <li>If a change is to be made to an existing ZIP, check that the Title, Category, and other metadata fields still accurately describe the modified content.</li>
-                    <li>Ensure that the update has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-8" class="footnote_reference" href="#zips-repo">8</a>. In some cases it may also be appropriate for it to be sent to the Zcash Community Forum.</li>
-                    <li>Ensure that motivation and backward compatibility have been addressed, if applicable.</li>
+                    <li>Ensure that the update has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-8" class="footnote_reference" href="#zips-repo">7</a>.</li>
+                    <li>If the proposed update is substantive and not merely editorial, ensure that it has been announced on the Zcash Community Forum and the <cite>#zips</cite> channel of the Zcash R&amp;D Discord.</li>
                     <li>Check that the licensing terms are still acceptable for ZIPs.</li>
                 </ul>
+                <p>Announcing new ZIP drafts and updated ZIPs helps ensure transparency and encourages timely community engagement and feedback. Such announcements SHOULD clearly state the ZIP number, title, and a brief summary.</p>
                 <p>If an Update ZIP is accepted, it is the responsibility of the ZIP Editors to apply the changes it describes to any existing specifications, but this MUST only be done once the Status of the Update ZIP has reached at least Proposed.</p>
                 <p>If a new Revision is added to a ZIP, then its original deployment is called Revision 0. In some cases the revisions of a ZIP may have differing deployment Status, which is expressed in the Status field as described in <a href="#zip-status-field">ZIP Status Field</a> below.</p>
             </section>
@@ -115,11 +116,23 @@ License: BSD-2-Clause</pre>
                 <p>ZIP Owners are free to clarify, modify, or decline suggestions from ZIP Editors. If the ZIP Editors make a change to a ZIP that the Owners disagree with, then the Editors SHOULD revert the change.</p>
                 <p>Typically, the ZIP Editors suggest changes in two phases:</p>
                 <ul>
-                    <li><cite>content review</cite>: multiple ZIP Editors discuss the ZIP, and suggest changes to the overall content. This is a "big picture" review.</li>
-                    <li><cite>format review</cite>: two ZIP Editors do a detailed review of the structure and format of the ZIP. This ensures the ZIP is consistent with other Zcash specifications.</li>
+                    <li><cite>content review</cite>: multiple ZIP Editors discuss the ZIP draft or update, and suggest changes to the overall content. This is a "big picture" review.</li>
+                    <li><cite>format review</cite>: two ZIP Editors do a detailed review of the structure and format of the ZIP draft. This ensures the ZIP draft is consistent with other Zcash specifications.</li>
                 </ul>
-                <p>If the ZIP isn't ready, the Editors will send it back to the Owners for revision, with specific instructions. This decision is made by consensus among the current Editors.</p>
-                <p>When a ZIP is ready, the ZIP Editors will:</p>
+                <p>The content review is where general weaknesses in the ZIP draft should be identified, which might include:</p>
+                <ul>
+                    <li>Insufficient or unclear motivation.</li>
+                    <li>Unclear, under-documented, or missing privacy implications.</li>
+                    <li>Significant objectives of the ZIP draft that are not clearly documented in the <cite>Requirements</cite> section.</li>
+                    <li>Missing trust assumptions.</li>
+                    <li>Security risks that are insufficiently addressed.</li>
+                    <li>Unaddressed backward compatibility issues.</li>
+                </ul>
+                <p>In addition, ZIP Editors may request input from community security or privacy experts for proposals with significant implications.</p>
+                <p>Note that it is not the primary responsibility of the ZIP Editors to review proposals for security, correctness, or implementability.</p>
+                <p>If the ZIP draft isn't ready, the Editors will send it back to the Owners for revision, with specific instructions. This decision is made by consensus among the current Editors.</p>
+                <p>Format review should generally occur after content review feedback has been addressed, to avoid unnecessary document churn or merge conflicts.</p>
+                <p>When a ZIP draft is ready, the ZIP Editors will:</p>
                 <ul>
                     <li>Ensure that a unique ZIP number has been assigned in the pull request.</li>
                     <li>Regenerate the corresponding HTML documents, if required.</li>
@@ -128,12 +141,13 @@ License: BSD-2-Clause</pre>
                 <p>The ZIP editors monitor ZIP changes and update ZIP headers as appropriate.</p>
             </section>
             <section id="rejecting-a-zip-or-update"><h3><span class="section-heading">Rejecting a ZIP or update</span><span class="section-anchor"> <a rel="bookmark" href="#rejecting-a-zip-or-update"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>The ZIP Editors MAY reject a new ZIP or an update to an existing ZIP, by consensus among the current Editors. Rejections can be based on any of the following reasons:</p>
+                <p>The ZIP Editors MAY reject a new ZIP draft or an update to an existing ZIP, by consensus among the current Editors. Rejections can be based on any of the following reasons:</p>
                 <ul>
-                    <li>it violates the Zcash Code of Conduct <a id="footnote-reference-9" class="footnote_reference" href="#conduct">4</a> ;</li>
+                    <li>it violates the Zcash Code of Conduct <a id="footnote-reference-9" class="footnote_reference" href="#conduct">3</a> ;</li>
                     <li>it appears too unfocused or broad;</li>
                     <li>it duplicates effort in other ZIPs without sufficient technical justification (however, alternative proposals to address similar or overlapping problems are not excluded for this reason);</li>
                     <li>it has manifest security flaws (including being unrealistically dependent on user vigilance to avoid security weaknesses);</li>
+                    <li>it fails to adequately consider privacy implications;</li>
                     <li>it disregards compatibility with the existing Zcash blockchain or ecosystem;</li>
                     <li>it is manifestly unimplementable;</li>
                     <li>it includes buggy code, pseudocode, or algorithms;</li>
@@ -145,15 +159,14 @@ License: BSD-2-Clause</pre>
                     <li>it disregards formatting rules;</li>
                     <li>it makes non-editorial edits to previous entries in a ZIP's Change history, if there is one;</li>
                     <li>an update to an existing ZIP extends or changes its scope to an extent that would be better handled as a separate ZIP;</li>
-                    <li>a new ZIP has a category that does not reflect its content, or an update would change a ZIP to an inappropriate category;</li>
+                    <li>a new ZIP draft has a category that does not reflect its content, or an update would change a ZIP to an inappropriate category;</li>
                     <li>it violates any specific "MUST" or "MUST NOT" rule in this document;</li>
-                    <li>the expressed political views of a Owner of the document are inimical to the Zcash Code of Conduct <a id="footnote-reference-10" class="footnote_reference" href="#conduct">4</a> (except in the case of an update removing that Owner);</li>
+                    <li>the expressed political views of a Owner of the document are inimical to the Zcash Code of Conduct <a id="footnote-reference-10" class="footnote_reference" href="#conduct">3</a> (except in the case of an update removing that Owner);</li>
                     <li>it is not authorized by the stated ZIP Owners;</li>
                     <li>it removes an Owner without their consent (unless the reason for removal is directly related to a breach of the Code of Conduct by that Owner);</li>
                     <li>it violates a conformance requirement of any Active Process ZIP (including this ZIP).</li>
                 </ul>
-                <p>The ZIP Editors MUST NOT unreasonably deny publication of a ZIP proposal or update that does not violate any of these criteria. If they refuse a proposal or update, they MUST give an explanation of which of the criteria were violated, with the exception that spam may be deleted without an explanation.</p>
-                <p>Note that it is not the primary responsibility of the ZIP Editors to review proposals for security, correctness, or implementability.</p>
+                <p>The ZIP Editors MUST NOT unreasonably deny publication of a ZIP draft or update that does not violate any of these criteria. If they refuse a proposal or update, they MUST give an explanation of which of the criteria were violated, with the exception that spam may be deleted without an explanation.</p>
             </section>
             <section id="communicating-with-the-zip-editors"><h3><span class="section-heading">Communicating with the ZIP Editors</span><span class="section-anchor"> <a rel="bookmark" href="#communicating-with-the-zip-editors"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>Please send all ZIP-related communications either:</p>
@@ -162,7 +175,7 @@ License: BSD-2-Clause</pre>
                     <li>by opening an issue on the <a href="https://github.com/zcash/zips/issues">ZIPs issue tracker</a>, or</li>
                     <li>by sending a message in the <a href="https://discord.com/channels/809218587167293450/809251050741170187">#zips channel on the Zcash R&amp;D Discord</a>.</li>
                 </ul>
-                <p><strong>All communications should abide by the Zcash Code of Conduct</strong> <a id="footnote-reference-11" class="footnote_reference" href="#conduct">4</a>.</p>
+                <p><strong>All communications should abide by the Zcash Code of Conduct</strong> <a id="footnote-reference-11" class="footnote_reference" href="#conduct">3</a>.</p>
             </section>
             <section id="zip-editor-meeting-practices"><h3><span class="section-heading">ZIP Editor Meeting Practices</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-meeting-practices"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The ZIP Editors SHOULD meet on a regular basis to review draft changes to ZIPs. Meeting times are agreed by consensus among the current ZIP Editors. A ZIP Editor meeting can be held even if some ZIP Editors are not available, but all Editors SHOULD be informed of significant decisions that are likely to be made at upcoming meetings.</p>
@@ -176,13 +189,20 @@ License: BSD-2-Clause</pre>
             </section>
         </section>
         <section id="zip-format-and-structure"><h2><span class="section-heading">ZIP format and structure</span><span class="section-anchor"> <a rel="bookmark" href="#zip-format-and-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>ZIPs SHOULD be written in reStructuredText <a id="footnote-reference-12" class="footnote_reference" href="#rst">5</a>, Markdown <a id="footnote-reference-13" class="footnote_reference" href="#markdown">6</a>, or LaTeX <a id="footnote-reference-14" class="footnote_reference" href="#latex">7</a>. For ZIPs written in LaTeX, a <code>Makefile</code> MUST be provided to build (at least) a PDF version of the document.</p>
+            <p>ZIPs SHOULD be written in reStructuredText <a id="footnote-reference-12" class="footnote_reference" href="#rst">4</a>, Markdown <a id="footnote-reference-13" class="footnote_reference" href="#markdown">5</a>, or LaTeX <a id="footnote-reference-14" class="footnote_reference" href="#latex">6</a>. For ZIPs written in LaTeX, a <code>Makefile</code> MUST be provided to build (at least) a PDF version of the document.</p>
             <p>Each ZIP SHOULD have the following parts:</p>
             <ul>
                 <li>Preamble — Headers containing metadata about the ZIP (<a href="#zip-header-preamble">see below</a>). The License field of the preamble indicates the licensing terms, which MUST be acceptable according to <a href="#zip-licensing">the ZIP licensing requirements</a>.</li>
                 <li>Terminology — Definitions of technical or non-obvious terms used in the document.</li>
-                <li>Abstract — A short (~200 word) description of the technical issue being addressed.</li>
+                <li>Abstract — The abstract SHOULD be a concise summary (approximately 200 words) that clearly describes the issue the ZIP addresses, the proposed solution, and the intended outcome. The ZIP MUST remain complete without the abstract.
+                    <p>The abstract SHOULD, as far as practical, provide enough context for readers to quickly understand what the ZIP is about, why it matters, and how it fits into the broader Zcash ecosystem. In addition to summarizing the technical content, the abstract SHOULD briefly mention any significant privacy implications. The abstract should not be vague or overly generic, but should serve as a faithful, high-level summary of the proposal that enables reviewers to understand the key ideas and potential implications without reading the entire document.</p>
+                </li>
                 <li>Motivation — The motivation is critical for ZIPs that want to change the Zcash protocol. It should clearly explain why the existing protocol is inadequate to address the problem that the ZIP solves.</li>
+                <li>Privacy Implications — This section SHOULD be present if the ZIP makes trade-offs or assumptions that could impact the privacy of Zcash users or protocol participants. Since this section is not part of the Specification, it MUST NOT directly include or duplicate conformance requirements on implementations or processes. Instead it contains a high-level overview of the privacy implications that may need to be considered for deployment of the ZIP.
+                    <p>The contents of this section could include, for example, trust assumptions affecting privacy that are introduced or modified by the proposal; privacy trade-offs or changes to anonymity guarantees; potential data leakage (e.g., from metadata, timing, or usage patterns); and exposure to known or novel privacy attack vectors. Proposals SHOULD consider any relevant threat model(s), and SHOULD propose updates to those threat models if the ZIP introduces new privacy-relevant assumptions or risks not currently addressed.</p>
+                    <p>If a change affects how wallets construct, interpret, or expose transaction data, or modifies user-facing protocol behavior, the ZIP SHOULD assess the implications for user privacy in that context.</p>
+                </li>
+                <li>Requirements — This section describes high-level goals that the Specification MUST ensure. It MUST NOT itself include conformance requirements, so that it is possible to perform a consistency check that what is specified meets the Requirements.</li>
                 <li>Specification — The technical specification should describe the interface and semantics of any new feature. The specification should be detailed enough to allow competing, interoperable implementations for any of the current Zcash platforms.</li>
                 <li>Rationale — The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work. The rationale should provide evidence of consensus within the community and discuss important objections or concerns raised during discussion.
                     <p>For longer ZIPs it can potentially be easier to have inline Rationale subsections interspersed throughout the Specification part. When taking this approach, the content of these subsections should be annotated with HTML tags to make it collapsible (so the rationale is available for review but doesn't get in the way of reading the specification). ZIPs written in Markdown can use the following syntax (note the newline after the <code>&lt;summary&gt;</code> tag):</p>
@@ -223,11 +243,10 @@ Important but hidden rationale!
 
    &lt;/details&gt;</pre>
                 </li>
-                <li>Security and privacy considerations — If applicable, security and privacy considerations should be explicitly described, particularly if the ZIP makes explicit trade-offs or assumptions. For guidance on this section consider RFC 3552 <a id="footnote-reference-15" class="footnote_reference" href="#rfc3552">2</a> as a starting point.</li>
                 <li>Reference implementation — Literal code implementing the ZIP's specification, and/or a link to the reference implementation of the ZIP's specification. The reference implementation MUST be completed before any ZIP is given status “Implemented” or “Final”, but it generally need not be completed before the ZIP is accepted into “Proposed”.</li>
             </ul>
             <section id="zip-stubs"><h3><span class="section-heading">ZIP stubs</span><span class="section-anchor"> <a rel="bookmark" href="#zip-stubs"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>A ZIP stub records that the ZIP Editors have reserved a number for a ZIP that is under development. It is not a ZIP, but exists in the ZIPs git repository <a id="footnote-reference-16" class="footnote_reference" href="#zips-repo">8</a> at the same path that will be used for the corresponding ZIP if and when it is published. It consists only of a preamble, which MUST use Reserved as the value of the Status field.</p>
+                <p>A ZIP stub records that the ZIP Editors have reserved a number for a ZIP that is under development. It is not a ZIP, but exists in the ZIPs git repository <a id="footnote-reference-15" class="footnote_reference" href="#zips-repo">7</a> at the same path that will be used for the corresponding ZIP if and when it is published. It consists only of a preamble, which MUST use Reserved as the value of the Status field.</p>
                 <p>ZIP stubs can be added and removed, or replaced by the corresponding ZIP, at the discretion of the ZIP Editors. If a ZIP stub is removed then its number MAY be reused, possibly for an entirely different ZIP.</p>
             </section>
             <section id="zip-header-preamble"><h3><span class="section-heading">ZIP header preamble</span><span class="section-anchor"> <a rel="bookmark" href="#zip-header-preamble"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -313,6 +332,7 @@ Updates:</pre>
                 <p>Owners of a ZIP MAY decide on their own to change the status between Draft or Withdrawn. All other changes in status MUST be approved by consensus among the current ZIP Editors.</p>
                 <p>A ZIP SHOULD only change status from Draft (or Rejected) to Proposed, when the Owner deems it is complete and there is rough consensus on the forums, validated by consensus among the current ZIP Editors. If it's a Consensus ZIP, a Deployment section MUST be present in order for the ZIP to change status to Proposed. Typically, although not necessarily, this will specify a network upgrade in which the consensus change is to activate.</p>
                 <p>A ZIP's status is Released if it is Proposed, Active, Implemented, or Final (i.e. not Draft, Rejected, Obsolete, or Withdrawn).</p>
+                <p>A ZIP that has significant security or privacy implications MUST NOT be changed from a non-Released status to a Released status without the design having undergone independent security review from qualified security or privacy experts. Similarly, changes to a Released ZIP that might invalidate the conclusions of previous security or privacy review, or leave significant security or privacy implications unaddressed, MUST undergo further independent review.</p>
                 <p>A ZIP SHOULD NOT be changed from a non-Released status to a Released status if there is significant community opposition to its content. (However, Draft ZIPs explicitly MAY describe proposals to which there is, or could be expected, significant community opposition.)</p>
                 <p>A Released ZIP MUST NOT be changed to a non-Released status if the specification is already implemented and is in common use, or where a Process ZIP still reflects a consensus of the community.</p>
                 <p>A Standards ZIP SHOULD only change status from Proposed to Implemented once the Owners provide an associated reference implementation. For Consensus ZIPs, an implementation MUST have been merged into at least one consensus node codebase (currently zcashd and/or zebra), typically in the period after the network upgrade's specification freeze but before the implementation audit. If the Owners miss this deadline, the Editors or Owners MAY choose to update the Deployment section of the ZIP to target another upgrade, at their discretion.</p>
@@ -391,18 +411,10 @@ Updates:</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="rfc3552" class="footnote">
-                <tbody>
-                    <tr>
-                        <th>2</th>
-                        <td><a href="https://www.rfc-editor.org/rfc/rfc3552.html">RFC 3552: Guidelines for Writing RFC Text on Security Considerations</a></td>
-                    </tr>
-                </tbody>
-            </table>
             <table id="zip-0200" class="footnote">
                 <tbody>
                     <tr>
-                        <th>3</th>
+                        <th>2</th>
                         <td><a href="zip-0200">ZIP 200: Network Upgrade Mechanism</a></td>
                     </tr>
                 </tbody>
@@ -410,7 +422,7 @@ Updates:</pre>
             <table id="conduct" class="footnote">
                 <tbody>
                     <tr>
-                        <th>4</th>
+                        <th>3</th>
                         <td><a href="https://github.com/zcash/zcash/blob/master/code_of_conduct.md">Zcash Code of Conduct</a></td>
                     </tr>
                 </tbody>
@@ -418,7 +430,7 @@ Updates:</pre>
             <table id="rst" class="footnote">
                 <tbody>
                     <tr>
-                        <th>5</th>
+                        <th>4</th>
                         <td><a href="https://docutils.sourceforge.io/rst.html">reStructuredText documentation</a></td>
                     </tr>
                 </tbody>
@@ -426,7 +438,7 @@ Updates:</pre>
             <table id="markdown" class="footnote">
                 <tbody>
                     <tr>
-                        <th>6</th>
+                        <th>5</th>
                         <td><a href="https://www.markdownguide.org/">The Markdown Guide</a></td>
                     </tr>
                 </tbody>
@@ -434,7 +446,7 @@ Updates:</pre>
             <table id="latex" class="footnote">
                 <tbody>
                     <tr>
-                        <th>7</th>
+                        <th>6</th>
                         <td><a href="https://www.latex-project.org/">LaTeX — a document preparation system</a></td>
                     </tr>
                 </tbody>
@@ -442,7 +454,7 @@ Updates:</pre>
             <table id="zips-repo" class="footnote">
                 <tbody>
                     <tr>
-                        <th>8</th>
+                        <th>7</th>
                         <td><a href="https://github.com/zcash/zips">ZIPs git repository</a></td>
                     </tr>
                 </tbody>

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -260,6 +260,7 @@ For proposals to revise an existing ZIP, the ZIP Editors SHOULD:
   for it to be sent to the Zcash Community Forum.
 * Ensure that motivation and backward compatibility have been
   addressed, if applicable.
+* Ensure that the ZIP considers relevant security and privacy implications and adequately addresses and documents relevant risks, trust assumptions, and privacy trade-offs.
 * Check that the licensing terms are still acceptable for ZIPs.
 
 If an Update ZIP is accepted, it is the responsibility of the ZIP Editors
@@ -272,6 +273,7 @@ called Revision 0. In some cases the revisions of a ZIP may have
 differing deployment Status, which is expressed in the Status field as
 described in `ZIP Status Field`_ below.
 
+In all instances, ZIP Editors SHOULD ensure that the community is made aware when a ZIP has been submitted as a proposal. When a ZIP transitions to Proposed status, Editors SHOULD announce it publicly on appropriate community channels (e.g., the Zcash Community Forum and the #zips Discord channel), clearly stating the ZIP number, title, and a brief summary. This helps ensure transparency and encourages timely community engagement and feedback.
 
 Reviewing a ZIP
 ---------------
@@ -349,6 +351,7 @@ of the following reasons:
   is directly related to a breach of the Code of Conduct by that Owner);
 * it violates a conformance requirement of any Active Process ZIP
   (including this ZIP).
+* it fails to adequately consider relevant security or privacy implications, including impact on the Wallet Threat Model where applicable.
 
 The ZIP Editors MUST NOT unreasonably deny publication of a ZIP proposal
 or update that does not violate any of these criteria. If they refuse a
@@ -356,8 +359,10 @@ proposal or update, they MUST give an explanation of which of the
 criteria were violated, with the exception that spam may be deleted
 without an explanation.
 
-Note that it is not the primary responsibility of the ZIP Editors to
-review proposals for security, correctness, or implementability.
+Note: While it is not the primary responsibility of the ZIP Editors to perform in-depth reviews of a proposal’s security, correctness, or implementability, they MUST verify that the proposal includes a Security and Privacy Considerations section that identifies relevant risks, trust assumptions, and privacy trade-offs.
+
+Editors MAY request input from community security or privacy experts for proposals with significant implications. Editors MUST require ZIP authors to consult qualified security or privacy experts for proposals with significant security or privacy implications. ZIP authors are responsible for ensuring that both the design and the implementation undergo independent security review, including formal code review. Editors themselves are not expected to perform audits or provide definitive assessments of security or correctness.
+
 
 Communicating with the ZIP Editors
 ----------------------------------
@@ -410,8 +415,7 @@ Each ZIP SHOULD have the following parts:
 * Terminology — Definitions of technical or non-obvious terms used
   in the document.
 
-* Abstract — A short (~200 word) description of the technical issue
-  being addressed.
+* Abstract — The abstract should be a concise summary (approximately 200 words) that clearly describes the problem the ZIP addresses, the proposed solution, and the intended outcome. It MUST provide enough context for readers to quickly understand what the ZIP is about, why it matters, and how it fits into the broader Zcash ecosystem. In addition to summarizing the technical content, the abstract MUST briefly mention any significant security or privacy considerations. The abstract should not be vague or overly generic, but should serve as a faithful, high-level summary of the proposal that enables reviewers to understand the key ideas and potential implications without reading the entire document.
 
 * Motivation — The motivation is critical for ZIPs that want to change
   the Zcash protocol. It should clearly explain why the existing
@@ -476,10 +480,7 @@ Each ZIP SHOULD have the following parts:
 
        </details>
 
-* Security and privacy considerations — If applicable, security
-  and privacy considerations should be explicitly described, particularly
-  if the ZIP makes explicit trade-offs or assumptions. For guidance on
-  this section consider RFC 3552 [#RFC3552]_ as a starting point.
+* Security and privacy considerations — This section is mandatory for all ZIPs. Security and privacy considerations MUST be explicitly described, particularly if the ZIP makes trade-offs or assumptions that could impact the privacy, integrity, or safety of Zcash users. This includes, but is not limited to, trust assumptions introduced or modified by the proposal; privacy trade-offs or changes to anonymity guarantees; potential data leakage (e.g., from metadata, timing, or usage patterns); exposure to known or novel attack vectors; and impact on interoperability with existing shielded or transparent features. Proposals MUST also consider the Zcash Wallet Threat Model. If a change affects how wallets construct, interpret, or expose transaction data, or modifies user-facing protocol behavior, it MUST assess the implications for user security and privacy in that context. Where relevant, the ZIP MUST reference the Wallet Threat Model and SHOULD propose updates if it introduces new assumptions or risks not currently addressed. For guidance on writing this section, consider RFC 3552 as a starting point.
 
 * Reference implementation — Literal code implementing the ZIP's
   specification, and/or a link to the reference implementation of

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -232,20 +232,20 @@ For each new ZIP that comes in, the ZIP Editors SHOULD:
 
 * Read the ZIP to check if it is ready: sound and complete. The ideas
   must make technical sense, even if they don't seem likely to be
-  accepted.
+  accepted. See `Reviewing a ZIP`_ below for further detail.
 * Check that the Title, Category, and other metadata fields accurately
   describe the content.
-* Ensure that the ZIP draft has been submitted as a PR to the ZIPs git
-  repository [#zips-repo]_. In some cases it may also be appropriate
-  for it to be sent to the Zcash Community Forum.
-* Ensure that motivation and backward compatibility have been
-  addressed, if applicable.
+* Ensure that a PR has been created for the ZIP draft in ZIPs git
+  repository [#zips-repo]_.
+* Ensure that the existence of the draft has been announced on the Zcash
+  Community Forum and the `#zips` channel of the Zcash R&D Discord.
 * Check that the licensing terms are acceptable for ZIPs.
 
 For proposals to revise an existing ZIP, the ZIP Editors SHOULD:
 
 * Read the proposed modification to check if it is ready: sound,
   complete, and non-disruptive to the ZIP's existing deployments if any.
+  See `Reviewing a ZIP`_ below for further detail.
 * If the proposed changes primarily affect already-deployed aspects
   of the Zcash consensus protocol, they SHOULD be specified in an
   "Update ZIP" describing the changes to be made, rather than directly
@@ -256,12 +256,15 @@ For proposals to revise an existing ZIP, the ZIP Editors SHOULD:
   Category, and other metadata fields still accurately describe the
   modified content.
 * Ensure that the update has been submitted as a PR to the ZIPs git
-  repository [#zips-repo]_. In some cases it may also be appropriate
-  for it to be sent to the Zcash Community Forum.
-* Ensure that motivation and backward compatibility have been
-  addressed, if applicable.
-* Ensure that the ZIP considers relevant security and privacy implications and adequately addresses and documents relevant risks, trust assumptions, and privacy trade-offs.
+  repository [#zips-repo]_.
+* If the proposed update is substantive and not merely editorial,
+  ensure that it has been announced on the Zcash Community Forum and
+  the `#zips` channel of the Zcash R&D Discord.
 * Check that the licensing terms are still acceptable for ZIPs.
+
+Announcing new and updated ZIP drafts helps ensure transparency and
+encourages timely community engagement and feedback. Such announcements
+SHOULD clearly state the ZIP number, title, and a brief summary.
 
 If an Update ZIP is accepted, it is the responsibility of the ZIP Editors
 to apply the changes it describes to any existing specifications, but
@@ -273,7 +276,6 @@ called Revision 0. In some cases the revisions of a ZIP may have
 differing deployment Status, which is expressed in the Status field as
 described in `ZIP Status Field`_ below.
 
-In all instances, ZIP Editors SHOULD ensure that the community is made aware when a ZIP has been submitted as a proposal. When a ZIP transitions to Proposed status, Editors SHOULD announce it publicly on appropriate community channels (e.g., the Zcash Community Forum and the #zips Discord channel), clearly stating the ZIP number, title, and a brief summary. This helps ensure transparency and encourages timely community engagement and feedback.
 
 Reviewing a ZIP
 ---------------
@@ -287,7 +289,6 @@ ZIP Owners are free to clarify, modify, or decline suggestions from ZIP Editors.
 If the ZIP Editors make a change to a ZIP that the Owners disagree with, then
 the Editors SHOULD revert the change.
 
-
 Typically, the ZIP Editors suggest changes in two phases:
 
 * `content review`: multiple ZIP Editors discuss the ZIP, and suggest
@@ -296,9 +297,29 @@ Typically, the ZIP Editors suggest changes in two phases:
   structure and format of the ZIP. This ensures the ZIP is consistent
   with other Zcash specifications.
 
+The content review is where general weaknesses in the ZIP draft should
+be identified, which might include:
+
+* Insufficient or unclear motivation.
+* Unclear, under-documented, or missing privacy implications.
+* Significant objectives of the ZIP that are not clearly documented in
+  the `Requirements` section.
+* Missing trust assumptions.
+* Security risks that are insufficiently addressed.
+* Unaddressed backward compatibility issues.
+
+In addition, ZIP Editors may request input from community security or
+privacy experts for proposals with significant implications.
+
+Note that it is not the primary responsibility of the ZIP Editors to
+review proposals for security, correctness, or implementability.
+
 If the ZIP isn't ready, the Editors will send it back to the Owners for
 revision, with specific instructions. This decision is made by consensus
 among the current Editors.
+
+Format review should generally occur after content review feedback has
+been addressed, to avoid unnecessary document churn or merge conflicts.
 
 When a ZIP is ready, the ZIP Editors will:
 
@@ -323,6 +344,7 @@ of the following reasons:
   are not excluded for this reason);
 * it has manifest security flaws (including being unrealistically dependent
   on user vigilance to avoid security weaknesses);
+* it fails to adequately consider privacy implications;
 * it disregards compatibility with the existing Zcash blockchain or ecosystem;
 * it is manifestly unimplementable;
 * it includes buggy code, pseudocode, or algorithms;
@@ -351,17 +373,12 @@ of the following reasons:
   is directly related to a breach of the Code of Conduct by that Owner);
 * it violates a conformance requirement of any Active Process ZIP
   (including this ZIP).
-* it fails to adequately consider relevant security or privacy implications, including impact on the Wallet Threat Model where applicable.
 
 The ZIP Editors MUST NOT unreasonably deny publication of a ZIP proposal
 or update that does not violate any of these criteria. If they refuse a
 proposal or update, they MUST give an explanation of which of the
 criteria were violated, with the exception that spam may be deleted
 without an explanation.
-
-It is not the primary responsibility of the ZIP Editors to perform in-depth reviews of a proposal’s security, correctness, or implementability. However, they MUST verify that the proposal attempts to identify relevant risks, trust assumptions, and privacy trade-offs.
-
-Editors MAY request input from community security or privacy experts for proposals with significant implications. Editors MUST require ZIP authors to consult qualified security or privacy experts for proposals with significant security or privacy implications. ZIP authors are responsible for ensuring that both the design and the implementation undergo independent security review, including formal code review. Editors themselves are not expected to perform audits or provide definitive assessments of security or correctness.
 
 
 Communicating with the ZIP Editors
@@ -415,11 +432,49 @@ Each ZIP SHOULD have the following parts:
 * Terminology — Definitions of technical or non-obvious terms used
   in the document.
 
-* Abstract — The abstract should be a concise summary (approximately 200 words) that clearly describes the problem the ZIP addresses, the proposed solution, and the intended outcome. It MUST provide enough context for readers to quickly understand what the ZIP is about, why it matters, and how it fits into the broader Zcash ecosystem. In addition to summarizing the technical content, the abstract MUST briefly mention any significant security or privacy considerations. The abstract should not be vague or overly generic, but should serve as a faithful, high-level summary of the proposal that enables reviewers to understand the key ideas and potential implications without reading the entire document.
+* Abstract — The abstract SHOULD be a concise summary (approximately
+  200 words) that clearly describes the issue the ZIP addresses, the
+  proposed solution, and the intended outcome. The ZIP MUST remain
+  complete without the abstract.
+
+  The abstract SHOULD, as far as practical, provide enough context for
+  readers to quickly understand what the ZIP is about, why it matters,
+  and how it fits into the broader Zcash ecosystem. In addition to
+  summarizing the technical content, the abstract SHOULD briefly mention
+  any significant privacy implications. The abstract should not be
+  vague or overly generic, but should serve as a faithful, high-level
+  summary of the proposal that enables reviewers to understand the key
+  ideas and potential implications without reading the entire document.
 
 * Motivation — The motivation is critical for ZIPs that want to change
   the Zcash protocol. It should clearly explain why the existing
   protocol is inadequate to address the problem that the ZIP solves.
+
+* Privacy Implications — This section SHOULD be present if the ZIP makes
+  trade-offs or assumptions that could impact the privacy of Zcash users
+  or protocol participants. Since this section is not part of the
+  Specification, it MUST NOT directly include or duplicate conformance
+  requirements on implementations. Instead it contains a high-level overview
+  of the privacy implications that may need to be considered for deployment
+  of the ZIP.
+
+  The contents of this section could include, for example, trust assumptions
+  affecting privacy that are introduced or modified by the proposal; privacy
+  trade-offs or changes to anonymity guarantees; potential data leakage
+  (e.g., from metadata, timing, or usage patterns); and exposure to known
+  or novel privacy attack vectors. Proposals SHOULD consider any relevant
+  threat model(s), and SHOULD propose updates to those threat models if the
+  ZIP introduces new privacy-relevant assumptions or risks not currently
+  addressed.
+
+  If a change affects how wallets construct, interpret, or expose
+  transaction data, or modifies user-facing protocol behavior, the ZIP
+  SHOULD assess the implications for user privacy in that context.
+
+* Requirements — This section describes high-level goals that the
+  Specification MUST ensure. It MUST NOT include conformance requirements,
+  so that it is possible to perform a consistency check that what is
+  specified meets the Requirements.
 
 * Specification — The technical specification should describe the
   interface and semantics of any new feature. The specification should be
@@ -479,8 +534,6 @@ Each ZIP SHOULD have the following parts:
     .. raw:: html
 
        </details>
-
-* Security and privacy considerations — This section is mandatory for all ZIPs. Security and privacy considerations MUST be explicitly described, particularly if the ZIP makes trade-offs or assumptions that could impact the privacy, integrity, or safety of Zcash users. This includes, but is not limited to, trust assumptions introduced or modified by the proposal; privacy trade-offs or changes to anonymity guarantees; potential data leakage (e.g., from metadata, timing, or usage patterns); exposure to known or novel attack vectors; and impact on interoperability with existing shielded or transparent features. Proposals MUST also consider the Zcash Wallet Threat Model. If a change affects how wallets construct, interpret, or expose transaction data, or modifies user-facing protocol behavior, it MUST assess the implications for user security and privacy in that context. Where relevant, the ZIP MUST reference the Wallet Threat Model and SHOULD propose updates if it introduces new assumptions or risks not currently addressed. For guidance on writing this section, consider RFC 3552 as a starting point.
 
 * Reference implementation — Literal code implementing the ZIP's
   specification, and/or a link to the reference implementation of
@@ -693,6 +746,11 @@ will specify a network upgrade in which the consensus change is to activate.
 
 A ZIP's status is Released if it is Proposed, Active, Implemented, or Final
 (i.e. not Draft, Rejected, Obsolete, or Withdrawn).
+
+A ZIP that has significant security or privacy implications MUST NOT
+be changed from a non-Released status to a Released status without the
+design having undergone independent security review from qualified
+security or privacy experts.
 
 A ZIP SHOULD NOT be changed from a non-Released status to a Released
 status if there is significant community opposition to its content.

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -922,7 +922,6 @@ References
 ==========
 
 .. [#BCP14] `Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words" <https://www.rfc-editor.org/info/bcp14>`_
-.. [#RFC3552] `RFC 3552: Guidelines for Writing RFC Text on Security Considerations <https://www.rfc-editor.org/rfc/rfc3552.html>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#conduct] `Zcash Code of Conduct <https://github.com/zcash/zcash/blob/master/code_of_conduct.md>`_
 .. [#gnukind] `GNU Kind Communication Guidelines <https://www.gnu.org/philosophy/kind-communication.en.html>`_

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -82,9 +82,9 @@ the Owners does not mean it will work for most people in most areas
 where Zcash is used.
 
 Once the Owners have asked the Zcash community as to whether an idea
-has any chance of acceptance, a draft ZIP should be presented to the
+has any chance of acceptance, a ZIP draft should be presented to the
 `Zcash Community Forum <https://forum.zcashcommunity.com/>`__.
-This gives the Owners a chance to flesh out the draft ZIP to make it
+This gives the Owners a chance to flesh out the ZIP draft to make it
 properly formatted, of high quality, and to address additional concerns
 about the proposal. Following a discussion, the proposal should be
 submitted to the ZIPs git repository [#zips-repo]_ as a pull request.
@@ -94,12 +94,12 @@ ZIP Editors have assigned it a ZIP number (Owners MUST NOT self-assign
 ZIP numbers).
 
 ZIP Owners are responsible for collecting community feedback on both
-the initial idea and the ZIP before submitting it for review. However,
+the initial idea and the ZIP draft before submitting it for review. However,
 wherever possible, long open-ended discussions on forums should be avoided.
 
 It is highly recommended that a single ZIP contain a single key proposal
 or new idea. The more focused the ZIP, the more successful it tends to
-be. If in doubt, split your ZIP into several well-focused ones.
+be. If in doubt, split your ZIP draft into several well-focused ones.
 
 When the ZIP draft is complete, the ZIP Editors will assign the ZIP a
 number (if that has not already been done) and one or more Categories,
@@ -221,17 +221,17 @@ ZIP Editor Responsibilities
 The ZIP Editors subscribe to the `Zcash Community Forum.
 <https://forum.zcashcommunity.com/>`__
 
-Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git
-repository [#zips-repo]_. It SHOULD NOT contain a ZIP number unless
-one had already been assigned by the ZIP Editors. The pull request
-SHOULD initially be marked as a Draft. The ZIP content SHOULD be
-submitted in reStructuredText [#rst]_ or Markdown [#markdown]_
-format. Generating HTML for a ZIP is OPTIONAL.
+Each new ZIP draft SHOULD be submitted as a "pull request" to the ZIPs
+git repository [#zips-repo]_. It SHOULD NOT contain a ZIP number unless
+one had already been assigned by the ZIP Editors. The ZIP content
+SHOULD be submitted in reStructuredText [#rst]_ or Markdown [#markdown]_
+format, and the Status field MUST initially be set to Draft. Generating
+HTML for a ZIP is OPTIONAL.
 
-For each new ZIP that comes in, the ZIP Editors SHOULD:
+For each new ZIP draft that is received, the ZIP Editors SHOULD:
 
-* Read the ZIP to check if it is ready: sound and complete. The ideas
-  must make technical sense, even if they don't seem likely to be
+* Read the ZIP draft to check if it is ready: sound and complete. The
+  ideas must make technical sense, even if they don't seem likely to be
   accepted. See `Reviewing a ZIP`_ below for further detail.
 * Check that the Title, Category, and other metadata fields accurately
   describe the content.
@@ -262,7 +262,7 @@ For proposals to revise an existing ZIP, the ZIP Editors SHOULD:
   the `#zips` channel of the Zcash R&D Discord.
 * Check that the licensing terms are still acceptable for ZIPs.
 
-Announcing new and updated ZIP drafts helps ensure transparency and
+Announcing new ZIP drafts and updated ZIPs helps ensure transparency and
 encourages timely community engagement and feedback. Such announcements
 SHOULD clearly state the ZIP number, title, and a brief summary.
 
@@ -291,18 +291,18 @@ the Editors SHOULD revert the change.
 
 Typically, the ZIP Editors suggest changes in two phases:
 
-* `content review`: multiple ZIP Editors discuss the ZIP, and suggest
-  changes to the overall content. This is a "big picture" review.
+* `content review`: multiple ZIP Editors discuss the ZIP draft or update, and
+  suggest changes to the overall content. This is a "big picture" review.
 * `format review`: two ZIP Editors do a detailed review of the
-  structure and format of the ZIP. This ensures the ZIP is consistent
-  with other Zcash specifications.
+  structure and format of the ZIP draft. This ensures the ZIP draft is
+  consistent with other Zcash specifications.
 
 The content review is where general weaknesses in the ZIP draft should
 be identified, which might include:
 
 * Insufficient or unclear motivation.
 * Unclear, under-documented, or missing privacy implications.
-* Significant objectives of the ZIP that are not clearly documented in
+* Significant objectives of the ZIP draft that are not clearly documented in
   the `Requirements` section.
 * Missing trust assumptions.
 * Security risks that are insufficiently addressed.
@@ -314,14 +314,14 @@ privacy experts for proposals with significant implications.
 Note that it is not the primary responsibility of the ZIP Editors to
 review proposals for security, correctness, or implementability.
 
-If the ZIP isn't ready, the Editors will send it back to the Owners for
+If the ZIP draft isn't ready, the Editors will send it back to the Owners for
 revision, with specific instructions. This decision is made by consensus
 among the current Editors.
 
 Format review should generally occur after content review feedback has
 been addressed, to avoid unnecessary document churn or merge conflicts.
 
-When a ZIP is ready, the ZIP Editors will:
+When a ZIP draft is ready, the ZIP Editors will:
 
 * Ensure that a unique ZIP number has been assigned in the pull request.
 * Regenerate the corresponding HTML documents, if required.
@@ -333,7 +333,7 @@ appropriate.
 Rejecting a ZIP or update
 -------------------------
 
-The ZIP Editors MAY reject a new ZIP or an update to an existing ZIP,
+The ZIP Editors MAY reject a new ZIP draft or an update to an existing ZIP,
 by consensus among the current Editors. Rejections can be based on any
 of the following reasons:
 
@@ -362,7 +362,7 @@ of the following reasons:
   if there is one;
 * an update to an existing ZIP extends or changes its scope to an extent
   that would be better handled as a separate ZIP;
-* a new ZIP has a category that does not reflect its content, or an update
+* a new ZIP draft has a category that does not reflect its content, or an update
   would change a ZIP to an inappropriate category;
 * it violates any specific "MUST" or "MUST NOT" rule in this document;
 * the expressed political views of a Owner of the document are inimical
@@ -374,7 +374,7 @@ of the following reasons:
 * it violates a conformance requirement of any Active Process ZIP
   (including this ZIP).
 
-The ZIP Editors MUST NOT unreasonably deny publication of a ZIP proposal
+The ZIP Editors MUST NOT unreasonably deny publication of a ZIP draft
 or update that does not violate any of these criteria. If they refuse a
 proposal or update, they MUST give an explanation of which of the
 criteria were violated, with the exception that spam may be deleted

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -359,7 +359,7 @@ proposal or update, they MUST give an explanation of which of the
 criteria were violated, with the exception that spam may be deleted
 without an explanation.
 
-Note: While it is not the primary responsibility of the ZIP Editors to perform in-depth reviews of a proposal’s security, correctness, or implementability, they MUST verify that the proposal includes a Security and Privacy Considerations section that identifies relevant risks, trust assumptions, and privacy trade-offs.
+It is not the primary responsibility of the ZIP Editors to perform in-depth reviews of a proposal’s security, correctness, or implementability. However, they MUST verify that the proposal attempts to identify relevant risks, trust assumptions, and privacy trade-offs.
 
 Editors MAY request input from community security or privacy experts for proposals with significant implications. Editors MUST require ZIP authors to consult qualified security or privacy experts for proposals with significant security or privacy implications. ZIP authors are responsible for ensuring that both the design and the implementation undergo independent security review, including formal code review. Editors themselves are not expected to perform audits or provide definitive assessments of security or correctness.
 

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -235,7 +235,7 @@ For each new ZIP draft that is received, the ZIP Editors SHOULD:
   accepted. See `Reviewing a ZIP`_ below for further detail.
 * Check that the Title, Category, and other metadata fields accurately
   describe the content.
-* Ensure that a PR has been created for the ZIP draft in ZIPs git
+* Ensure that a PR has been created for the ZIP draft in the ZIPs git
   repository [#zips-repo]_.
 * Ensure that the existence of the draft has been announced on the Zcash
   Community Forum and the `#zips` channel of the Zcash R&D Discord.
@@ -380,7 +380,6 @@ proposal or update, they MUST give an explanation of which of the
 criteria were violated, with the exception that spam may be deleted
 without an explanation.
 
-
 Communicating with the ZIP Editors
 ----------------------------------
 
@@ -454,9 +453,9 @@ Each ZIP SHOULD have the following parts:
   trade-offs or assumptions that could impact the privacy of Zcash users
   or protocol participants. Since this section is not part of the
   Specification, it MUST NOT directly include or duplicate conformance
-  requirements on implementations. Instead it contains a high-level overview
-  of the privacy implications that may need to be considered for deployment
-  of the ZIP.
+  requirements on implementations or processes. Instead it contains a
+  high-level overview of the privacy implications that may need to be
+  considered for deployment of the ZIP.
 
   The contents of this section could include, for example, trust assumptions
   affecting privacy that are introduced or modified by the proposal; privacy
@@ -472,9 +471,9 @@ Each ZIP SHOULD have the following parts:
   SHOULD assess the implications for user privacy in that context.
 
 * Requirements — This section describes high-level goals that the
-  Specification MUST ensure. It MUST NOT include conformance requirements,
-  so that it is possible to perform a consistency check that what is
-  specified meets the Requirements.
+  Specification MUST ensure. It MUST NOT itself include conformance
+  requirements, so that it is possible to perform a consistency check
+  that what is specified meets the Requirements.
 
 * Specification — The technical specification should describe the
   interface and semantics of any new feature. The specification should be
@@ -750,7 +749,10 @@ A ZIP's status is Released if it is Proposed, Active, Implemented, or Final
 A ZIP that has significant security or privacy implications MUST NOT
 be changed from a non-Released status to a Released status without the
 design having undergone independent security review from qualified
-security or privacy experts.
+security or privacy experts. Similarly, changes to a Released ZIP that might
+invalidate the conclusions of previous security or privacy review, or leave
+significant security or privacy implications unaddressed, MUST undergo
+further independent review.
 
 A ZIP SHOULD NOT be changed from a non-Released status to a Released
 status if there is significant community opposition to its content.


### PR DESCRIPTION
- Require that a submitted ZIP draft MUST (rather than SHOULD) start in Draft status when published.
- Add references to "Reviewing a ZIP" from "ZIP Editor Responsibilities".
- Require newly published or substantively updated ZIP drafts to be announced on the Zcash Community Forum always (rather than "in some cases"), and also on the `#zips` channel of the R&D Discord. Give motivation and say what the announcements contain.
- In "Reviewing a ZIP":
  - Content review applies to updates as well as new ZIP drafts.
  - Describe what content review entails, including potentially requesting "input from community security or privacy experts".
  - Move the statement that "it is not the primary responsibility of the ZIP Editors to review proposals for security, correctness, or implementability" to this section.
  - Say that format review should generally occur after content review feedback has been addressed.
- Add "it fails to adequately consider privacy implications" as a potential reason for rejecting publication.
- In "ZIP format and structure":
  - Describe the Abstract section in more detail.
  - Describe a Privacy Implications section that "SHOULD be present if the ZIP makes trade-offs or assumptions that could impact the privacy of Zcash users  or protocol participants".
  - Describe the Requirements section.
  - Delete the suggestion to include a "Security and privacy considerations" section and the reference to RFC 3552.
- In "Specification of Status Workflow", require "a ZIP that has significant security or privacy implications" to have undergone "independent security review from qualified security of privacy experts" before it transitions to Released, or when an update "might invalidate the conclusions of previous security or privacy review, or leave significant security or privacy implications unaddressed".
- Use more consistent terminology: "ZIP draft" rather than "draft ZIP".
- Includes merge of #1004.