### PR TITLE
ZIP 0: Remove reference to the "GNU Kind Communication Guidelines" given Richard Stallman's involvement

### DIFF
--- a/rendered/zip-0000.html
+++ b/rendered/zip-0000.html
@@ -37,7 +37,7 @@ License: BSD-2-Clause</pre>
         <section id="zip-workflow"><h2><span class="section-heading">ZIP Workflow</span><span class="section-anchor"> <a rel="bookmark" href="#zip-workflow"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <p>The ZIP process begins with a new idea for Zcash. Each potential ZIP must have Owners — one or more people who write the ZIP using the style and format described below, shepherd the discussions in the appropriate forums, and attempt to build community consensus around the idea. The ZIP Owners should first attempt to ascertain whether the idea is ZIP-able. Small enhancements or patches to a particular piece of software often don't require standardisation between multiple projects; these don't need a ZIP and should be injected into the relevant project-specific development workflow with a patch submission to the applicable issue tracker. Additionally, many ideas have been brought forward for changing Zcash that have been rejected for various reasons. The first step should be to search past discussions to see if an idea has been considered before, and if so, what issues arose in its progression. After investigating past work, the best way to proceed is by posting about the new idea to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum</a>.</p>
             <p>Vetting an idea publicly before going as far as writing a ZIP is meant to save both the potential Owners and the wider community time. Asking the Zcash community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the internet does not always do the trick). It also helps to make sure the idea is applicable to the entire community and not just the Owners. Just because an idea sounds good to the Owners does not mean it will work for most people in most areas where Zcash is used.</p>
-            <p>Once the Owners have asked the Zcash community as to whether an idea has any chance of acceptance, a draft ZIP should be presented to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum</a>. This gives the Owners a chance to flesh out the draft ZIP to make it properly formatted, of high quality, and to address additional concerns about the proposal. Following a discussion, the proposal should be submitted to the ZIPs git repository <a id="footnote-reference-3" class="footnote_reference" href="#zips-repo">9</a> as a pull request. This draft must be written in ZIP style as described below, and named with an alias such as <code>draft-zatoshizakamoto-42millionzec</code> until the ZIP Editors have assigned it a ZIP number (Owners MUST NOT self-assign ZIP numbers).</p>
+            <p>Once the Owners have asked the Zcash community as to whether an idea has any chance of acceptance, a draft ZIP should be presented to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum</a>. This gives the Owners a chance to flesh out the draft ZIP to make it properly formatted, of high quality, and to address additional concerns about the proposal. Following a discussion, the proposal should be submitted to the ZIPs git repository <a id="footnote-reference-3" class="footnote_reference" href="#zips-repo">8</a> as a pull request. This draft must be written in ZIP style as described below, and named with an alias such as <code>draft-zatoshizakamoto-42millionzec</code> until the ZIP Editors have assigned it a ZIP number (Owners MUST NOT self-assign ZIP numbers).</p>
             <p>ZIP Owners are responsible for collecting community feedback on both the initial idea and the ZIP before submitting it for review. However, wherever possible, long open-ended discussions on forums should be avoided.</p>
             <p>It is highly recommended that a single ZIP contain a single key proposal or new idea. The more focused the ZIP, the more successful it tends to be. If in doubt, split your ZIP into several well-focused ones.</p>
             <p>When the ZIP draft is complete, the ZIP Editors will assign the ZIP a number (if that has not already been done) and one or more Categories, and merge the pull request to the ZIPs git repository. The ZIP Editors will not unreasonably reject a ZIP. Reasons for rejecting ZIPs include duplication of effort, disregard for formatting rules, being too unfocused or too broad, being technically unsound, not providing proper motivation or not in keeping with the Zcash philosophy. For a ZIP to be accepted it must meet certain minimum criteria. It must be a clear and complete description of the proposed enhancement. The enhancement must represent a net improvement. The proposed implementation, if applicable, must be solid and must not complicate the protocol unduly.</p>
@@ -89,12 +89,12 @@ License: BSD-2-Clause</pre>
             </section>
             <section id="zip-editor-responsibilities"><h3><span class="section-heading">ZIP Editor Responsibilities</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-responsibilities"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The ZIP Editors subscribe to the <a href="https://forum.zcashcommunity.com/">Zcash Community Forum.</a></p>
-                <p>Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git repository <a id="footnote-reference-4" class="footnote_reference" href="#zips-repo">9</a>. It SHOULD NOT contain a ZIP number unless one had already been assigned by the ZIP Editors. The pull request SHOULD initially be marked as a Draft. The ZIP content SHOULD be submitted in reStructuredText <a id="footnote-reference-5" class="footnote_reference" href="#rst">6</a> or Markdown <a id="footnote-reference-6" class="footnote_reference" href="#markdown">7</a> format. Generating HTML for a ZIP is OPTIONAL.</p>
+                <p>Each new ZIP SHOULD be submitted as a "pull request" to the ZIPs git repository <a id="footnote-reference-4" class="footnote_reference" href="#zips-repo">8</a>. It SHOULD NOT contain a ZIP number unless one had already been assigned by the ZIP Editors. The pull request SHOULD initially be marked as a Draft. The ZIP content SHOULD be submitted in reStructuredText <a id="footnote-reference-5" class="footnote_reference" href="#rst">5</a> or Markdown <a id="footnote-reference-6" class="footnote_reference" href="#markdown">6</a> format. Generating HTML for a ZIP is OPTIONAL.</p>
                 <p>For each new ZIP that comes in, the ZIP Editors SHOULD:</p>
                 <ul>
                     <li>Read the ZIP to check if it is ready: sound and complete. The ideas must make technical sense, even if they don't seem likely to be accepted.</li>
                     <li>Check that the Title, Category, and other metadata fields accurately describe the content.</li>
-                    <li>Ensure that the ZIP draft has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-7" class="footnote_reference" href="#zips-repo">9</a>. In some cases it may also be appropriate for it to be sent to the Zcash Community Forum.</li>
+                    <li>Ensure that the ZIP draft has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-7" class="footnote_reference" href="#zips-repo">8</a>. In some cases it may also be appropriate for it to be sent to the Zcash Community Forum.</li>
                     <li>Ensure that motivation and backward compatibility have been addressed, if applicable.</li>
                     <li>Check that the licensing terms are acceptable for ZIPs.</li>
                 </ul>
@@ -103,7 +103,7 @@ License: BSD-2-Clause</pre>
                     <li>Read the proposed modification to check if it is ready: sound, complete, and non-disruptive to the ZIP's existing deployments if any.</li>
                     <li>If the proposed changes primarily affect already-deployed aspects of the Zcash consensus protocol, they SHOULD be specified in an "Update ZIP" describing the changes to be made, rather than directly as a pull request modifying the existing ZIP(s) or the Zcash Protocol Specification. At the discretion of the ZIP Editors, this might not be needed for compatible changes or clarifications.</li>
                     <li>If a change is to be made to an existing ZIP, check that the Title, Category, and other metadata fields still accurately describe the modified content.</li>
-                    <li>Ensure that the update has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-8" class="footnote_reference" href="#zips-repo">9</a>. In some cases it may also be appropriate for it to be sent to the Zcash Community Forum.</li>
+                    <li>Ensure that the update has been submitted as a PR to the ZIPs git repository <a id="footnote-reference-8" class="footnote_reference" href="#zips-repo">8</a>. In some cases it may also be appropriate for it to be sent to the Zcash Community Forum.</li>
                     <li>Ensure that motivation and backward compatibility have been addressed, if applicable.</li>
                     <li>Check that the licensing terms are still acceptable for ZIPs.</li>
                 </ul>
@@ -162,7 +162,7 @@ License: BSD-2-Clause</pre>
                     <li>by opening an issue on the <a href="https://github.com/zcash/zips/issues">ZIPs issue tracker</a>, or</li>
                     <li>by sending a message in the <a href="https://discord.com/channels/809218587167293450/809251050741170187">#zips channel on the Zcash R&amp;D Discord</a>.</li>
                 </ul>
-                <p><strong>All communications should abide by the Zcash Code of Conduct</strong> <a id="footnote-reference-11" class="footnote_reference" href="#conduct">4</a> <strong>and follow the GNU Kind Communication Guidelines</strong> <a id="footnote-reference-12" class="footnote_reference" href="#gnukind">5</a>.</p>
+                <p><strong>All communications should abide by the Zcash Code of Conduct</strong> <a id="footnote-reference-11" class="footnote_reference" href="#conduct">4</a>.</p>
             </section>
             <section id="zip-editor-meeting-practices"><h3><span class="section-heading">ZIP Editor Meeting Practices</span><span class="section-anchor"> <a rel="bookmark" href="#zip-editor-meeting-practices"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>The ZIP Editors SHOULD meet on a regular basis to review draft changes to ZIPs. Meeting times are agreed by consensus among the current ZIP Editors. A ZIP Editor meeting can be held even if some ZIP Editors are not available, but all Editors SHOULD be informed of significant decisions that are likely to be made at upcoming meetings.</p>
@@ -176,7 +176,7 @@ License: BSD-2-Clause</pre>
             </section>
         </section>
         <section id="zip-format-and-structure"><h2><span class="section-heading">ZIP format and structure</span><span class="section-anchor"> <a rel="bookmark" href="#zip-format-and-structure"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
-            <p>ZIPs SHOULD be written in reStructuredText <a id="footnote-reference-13" class="footnote_reference" href="#rst">6</a>, Markdown <a id="footnote-reference-14" class="footnote_reference" href="#markdown">7</a>, or LaTeX <a id="footnote-reference-15" class="footnote_reference" href="#latex">8</a>. For ZIPs written in LaTeX, a <code>Makefile</code> MUST be provided to build (at least) a PDF version of the document.</p>
+            <p>ZIPs SHOULD be written in reStructuredText <a id="footnote-reference-12" class="footnote_reference" href="#rst">5</a>, Markdown <a id="footnote-reference-13" class="footnote_reference" href="#markdown">6</a>, or LaTeX <a id="footnote-reference-14" class="footnote_reference" href="#latex">7</a>. For ZIPs written in LaTeX, a <code>Makefile</code> MUST be provided to build (at least) a PDF version of the document.</p>
             <p>Each ZIP SHOULD have the following parts:</p>
             <ul>
                 <li>Preamble — Headers containing metadata about the ZIP (<a href="#zip-header-preamble">see below</a>). The License field of the preamble indicates the licensing terms, which MUST be acceptable according to <a href="#zip-licensing">the ZIP licensing requirements</a>.</li>
@@ -223,11 +223,11 @@ Important but hidden rationale!
 
    &lt;/details&gt;</pre>
                 </li>
-                <li>Security and privacy considerations — If applicable, security and privacy considerations should be explicitly described, particularly if the ZIP makes explicit trade-offs or assumptions. For guidance on this section consider RFC 3552 <a id="footnote-reference-16" class="footnote_reference" href="#rfc3552">2</a> as a starting point.</li>
+                <li>Security and privacy considerations — If applicable, security and privacy considerations should be explicitly described, particularly if the ZIP makes explicit trade-offs or assumptions. For guidance on this section consider RFC 3552 <a id="footnote-reference-15" class="footnote_reference" href="#rfc3552">2</a> as a starting point.</li>
                 <li>Reference implementation — Literal code implementing the ZIP's specification, and/or a link to the reference implementation of the ZIP's specification. The reference implementation MUST be completed before any ZIP is given status “Implemented” or “Final”, but it generally need not be completed before the ZIP is accepted into “Proposed”.</li>
             </ul>
             <section id="zip-stubs"><h3><span class="section-heading">ZIP stubs</span><span class="section-anchor"> <a rel="bookmark" href="#zip-stubs"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>A ZIP stub records that the ZIP Editors have reserved a number for a ZIP that is under development. It is not a ZIP, but exists in the ZIPs git repository <a id="footnote-reference-17" class="footnote_reference" href="#zips-repo">9</a> at the same path that will be used for the corresponding ZIP if and when it is published. It consists only of a preamble, which MUST use Reserved as the value of the Status field.</p>
+                <p>A ZIP stub records that the ZIP Editors have reserved a number for a ZIP that is under development. It is not a ZIP, but exists in the ZIPs git repository <a id="footnote-reference-16" class="footnote_reference" href="#zips-repo">8</a> at the same path that will be used for the corresponding ZIP if and when it is published. It consists only of a preamble, which MUST use Reserved as the value of the Status field.</p>
                 <p>ZIP stubs can be added and removed, or replaced by the corresponding ZIP, at the discretion of the ZIP Editors. If a ZIP stub is removed then its number MAY be reused, possibly for an entirely different ZIP.</p>
             </section>
             <section id="zip-header-preamble"><h3><span class="section-heading">ZIP header preamble</span><span class="section-anchor"> <a rel="bookmark" href="#zip-header-preamble"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -415,18 +415,10 @@ Updates:</pre>
                     </tr>
                 </tbody>
             </table>
-            <table id="gnukind" class="footnote">
-                <tbody>
-                    <tr>
-                        <th>5</th>
-                        <td><a href="https://www.gnu.org/philosophy/kind-communication.en.html">GNU Kind Communication Guidelines</a></td>
-                    </tr>
-                </tbody>
-            </table>
             <table id="rst" class="footnote">
                 <tbody>
                     <tr>
-                        <th>6</th>
+                        <th>5</th>
                         <td><a href="https://docutils.sourceforge.io/rst.html">reStructuredText documentation</a></td>
                     </tr>
                 </tbody>
@@ -434,7 +426,7 @@ Updates:</pre>
             <table id="markdown" class="footnote">
                 <tbody>
                     <tr>
-                        <th>7</th>
+                        <th>6</th>
                         <td><a href="https://www.markdownguide.org/">The Markdown Guide</a></td>
                     </tr>
                 </tbody>
@@ -442,7 +434,7 @@ Updates:</pre>
             <table id="latex" class="footnote">
                 <tbody>
                     <tr>
-                        <th>8</th>
+                        <th>7</th>
                         <td><a href="https://www.latex-project.org/">LaTeX — a document preparation system</a></td>
                     </tr>
                 </tbody>
@@ -450,7 +442,7 @@ Updates:</pre>
             <table id="zips-repo" class="footnote">
                 <tbody>
                     <tr>
-                        <th>9</th>
+                        <th>8</th>
                         <td><a href="https://github.com/zcash/zips">ZIPs git repository</a></td>
                     </tr>
                 </tbody>

--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -378,8 +378,7 @@ Please send all ZIP-related communications either:
 * by opening an issue on the `ZIPs issue tracker <https://github.com/zcash/zips/issues>`_, or
 * by sending a message in the `#zips channel on the Zcash R&D Discord <https://discord.com/channels/809218587167293450/809251050741170187>`_.
 
-**All communications should abide by the Zcash Code of Conduct** [#conduct]_
-**and follow the GNU Kind Communication Guidelines** [#gnukind]_.
+**All communications should abide by the Zcash Code of Conduct** [#conduct]_.
 
 ZIP Editor Meeting Practices
 ----------------------------
@@ -875,7 +874,6 @@ References
 .. [#RFC3552] `RFC 3552: Guidelines for Writing RFC Text on Security Considerations <https://www.rfc-editor.org/rfc/rfc3552.html>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
 .. [#conduct] `Zcash Code of Conduct <https://github.com/zcash/zcash/blob/master/code_of_conduct.md>`_
-.. [#gnukind] `GNU Kind Communication Guidelines <https://www.gnu.org/philosophy/kind-communication.en.html>`_
 .. [#rst] `reStructuredText documentation <https://docutils.sourceforge.io/rst.html>`_
 .. [#markdown] `The Markdown Guide <https://www.markdownguide.org/>`_
 .. [#latex] `LaTeX — a document preparation system <https://www.latex-project.org/>`_


### PR DESCRIPTION
See https://rms-open-letter.github.io/appendix . I thought I had already done this in db3b2f72d4fe70365ca4f9cd0e618a8635c835cf.

A universal exhortation to "assume good faith" is verging on tone-policing when applied to marginalized communities. In any case, ZIP 0 is not about that topic and the link is out-of-place.