### PR TITLE
Fix typos: correct spelling in documentation files

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -19098,7 +19098,7 @@ zero for any $z_j$ is negligible.
 } %nnote
 
 The performance benefit of this approach arises from computing two of the three Miller loops, and
-the final exponentation, per batch instead of per proof. For the multiplications by $z_j$, an efficient
+the final exponentiation, per batch instead of per proof. For the multiplications by $z_j$, an efficient
 algorithm for multiscalar multiplication such as Pippinger's method \cite{Bernstein2001} or the Bos--Coster
 method \cite{deRooij1995} may be used.
 

--- a/rendered/zip-0225.html
+++ b/rendered/zip-0225.html
@@ -456,7 +456,7 @@ Discussions-To: &lt;<a href="https://github.com/zcash/zips/issues/440">https://g
                         <td><code>1698 * nJoinSplit</code></td>
                         <td><code>vJoinSplit</code></td>
                         <td><code>JSDescriptionGroth16[nJoinSplit]</code></td>
-                        <td>A sequence of JoinSplit descrptions using Groth16 proofs, encoded per §7.2 ‘JoinSplit Description Encoding and Consensus’.</td>
+                        <td>A sequence of JoinSplit descriptions using Groth16 proofs, encoded per §7.2 ‘JoinSplit Description Encoding and Consensus’.</td>
                     </tr>
                     <tr>
                         <td><code>32</code></td>

--- a/zips/zip-1013.rst
+++ b/zips/zip-1013.rst
@@ -117,7 +117,7 @@ expected due to:
   over 4 years depends completely on the continued health & growth of the Zcash
   ecosystem;
 * proven records of dedication to the Zcash project, and effective efforts on
-  related projects, by receipient entities & personnel – even in the absence
+  related projects, by recipient entities & personnel – even in the absence
   of formalized funding conditions.
 
 From original "Founders’ Reward"-era development-funds, roughly 15% has been


### PR DESCRIPTION


**Description:**
This PR fixes several typos in documentation files:

- Corrects "descriprions" to "descriptions" in rendered/zip-0225.html
- Fixes "receipient" to "recipient" in zips/zip-1013.rst
- Updates formatting in protocol/protocol.tex

These changes improve readability and consistency of the documentation without affecting any functional code.


