### PR TITLE
draft-ecc-lockbox-disbursement minor clarifications

### DIFF
--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -23,7 +23,7 @@ Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/???">https://githu
 
 <h1 id="terminology"><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h1>
 
-<p>The key words &#8220;MUST&#8221;, &#8220;SHOULD&#8221;, &#8220;MAY&#8221;, and &#8220;RECOMMENDED&#8221; in this document are
+<p>The key words &#8220;MUST&#8221;, &#8220;MUST NOT&#8221;, and &#8220;RECOMMENDED&#8221; in this document are
 to be interpreted as described in BCP 14 <a href="#fn:1" id="fnref:1" title="see footnote" class="footnote"><sup>1</sup></a> when, and only when, they
 appear in all capitals.</p>
 
@@ -76,9 +76,9 @@ as specified by this ZIP.</p>
 <h3 id="one-timelockboxdisbursement"><span class="section-heading">One-time lockbox disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#one-timelockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>The coinbase transaction of the activation block of this ZIP MUST include an
-additional output to a 2-of-3 P2SH multisig with keys held by the following
-&#8220;Key-Holder Organizations&#8221;: Zcash Foundation, the Electric Coin Company,
-and Shielded Labs.</p>
+additional lockbox disbursement output to a 2-of-3 P2SH multisig with keys held
+by the following &#8220;Key-Holder Organizations&#8221;: Zcash Foundation, the Electric Coin
+Company, and Shielded Labs.</p>
 
 <p>Let <span class="math">\(v\)</span> be the zatoshi amount in the Deferred Dev Fund Lockbox as of the end
 of the block preceding the activation height. (<span class="math">\(v\)</span> can be predicted in advance
@@ -108,6 +108,31 @@ the point when the relevant consensus check is done in node implementations.
 If so, the specification should be written in terms of the precalculated
 value.</p>
 
+<h4 id="changetothezcashprotocolspecification"><span class="section-heading">Change to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changetothezcashprotocolspecification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+
+<p>In section <strong>7.1.2 Transaction Consensus Rules</strong> <a href="#fn:5" id="fnref:5" title="see footnote" class="footnote"><sup>5</sup></a>, change:</p>
+
+<blockquote>
+<ul>
+<li>A transaction MUST NOT spend a transparent output of a coinbase transaction
+from a block less than 100 blocks prior to the spend. Note that transparent
+outputs of coinbase transactions include Founders’ Reward outputs and
+transparent funding stream outputs.</li>
+</ul>
+</blockquote>
+
+<p>to</p>
+
+<blockquote>
+<ul>
+<li>A transaction MUST NOT spend a transparent output of a coinbase transaction
+from a block less than 100 blocks prior to the spend. Note that transparent
+outputs of coinbase transactions include Founders’ Reward outputs,
+transparent funding stream outputs <a href="zip-0207">[ZIP-207]</a>, and lockbox
+disbursement outputs {{ reference to this ZIP section }}.</li>
+</ul>
+</blockquote>
+
 <h3 id="option1:extendthelockboxfundingstream"><span class="section-heading">Option 1: Extend the lockbox funding stream</span><span class="section-anchor"> <a rel="bookmark" href="#option1:extendthelockboxfundingstream"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>The <code>FS_DEFERRED</code> lockbox funding stream is set to receive
@@ -120,11 +145,11 @@ specified by the proposal under which this ZIP is activated.</p>
 <p>Performing a one-time disbursement to a P2SH multisig address will provide a
 source of grant funding for a limited period, allowing time for a lockbox
 disbursement mechanism to be specified and deployed, as originally intended by
-ZIP 1015 <a href="#fn:5" id="fnref:5" title="see footnote" class="footnote"><sup>5</sup></a>.</p>
+ZIP 1015 <a href="#fn:6" id="fnref:6" title="see footnote" class="footnote"><sup>6</sup></a>.</p>
 
 <p>In particular, this provides an opportunity for transaction format changes that
 may be required for such a mechanism to be included in the v6 transaction
-format <a href="#fn:6" id="fnref:6" title="see footnote" class="footnote"><sup>6</sup></a>. It is desirable to limit the frequency of transaction
+format <a href="#fn:7" id="fnref:7" title="see footnote" class="footnote"><sup>7</sup></a>. It is desirable to limit the frequency of transaction
 format changes because such changes are disruptive to the ecosystem. It is not
 necessary that protocol rules for disbursement actually be implemented until
 after the transaction format changes are live on the network. It is RECOMMENDED
@@ -151,7 +176,7 @@ and funds from the one-time lockbox disbursement described above.</p>
 
 <h4 id="mechanism2a:classicfundingstream"><span class="section-heading">Mechanism 2a: Classic funding stream</span><span class="section-anchor"> <a rel="bookmark" href="#mechanism2a:classicfundingstream"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
 
-<p>A new funding stream is definedthat pays directly to the above-mentioned 3-of-5
+<p>A new funding stream is defined that pays directly to the above-mentioned 3-of-5
 multisig address on a block-by-block basis. It is defined to start at the end
 height of the existing <code>FS_DEFERRED</code> funding stream and end at
 <span class="math">\(\mathsf{stream\_end\_height}\)</span> and consists of <span class="math">\(\mathsf{stream\_value}\%\)</span> of the
@@ -178,7 +203,7 @@ that all output to the same address.</p>
 
 <h4 id="rationaleforperiodicdisbursement"><span class="section-heading">Rationale for periodic disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforperiodicdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
 
-<p>Classic funding streams <a href="#fn:7" id="fnref:7" title="see footnote" class="footnote"><sup>7</sup></a> produce many small output values, due to
+<p>Classic funding streams <a href="#fn:8" id="fnref:8" title="see footnote" class="footnote"><sup>8</sup></a> produce many small output values, due to
 only being able to direct funds from a single block&#8217;s subsidy at a time. This
 creates operational burdens to utilizing the funds — in particular due to block
 and transaction sizes limiting how many outputs can be combined at once, which
@@ -234,7 +259,7 @@ these funds. This process is an attractive target for compromise; for this
 reason it is RECOMMENDED that address rotation (in this case, by means of
 hard-coding a sequence of addresses, each of which receives a time-bounded
 subset of the block reward fractional outputs) be implemented, as was done
-for the ECC funding stream described in ZIP 1014 <a href="#fn:8" id="fnref:8" title="see footnote" class="footnote"><sup>8</sup></a>.</p>
+for the ECC funding stream described in ZIP 1014 <a href="#fn:9" id="fnref:9" title="see footnote" class="footnote"><sup>9</sup></a>.</p>
 
 <p>In the case of key compromise or loss, it may be necessary to perform an
 emergency Network Upgrade to perform a manual key rotation to ensure that
@@ -259,7 +284,7 @@ funds.</p>
 <ol>
 
 <li id="fn:1">
-<p>BCP14 <a href="#fnref:1" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="https://www.rfc-editor.org/info/bcp14">Information on BCP 14 — &#8220;RFC 2119: Key words for use in RFCs to Indicate Requirement Levels&#8221; and &#8220;RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words&#8221;</a> <a href="#fnref:1" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:2">
@@ -275,19 +300,23 @@ funds.</p>
 </li>
 
 <li id="fn:5">
-<p><a href="zip-1015">ZIP 1015: Block Subsidy Allocation for Non-Direct Development Funding</a> <a href="#fnref:5" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="protocol/protocol.pdf#txnconsensus">Zcash Protocol Specification, Version 2024.5.1. Section 7.1.2: Transaction Consensus Rules</a> <a href="#fnref:5" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:6">
-<p><a href="zip-0230">ZIP 230: Version 6 Transaction Format</a> <a href="#fnref:6" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="zip-1015">ZIP 1015: Block Subsidy Allocation for Non-Direct Development Funding</a> <a href="#fnref:6" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:7">
-<p><a href="zip-0207">ZIP 207: Funding Streams</a> <a href="#fnref:7" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="zip-0230">ZIP 230: Version 6 Transaction Format</a> <a href="#fnref:7" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:8">
-<p>zip-1014 <a href="#fnref:8" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="zip-0207">ZIP 207: Funding Streams</a> <a href="#fnref:8" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+</li>
+
+<li id="fn:9">
+<p>zip-1014 <a href="#fnref:9" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 </ol>

--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -107,6 +107,40 @@ the point when the relevant consensus check is done in node implementations.
 If so, the specification should be written in terms of the precalculated
 value.</p>
 
+<h3 id="rationaleforusingap2shoutput"><span class="section-heading">Rationale for using a P2SH output</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforusingap2shoutput"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+
+<p>The keyholders may desire the grant-filling transactions use transparent inputs or
+shielded inputs. Regardless of their desire, the one-time disbursement must at some
+point go through a shielded pool, because this ZIP does not propose altering the
+consensus rules for spendability of transparent coinbase outputs. That would be far
+too complex a change for the intended scope.</p>
+
+<p>This means that by using a P2SH output in consensus, the Key-Holder Organizations
+will need to spend the one-time disbursement completely into a shielded output.
+This spend would presumably be to a FROST address in order to maintain consistent
+security position over the lockbox funds; perhaps publishing the viewing key to
+maintain visibility.</p>
+
+<p>An alternative proposal could require the one-time disbursement to directly create
+a shielded output to the FROST address. This would mean that the Key-Holder
+Organizations could immediately start disbursing grants (although the 100-block
+coinbase maturity is not particularly onerous).</p>
+
+<p>This ZIP instead uses a P2SH output for two reasons:</p>
+
+<ul>
+<li>Using a shielded output would place a requirement on the miner (or mining pool)
+to be able to create shielded coinbase outputs. Technically that requirement
+is already in the consensus rules, but it has never before been exercised,
+since no Funding Stream has been defined with a shielded address.</li>
+<li>Using a shielded output in the context of this ZIP would mean that the FROST
+address needs to be derived well in advance of NU activation. At the time of
+writing (May 2025), ZIP 312 does not specify key generation, and it would be
+undesirable to couple the specification process for that to this ZIP. P2SH
+multisig addresses by comparison have a stable and well understood format and
+generation process.</li>
+</ul>
+
 <h3 id="changetothezcashprotocolspecification"><span class="section-heading">Change to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changetothezcashprotocolspecification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>In section <strong>7.1.2 Transaction Consensus Rules</strong> <a href="#fn:6" id="fnref:6" title="see footnote" class="footnote"><sup>6</sup></a>, change:</p>

--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -18,7 +18,9 @@ Status: Draft
 Category: Consensus / Process
 Created: 2025-02-19
 License: MIT
-Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/???">https://github.com/zcash/zips/pull/???</a>&gt;
+Pull-Request: &lt;<a href="https://github.com/zcash/zips/pull/989">https://github.com/zcash/zips/pull/989</a>&gt;
+              &lt;<a href="https://github.com/zcash/zips/pull/1014">https://github.com/zcash/zips/pull/1014</a>&gt;
+              &lt;<a href="https://github.com/zcash/zips/pull/1015">https://github.com/zcash/zips/pull/1015</a>&gt;
 </code></pre>
 
 <h1 id="terminology"><span class="section-heading">Terminology</span><span class="section-anchor"> <a rel="bookmark" href="#terminology"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h1>
@@ -235,7 +237,7 @@ blocks).</p>
 
 <p>The <code>FS_DEFERRED</code> lockbox funding stream is extended to end at height
 <span class="math">\(\mathsf{stream\_end\_height}\)</span> and has its per-block output value set to
-<span class="math">\(\mathsf{stream\_value}\%\)</span> A consensus rule is added to disburse from the
+<span class="math">\(\mathsf{stream\_value}\%\)</span>. A consensus rule is added to disburse from the
 Deferred Dev Fund Lockbox to a 2-of-3 P2SH multisig with keys held by the same
 Key-Holder Organizations as above, starting at block height
 <span class="math">\(\mathsf{activation\_height} + N\)</span> and continuing at periodic intervals of <span class="math">\(N\)</span>

--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -73,7 +73,7 @@ Lockbox as of the activation height of this ZIP, plus any funds that later
 accrue to either the lockbox or to one or more transparent multisig addresses
 as specified by this ZIP.</p>
 
-<h3 id="one-timelockboxdisbursement"><span class="section-heading">One-time lockbox disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#one-timelockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+<h2 id="one-timelockboxdisbursement"><span class="section-heading">One-time lockbox disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#one-timelockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>The coinbase transaction of the activation block of this ZIP MUST include an
 additional lockbox disbursement output to a 2-of-3 P2SH multisig with keys held
@@ -107,7 +107,7 @@ the point when the relevant consensus check is done in node implementations.
 If so, the specification should be written in terms of the precalculated
 value.</p>
 
-<h4 id="changetothezcashprotocolspecification"><span class="section-heading">Change to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changetothezcashprotocolspecification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h3 id="changetothezcashprotocolspecification"><span class="section-heading">Change to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changetothezcashprotocolspecification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>In section <strong>7.1.2 Transaction Consensus Rules</strong> <a href="#fn:6" id="fnref:6" title="see footnote" class="footnote"><sup>6</sup></a>, change:</p>
 
@@ -132,14 +132,14 @@ disbursement outputs {{ reference to this ZIP section }}.</li>
 </ul>
 </blockquote>
 
-<h3 id="option1:extendthelockboxfundingstream"><span class="section-heading">Option 1: Extend the lockbox funding stream</span><span class="section-anchor"> <a rel="bookmark" href="#option1:extendthelockboxfundingstream"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+<h2 id="option1:extendthelockboxfundingstream"><span class="section-heading">Option 1: Extend the lockbox funding stream</span><span class="section-anchor"> <a rel="bookmark" href="#option1:extendthelockboxfundingstream"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>The <code>FS_DEFERRED</code> lockbox funding stream is set to receive
 <span class="math">\(\mathsf{stream\_value}\%\)</span> of the block subsidy and is extended until block
 height <span class="math">\(\mathsf{stream\_end\_height}\)</span>. Both of these parameters must be
 specified by the proposal under which this ZIP is activated.</p>
 
-<h4 id="rationaleforoption1"><span class="section-heading">Rationale for Option 1</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforoption1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h3 id="rationaleforoption1"><span class="section-heading">Rationale for Option 1</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforoption1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>Performing a one-time disbursement to a P2SH multisig address will provide a
 source of grant funding for a limited period, allowing time for a lockbox
@@ -162,7 +162,7 @@ from the lockbox — making it possible to address the need to rotate keys and/o
 alter the set of key holders in a way that reverting to hard-coded output
 addresses for repeated disbursements would not.</p>
 
-<h3 id="option2:reverttohard-codedoutputaddress"><span class="section-heading">Option 2: Revert to hard-coded output address</span><span class="section-anchor"> <a rel="bookmark" href="#option2:reverttohard-codedoutputaddress"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
+<h2 id="option2:reverttohard-codedoutputaddress"><span class="section-heading">Option 2: Revert to hard-coded output address</span><span class="section-anchor"> <a rel="bookmark" href="#option2:reverttohard-codedoutputaddress"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>A new funding stream consisting of <span class="math">\(\mathsf{stream\_value}\%\)</span> of the block
 subsidy is defined to begin when the existing ZIP 1015 funding streams
@@ -173,7 +173,7 @@ and funds from the one-time lockbox disbursement described above.</p>
 
 <p>Option 2 can be realized by either of the following mechanisms:</p>
 
-<h4 id="mechanism2a:classicfundingstream"><span class="section-heading">Mechanism 2a: Classic funding stream</span><span class="section-anchor"> <a rel="bookmark" href="#mechanism2a:classicfundingstream"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h3 id="mechanism2a:classicfundingstream"><span class="section-heading">Mechanism 2a: Classic funding stream</span><span class="section-anchor"> <a rel="bookmark" href="#mechanism2a:classicfundingstream"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>A new funding stream is defined that pays directly to the above-mentioned 3-of-5
 multisig address on a block-by-block basis. It is defined to start at the end
@@ -181,7 +181,7 @@ height of the existing <code>FS_DEFERRED</code> funding stream and end at
 <span class="math">\(\mathsf{stream\_end\_height}\)</span> and consists of <span class="math">\(\mathsf{stream\_value}\%\)</span> of the
 block subsidy.</p>
 
-<h4 id="mechanism2b:periodiclockboxdisbursement"><span class="section-heading">Mechanism 2b: Periodic lockbox disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#mechanism2b:periodiclockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h3 id="mechanism2b:periodiclockboxdisbursement"><span class="section-heading">Mechanism 2b: Periodic lockbox disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#mechanism2b:periodiclockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
 <p>Constant parameter <span class="math">\(N = 35000\)</span> blocks <span class="math">\(=
 \mathsf{PostBlossomHalvingInterval}/48\)</span> (i.e. approximately one month of
@@ -222,7 +222,7 @@ relevant privacy concerns related to this proposal; all disbursement of
 (but not necessarily subsequent distribution) of development funds is
 transparent and auditable by any participant in the network.</p>
 
-<h4 id="securityimplicationsoftheone-timelockboxdisbursement"><span class="section-heading">Security implications of the One-Time Lockbox Disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsoftheone-timelockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h2 id="securityimplicationsoftheone-timelockboxdisbursement"><span class="section-heading">Security implications of the One-Time Lockbox Disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsoftheone-timelockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>After the activation block of this ZIP has been mined, all development funds
 previously accrued to the in-protocol lockbox will be held instead by a 2-of-3
@@ -236,7 +236,7 @@ additional loss or compromise occurs.</p>
 <p>Because this is a one-time disbursement, additional key rotation infrastructure
 is not required.</p>
 
-<h4 id="securityimplicationsforoption1"><span class="section-heading">Security implications for Option 1</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsforoption1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h2 id="securityimplicationsforoption1"><span class="section-heading">Security implications for Option 1</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsforoption1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>Funds will continue to securely accrue to the Deferred Development Lockbox
 until a disbursement mechanism for the lockbox is implemented in a future
@@ -245,7 +245,7 @@ in-protocol option for key rotation, such that it is not necessary to perform a
 network upgrade to recover from key loss or compromise, or to change the size
 of the signing set or the number of signatures required to reach threshold.</p>
 
-<h4 id="securityimplicationsformechanism2a"><span class="section-heading">Security implications for Mechanism 2a</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsformechanism2a"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h2 id="securityimplicationsformechanism2a"><span class="section-heading">Security implications for Mechanism 2a</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsformechanism2a"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>As of the activation height of this ZIP, development funds will begin accruing
 as additional outputs spendable by a 2-of-3 multisig address on a
@@ -264,7 +264,7 @@ for the ECC funding stream described in ZIP 1014 <a href="#fn:10" id="fnref:10" 
 emergency Network Upgrade to perform a manual key rotation to ensure that
 future development funds are not lost.</p>
 
-<h4 id="securityimplicationsformechanism2b"><span class="section-heading">Security implications for Mechanism 2b</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsformechanism2b"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
+<h2 id="securityimplicationsformechanism2b"><span class="section-heading">Security implications for Mechanism 2b</span><span class="section-anchor"> <a rel="bookmark" href="#securityimplicationsformechanism2b"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
 <p>Due to the aggregation of funds recommended by Option 2b, it is no longer
 necessary to use scripts with spending privileges to perform shielding and/or

--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -109,6 +109,11 @@ value.</p>
 
 <h3 id="rationaleforusingap2shoutput"><span class="section-heading">Rationale for using a P2SH output</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforusingap2shoutput"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
+<details>
+<summary>
+Rationale
+</summary>
+
 <p>The keyholders may desire the grant-filling transactions use transparent inputs or
 shielded inputs. Regardless of their desire, the one-time disbursement must at some
 point go through a shielded pool, because this ZIP does not propose altering the
@@ -138,7 +143,8 @@ address needs to be derived well in advance of NU activation. At the time of
 writing (May 2025), ZIP 312 does not specify key generation, and it would be
 undesirable to couple the specification process for that to this ZIP. P2SH
 multisig addresses by comparison have a stable and well understood format and
-generation process.</li>
+generation process.
+</details></li>
 </ul>
 
 <h3 id="changetothezcashprotocolspecification"><span class="section-heading">Change to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changetothezcashprotocolspecification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
@@ -175,6 +181,11 @@ specified by the proposal under which this ZIP is activated.</p>
 
 <h3 id="rationaleforoption1"><span class="section-heading">Rationale for Option 1</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforoption1"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
 
+<details>
+<summary>
+Rationale
+</summary>
+
 <p>Performing a one-time disbursement to a P2SH multisig address will provide a
 source of grant funding for a limited period, allowing time for a lockbox
 disbursement mechanism to be specified and deployed, as originally intended by
@@ -194,7 +205,8 @@ transaction format in order to avoid such disruption.</p>
 and the implementation of a more flexible and secure mechanism for disbursement
 from the lockbox — making it possible to address the need to rotate keys and/or
 alter the set of key holders in a way that reverting to hard-coded output
-addresses for repeated disbursements would not.</p>
+addresses for repeated disbursements would not.
+</details></p>
 
 <h2 id="option2:reverttohard-codedoutputaddress"><span class="section-heading">Option 2: Revert to hard-coded output address</span><span class="section-anchor"> <a rel="bookmark" href="#option2:reverttohard-codedoutputaddress"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
@@ -236,6 +248,11 @@ that all output to the same address.</p>
 
 <h4 id="rationaleforperiodicdisbursement"><span class="section-heading">Rationale for periodic disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforperiodicdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
 
+<details>
+<summary>
+Rationale
+</summary>
+
 <p>Classic funding streams <a href="#fn:9" id="fnref:9" title="see footnote" class="footnote"><sup>9</sup></a> produce many small output values, due to
 only being able to direct funds from a single block&#8217;s subsidy at a time. This
 creates operational burdens to utilizing the funds — in particular due to block
@@ -247,7 +264,8 @@ fee.</p>
 funding stream, but with aggregation performed for free: the output to the
 funding stream recipient is aggregated into larger outputs every <span class="math">\(N\)</span> blocks. In
 the specific case of Mechanism 2b, the recipient multisig address would receive
-around 40 outputs, instead of around 1,300,000.</p>
+around 40 outputs, instead of around 1,300,000.
+</details></p>
 
 <h1 id="privacyandsecurityimplications"><span class="section-heading">Privacy and Security Implications</span><span class="section-anchor"> <a rel="bookmark" href="#privacyandsecurityimplications"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h1>
 

--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -86,10 +86,9 @@ given that height.)</p>
 
 <p>The additional coinbase output MUST contain at least one output that pays
 <span class="math">\(v\)</span> zatoshi to the above P2SH multisig address, using a standard P2SH script
-of the form <span class="math">\(\texttt{OP\_HASH160}\)</span> <span class="math">\(\mathsf{RedeemScriptHash}(\mathsf{height})\)</span>
-<span class="math">\(\texttt{OP\_EQUAL}\)</span> as the <span class="math">\(\mathtt{scriptPubKey}\)</span>. <span class="math">\(v\)</span> zatoshi are added to
-the transparent transaction value pool of the coinbase transaction to fund
-this output, and deducted from the balance of the Deferred Dev Fund Lockbox.
+as specified in <a href="#fn:5" id="fnref:5" title="see footnote" class="footnote"><sup>5</sup></a>. <span class="math">\(v\)</span> zatoshi are added to the transparent
+transaction value pool of the coinbase transaction to fund this output, and
+deducted from the balance of the Deferred Dev Fund Lockbox.
 The latter deduction occurs before any other change to the Deferred Dev Fund
 Lockbox balance in the transaction, and MUST NOT cause the Deferred Dev Fund
 Lockbox balance to become negative at that point.</p>
@@ -110,7 +109,7 @@ value.</p>
 
 <h4 id="changetothezcashprotocolspecification"><span class="section-heading">Change to the Zcash Protocol Specification</span><span class="section-anchor"> <a rel="bookmark" href="#changetothezcashprotocolspecification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
 
-<p>In section <strong>7.1.2 Transaction Consensus Rules</strong> <a href="#fn:5" id="fnref:5" title="see footnote" class="footnote"><sup>5</sup></a>, change:</p>
+<p>In section <strong>7.1.2 Transaction Consensus Rules</strong> <a href="#fn:6" id="fnref:6" title="see footnote" class="footnote"><sup>6</sup></a>, change:</p>
 
 <blockquote>
 <ul>
@@ -145,11 +144,11 @@ specified by the proposal under which this ZIP is activated.</p>
 <p>Performing a one-time disbursement to a P2SH multisig address will provide a
 source of grant funding for a limited period, allowing time for a lockbox
 disbursement mechanism to be specified and deployed, as originally intended by
-ZIP 1015 <a href="#fn:6" id="fnref:6" title="see footnote" class="footnote"><sup>6</sup></a>.</p>
+ZIP 1015 <a href="#fn:7" id="fnref:7" title="see footnote" class="footnote"><sup>7</sup></a>.</p>
 
 <p>In particular, this provides an opportunity for transaction format changes that
 may be required for such a mechanism to be included in the v6 transaction
-format <a href="#fn:7" id="fnref:7" title="see footnote" class="footnote"><sup>7</sup></a>. It is desirable to limit the frequency of transaction
+format <a href="#fn:8" id="fnref:8" title="see footnote" class="footnote"><sup>8</sup></a>. It is desirable to limit the frequency of transaction
 format changes because such changes are disruptive to the ecosystem. It is not
 necessary that protocol rules for disbursement actually be implemented until
 after the transaction format changes are live on the network. It is RECOMMENDED
@@ -203,7 +202,7 @@ that all output to the same address.</p>
 
 <h4 id="rationaleforperiodicdisbursement"><span class="section-heading">Rationale for periodic disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#rationaleforperiodicdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h4>
 
-<p>Classic funding streams <a href="#fn:8" id="fnref:8" title="see footnote" class="footnote"><sup>8</sup></a> produce many small output values, due to
+<p>Classic funding streams <a href="#fn:9" id="fnref:9" title="see footnote" class="footnote"><sup>9</sup></a> produce many small output values, due to
 only being able to direct funds from a single block&#8217;s subsidy at a time. This
 creates operational burdens to utilizing the funds — in particular due to block
 and transaction sizes limiting how many outputs can be combined at once, which
@@ -259,7 +258,7 @@ these funds. This process is an attractive target for compromise; for this
 reason it is RECOMMENDED that address rotation (in this case, by means of
 hard-coding a sequence of addresses, each of which receives a time-bounded
 subset of the block reward fractional outputs) be implemented, as was done
-for the ECC funding stream described in ZIP 1014 <a href="#fn:9" id="fnref:9" title="see footnote" class="footnote"><sup>9</sup></a>.</p>
+for the ECC funding stream described in ZIP 1014 <a href="#fn:10" id="fnref:10" title="see footnote" class="footnote"><sup>10</sup></a>.</p>
 
 <p>In the case of key compromise or loss, it may be necessary to perform an
 emergency Network Upgrade to perform a manual key rotation to ensure that
@@ -300,23 +299,27 @@ funds.</p>
 </li>
 
 <li id="fn:5">
-<p><a href="protocol/protocol.pdf#txnconsensus">Zcash Protocol Specification, Version 2024.5.1. Section 7.1.2: Transaction Consensus Rules</a> <a href="#fnref:5" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="https://developer.bitcoin.org/devguide/transactions.html#multisig">Bitcoin Developer Documentation — Pay To Script Hash (P2SH) — Multisig</a> <a href="#fnref:5" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:6">
-<p><a href="zip-1015">ZIP 1015: Block Subsidy Allocation for Non-Direct Development Funding</a> <a href="#fnref:6" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="protocol/protocol.pdf#txnconsensus">Zcash Protocol Specification, Version 2024.5.1. Section 7.1.2: Transaction Consensus Rules</a> <a href="#fnref:6" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:7">
-<p><a href="zip-0230">ZIP 230: Version 6 Transaction Format</a> <a href="#fnref:7" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="zip-1015">ZIP 1015: Block Subsidy Allocation for Non-Direct Development Funding</a> <a href="#fnref:7" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:8">
-<p><a href="zip-0207">ZIP 207: Funding Streams</a> <a href="#fnref:8" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="zip-0230">ZIP 230: Version 6 Transaction Format</a> <a href="#fnref:8" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 <li id="fn:9">
-<p>zip-1014 <a href="#fnref:9" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+<p><a href="zip-0207">ZIP 207: Funding Streams</a> <a href="#fnref:9" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
+</li>
+
+<li id="fn:10">
+<p>zip-1014 <a href="#fnref:10" title="return to body" class="reversefootnote">&#160;&#8617;&#xfe0e;</a></p>
 </li>
 
 </ol>

--- a/rendered/draft-ecc-lockbox-disbursement.html
+++ b/rendered/draft-ecc-lockbox-disbursement.html
@@ -77,10 +77,10 @@ as specified by this ZIP.</p>
 
 <h2 id="one-timelockboxdisbursement"><span class="section-heading">One-time lockbox disbursement</span><span class="section-anchor"> <a rel="bookmark" href="#one-timelockboxdisbursement"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
 
-<p>The coinbase transaction of the activation block of this ZIP MUST include an
-additional lockbox disbursement output to a 2-of-3 P2SH multisig with keys held
-by the following &#8220;Key-Holder Organizations&#8221;: Zcash Foundation, the Electric Coin
-Company, and Shielded Labs.</p>
+<p>The coinbase transaction of the activation block of this ZIP MUST include a
+lockbox disbursement output to a 2-of-3 P2SH multisig with keys held by the
+following &#8220;Key-Holder Organizations&#8221;: Zcash Foundation, the Electric Coin Company,
+and Shielded Labs.</p>
 
 <p>Let <span class="math">\(v\)</span> be the zatoshi amount in the Deferred Dev Fund Lockbox as of the end
 of the block preceding the activation height. (<span class="math">\(v\)</span> can be predicted in advance

--- a/rendered/zip-0207.html
+++ b/rendered/zip-0207.html
@@ -46,7 +46,7 @@ License: MIT</pre>
         </section>
         <section id="specification"><h2><span class="section-heading">Specification</span><span class="section-anchor"> <a rel="bookmark" href="#specification"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h2>
             <section id="definitions"><h3><span class="section-heading">Definitions</span><span class="section-anchor"> <a rel="bookmark" href="#definitions"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>We use the following constants and functions defined in <a id="footnote-reference-14" class="footnote_reference" href="#protocol-constants">5</a>, <a id="footnote-reference-15" class="footnote_reference" href="#protocol-diffadjustment">8</a>, <a id="footnote-reference-16" class="footnote_reference" href="#protocol-subsidies">9</a>, and <a id="footnote-reference-17" class="footnote_reference" href="#protocol-foundersreward">10</a>:</p>
+                <p>We use the following constants and functions defined in <a id="footnote-reference-14" class="footnote_reference" href="#protocol-constants">5</a>, <a id="footnote-reference-15" class="footnote_reference" href="#protocol-diffadjustment">8</a>, and <a id="footnote-reference-16" class="footnote_reference" href="#protocol-subsidies">9</a>:</p>
                 <ul>
                     <li>
                         <span class="math">\(\mathsf{BlossomActivationHeight}\)</span>
@@ -60,9 +60,6 @@ License: MIT</pre>
                     <li>
                         <span class="math">\(\mathsf{BlockSubsidy}(\mathsf{height})\)</span>
                     </li>
-                    <li>
-                        <span class="math">\(\mathsf{RedeemScriptHash}(\mathsf{height})\!\)</span>
-                    .</li>
                 </ul>
                 <p>We also define the following function:</p>
                 <ul>
@@ -77,16 +74,16 @@ License: MIT</pre>
             </section>
             <section id="funding-streams"><h3><span class="section-heading">Funding streams</span><span class="section-anchor"> <a rel="bookmark" href="#funding-streams"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
                 <p>A funding stream is defined by a block subsidy fraction (represented as a numerator and a denominator), a start height (inclusive), an end height (exclusive), and a sequence of recipients as defined below.</p>
-                <p>By defining the issuance as a proportion of the total block subsidy, rather than absolute zatoshis, this ZIP dovetails with any changes to both block target spacing and issuance-per-block rates. Such a change occurred at the Blossom network upgrade, for example. <a id="footnote-reference-18" class="footnote_reference" href="#zip-0208">14</a></p>
+                <p>By defining the issuance as a proportion of the total block subsidy, rather than absolute zatoshis, this ZIP dovetails with any changes to both block target spacing and issuance-per-block rates. Such a change occurred at the Blossom network upgrade, for example. <a id="footnote-reference-17" class="footnote_reference" href="#zip-0208">14</a></p>
                 <p>The value of a funding stream at a given block height is defined as:</p>
                 <div class="math">\(\mathsf{FundingStream[FUND].Value}(\mathsf{height}) =
     \mathsf{floor}\left(
         \frac{\mathsf{BlockSubsidy}(\mathsf{height}) \,\cdot\, \mathsf{FundingStream[FUND].ValueNumerator}}{\mathsf{FundingStream[FUND].ValueDenominator}}
     \right)\)</div>
                 <p>An active funding stream at a given block height is defined as a funding stream for which the block height is less than its end height, but not less than its start height.</p>
-                <p>The funding streams are paid to one of a pre-defined set of recipients, depending on the block height. Each recipient identifier MUST be either the string encoding of a transparent P2SH address or Sapling address (as specified in <a id="footnote-reference-19" class="footnote_reference" href="#protocol-transparentaddrencoding">6</a> or <a id="footnote-reference-20" class="footnote_reference" href="#protocol-saplingpaymentaddrencoding">7</a>) to be paid by an output in the coinbase transaction, or the identifier
+                <p>The funding streams are paid to one of a pre-defined set of recipients, depending on the block height. Each recipient identifier MUST be either the string encoding of a transparent P2SH address or Sapling address (as specified in <a id="footnote-reference-18" class="footnote_reference" href="#protocol-transparentaddrencoding">6</a> or <a id="footnote-reference-19" class="footnote_reference" href="#protocol-saplingpaymentaddrencoding">7</a>) to be paid by an output in the coinbase transaction, or the identifier
                     <span class="math">\(\mathsf{DEFERRED\_POOL}\!\)</span>
-                . The latter, added in the NU6 network upgrade <a id="footnote-reference-21" class="footnote_reference" href="#zip-0253">19</a>, indicates that the value is to be paid to a reserve to be used for development funding, the distribution of which is to be determined via a future ZIP.</p>
+                . The latter, added in the NU6 network upgrade <a id="footnote-reference-20" class="footnote_reference" href="#zip-0253">19</a>, indicates that the value is to be paid to a reserve to be used for development funding, the distribution of which is to be determined via a future ZIP.</p>
                 <p>Each address is used for at most 1/48th of a halving interval, creating a roughly-monthly sequence of funding periods. The address to be used for a given block height is defined as follows:</p>
                 <div class="math">\(\begin{array}{rcl}
     \mathsf{AddressChangeInterval} &amp;=&amp; \mathsf{PostBlossomHalvingInterval} / 48 \\
@@ -232,10 +229,10 @@ License: MIT</pre>
                  prior to NU6 activation.</p>
             </section>
             <section id="consensus-rules"><h3><span class="section-heading">Consensus rules</span><span class="section-anchor"> <a rel="bookmark" href="#consensus-rules"><img width="24" height="24" class="section-anchor" src="assets/images/section-anchor.png" alt=""></a></span></h3>
-                <p>Prior to activation of the Canopy network upgrade, the existing consensus rule for payment of the original Founders' Reward is enforced. <a id="footnote-reference-22" class="footnote_reference" href="#protocol-foundersreward">10</a></p>
+                <p>Prior to activation of the Canopy network upgrade, the existing consensus rule for payment of the original Founders' Reward is enforced. <a id="footnote-reference-21" class="footnote_reference" href="#protocol-foundersreward">10</a></p>
                 <p>Once the Canopy network upgrade activates:</p>
                 <ul>
-                    <li>The existing consensus rule for payment of the Founders' Reward <a id="footnote-reference-23" class="footnote_reference" href="#protocol-foundersreward">10</a> is no longer active. (This would be the case under the preexisting consensus rules for Mainnet, but not for Testnet.)</li>
+                    <li>The existing consensus rule for payment of the Founders' Reward <a id="footnote-reference-22" class="footnote_reference" href="#protocol-foundersreward">10</a> is no longer active. (This would be the case under the preexisting consensus rules for Mainnet, but not for Testnet.)</li>
                     <li>In each block with coinbase transaction
                         <span class="math">\(\mathsf{cb}\)</span>
                      at block height
@@ -256,7 +253,7 @@ License: MIT</pre>
                      is defined as
                         <span class="math">\(\mathsf{fs.Recipients_{\,fs.RecipientIndex}}(\mathsf{height})\!\)</span>
                     .</li>
-                    <li>The "prescribed way" to pay a transparent P2SH address is to use a standard P2SH script of the form <code>OP_HASH160 RedeemScriptHash(height) OP_EQUAL</code> as the <code>scriptPubKey</code>.</li>
+                    <li>The "prescribed way" to pay a transparent multisig P2SH address is to use a standard P2SH script as specified in <a id="footnote-reference-23" class="footnote_reference" href="#bitcoin-multisig">23</a>.</li>
                     <li>The "prescribed way" to pay a Sapling address is as defined in <a id="footnote-reference-24" class="footnote_reference" href="#zip-0213">16</a>. That is, all Sapling outputs in coinbase transactions (including, but not limited to, outputs for funding streams) MUST have valid note commitments when recovered using a 32-byte array of zeroes as the outgoing viewing key. In this case the note plaintext lead byte MUST be
                         <span class="math">\(\mathbf{0x02}\!\)</span>
                     , as specified in <a id="footnote-reference-25" class="footnote_reference" href="#zip-0212">15</a>.</li>
@@ -462,6 +459,14 @@ License: MIT</pre>
                     <tr>
                         <th>22</th>
                         <td><a href="zip-2001">ZIP 2001: Lockbox Funding Streams</a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <table id="bitcoin-multisig" class="footnote">
+                <tbody>
+                    <tr>
+                        <th>23</th>
+                        <td><cite>Bitcoin Developer Documentation — Pay To Script Hash (P2SH) — Multisig &lt;<a href="https://developer.bitcoin.org/devguide/transactions.html#multisig">https://developer.bitcoin.org/devguide/transactions.html#multisig</a>&gt;</cite></td>
                     </tr>
                 </tbody>
             </table>

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -7,7 +7,9 @@
     Category: Consensus / Process
     Created: 2025-02-19
     License: MIT
-    Pull-Request: <https://github.com/zcash/zips/pull/???>
+    Pull-Request: <https://github.com/zcash/zips/pull/989>
+                  <https://github.com/zcash/zips/pull/1014>
+                  <https://github.com/zcash/zips/pull/1015>
 
 # Terminology
 
@@ -206,7 +208,7 @@ blocks).
 
 The ``FS_DEFERRED`` lockbox funding stream is extended to end at height
 $\mathsf{stream\_end\_height}$ and has its per-block output value set to
-$\mathsf{stream\_value}\%$ A consensus rule is added to disburse from the
+$\mathsf{stream\_value}\%$. A consensus rule is added to disburse from the
 Deferred Dev Fund Lockbox to a 2-of-3 P2SH multisig with keys held by the same
 Key-Holder Organizations as above, starting at block height
 $\mathsf{activation\_height} + N$ and continuing at periodic intervals of $N$

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -88,6 +88,38 @@ the point when the relevant consensus check is done in node implementations.
 If so, the specification should be written in terms of the precalculated
 value.
 
+### Rationale for using a P2SH output
+
+The keyholders may desire the grant-filling transactions use transparent inputs or
+shielded inputs. Regardless of their desire, the one-time disbursement must at some
+point go through a shielded pool, because this ZIP does not propose altering the
+consensus rules for spendability of transparent coinbase outputs. That would be far
+too complex a change for the intended scope.
+
+This means that by using a P2SH output in consensus, the Key-Holder Organizations
+will need to spend the one-time disbursement completely into a shielded output.
+This spend would presumably be to a FROST address in order to maintain consistent
+security position over the lockbox funds; perhaps publishing the viewing key to
+maintain visibility.
+
+An alternative proposal could require the one-time disbursement to directly create
+a shielded output to the FROST address. This would mean that the Key-Holder
+Organizations could immediately start disbursing grants (although the 100-block
+coinbase maturity is not particularly onerous).
+
+This ZIP instead uses a P2SH output for two reasons:
+
+* Using a shielded output would place a requirement on the miner (or mining pool)
+  to be able to create shielded coinbase outputs. Technically that requirement
+  is already in the consensus rules, but it has never before been exercised,
+  since no Funding Stream has been defined with a shielded address.
+* Using a shielded output in the context of this ZIP would mean that the FROST
+  address needs to be derived well in advance of NU activation. At the time of
+  writing (May 2025), ZIP 312 does not specify key generation, and it would be
+  undesirable to couple the specification process for that to this ZIP. P2SH
+  multisig addresses by comparison have a stable and well understood format and
+  generation process.
+
 ### Change to the Zcash Protocol Specification
 
 In section **7.1.2 Transaction Consensus Rules** [^protocol-txnconsensus], change:

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -11,7 +11,7 @@
 
 # Terminology
 
-The key words "MUST", "SHOULD", "MAY", and "RECOMMENDED" in this document are
+The key words "MUST", "MUST NOT", and "RECOMMENDED" in this document are
 to be interpreted as described in BCP 14 [^BCP14] when, and only when, they
 appear in all capitals.
 
@@ -59,9 +59,9 @@ as specified by this ZIP.
 ### One-time lockbox disbursement
 
 The coinbase transaction of the activation block of this ZIP MUST include an
-additional output to a 2-of-3 P2SH multisig with keys held by the following
-"Key-Holder Organizations": Zcash Foundation, the Electric Coin Company,
-and Shielded Labs.
+additional lockbox disbursement output to a 2-of-3 P2SH multisig with keys held
+by the following "Key-Holder Organizations": Zcash Foundation, the Electric Coin
+Company, and Shielded Labs.
 
 Let $v$ be the zatoshi amount in the Deferred Dev Fund Lockbox as of the end
 of the block preceding the activation height. ($v$ can be predicted in advance
@@ -88,6 +88,23 @@ Note: The value $v$ might need to be precalculated so that it is known at
 the point when the relevant consensus check is done in node implementations.
 If so, the specification should be written in terms of the precalculated
 value.
+
+#### Change to the Zcash Protocol Specification
+
+In section **7.1.2 Transaction Consensus Rules** [^protocol-txnconsensus], change:
+
+> * A transaction MUST NOT spend a transparent output of a coinbase transaction
+>   from a block less than 100 blocks prior to the spend. Note that transparent
+>   outputs of coinbase transactions include Founders’ Reward outputs and
+>   transparent funding stream outputs.
+
+to
+
+> * A transaction MUST NOT spend a transparent output of a coinbase transaction
+>   from a block less than 100 blocks prior to the spend. Note that transparent
+>   outputs of coinbase transactions include Founders’ Reward outputs,
+>   transparent funding stream outputs [[ZIP-207]](zip-0207), and lockbox
+>   disbursement outputs {{ reference to this ZIP section }}.
 
 ### Option 1: Extend the lockbox funding stream
 
@@ -132,7 +149,7 @@ Option 2 can be realized by either of the following mechanisms:
 
 #### Mechanism 2a: Classic funding stream
 
-A new funding stream is definedthat pays directly to the above-mentioned 3-of-5
+A new funding stream is defined that pays directly to the above-mentioned 3-of-5
 multisig address on a block-by-block basis. It is defined to start at the end
 height of the existing ``FS_DEFERRED`` funding stream and end at
 $\mathsf{stream\_end\_height}$ and consists of $\mathsf{stream\_value}\%$ of the
@@ -234,6 +251,10 @@ Upgrade to perform manual key rotation to mitigate the potential for loss of
 funds.
 
 # References
+
+[^BCP14]: [Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
+
+[^protocol-txnconsensus]: [Zcash Protocol Specification, Version 2024.5.1. Section 7.1.2: Transaction Consensus Rules](protocol/protocol.pdf#txnconsensus)
 
 [^zip-0207]: [ZIP 207: Funding Streams](zip-0207.rst)
 

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -60,10 +60,10 @@ as specified by this ZIP.
 
 ## One-time lockbox disbursement
 
-The coinbase transaction of the activation block of this ZIP MUST include an
-additional lockbox disbursement output to a 2-of-3 P2SH multisig with keys held
-by the following "Key-Holder Organizations": Zcash Foundation, the Electric Coin
-Company, and Shielded Labs.
+The coinbase transaction of the activation block of this ZIP MUST include a
+lockbox disbursement output to a 2-of-3 P2SH multisig with keys held by the
+following "Key-Holder Organizations": Zcash Foundation, the Electric Coin Company,
+and Shielded Labs.
 
 Let $v$ be the zatoshi amount in the Deferred Dev Fund Lockbox as of the end
 of the block preceding the activation height. ($v$ can be predicted in advance

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -90,6 +90,11 @@ value.
 
 ### Rationale for using a P2SH output
 
+<details>
+<summary>
+Rationale
+</summary>
+
 The keyholders may desire the grant-filling transactions use transparent inputs or
 shielded inputs. Regardless of their desire, the one-time disbursement must at some
 point go through a shielded pool, because this ZIP does not propose altering the
@@ -119,6 +124,7 @@ This ZIP instead uses a P2SH output for two reasons:
   undesirable to couple the specification process for that to this ZIP. P2SH
   multisig addresses by comparison have a stable and well understood format and
   generation process.
+</details>
 
 ### Change to the Zcash Protocol Specification
 
@@ -146,6 +152,11 @@ specified by the proposal under which this ZIP is activated.
 
 ### Rationale for Option 1
 
+<details>
+<summary>
+Rationale
+</summary>
+
 Performing a one-time disbursement to a P2SH multisig address will provide a
 source of grant funding for a limited period, allowing time for a lockbox
 disbursement mechanism to be specified and deployed, as originally intended by 
@@ -166,6 +177,7 @@ and the implementation of a more flexible and secure mechanism for disbursement
 from the lockbox — making it possible to address the need to rotate keys and/or
 alter the set of key holders in a way that reverting to hard-coded output
 addresses for repeated disbursements would not.
+</details>
 
 ## Option 2: Revert to hard-coded output address
 
@@ -207,6 +219,11 @@ that all output to the same address.
 
 #### Rationale for periodic disbursement
 
+<details>
+<summary>
+Rationale
+</summary>
+
 Classic funding streams [^zip-0207] produce many small output values, due to
 only being able to direct funds from a single block's subsidy at a time. This
 creates operational burdens to utilizing the funds — in particular due to block
@@ -219,6 +236,7 @@ funding stream, but with aggregation performed for free: the output to the
 funding stream recipient is aggregated into larger outputs every $N$ blocks. In
 the specific case of Mechanism 2b, the recipient multisig address would receive
 around 40 outputs, instead of around 1,300,000.
+</details>
 
 # Privacy and Security Implications
 

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -69,10 +69,9 @@ given that height.)
 
 The additional coinbase output MUST contain at least one output that pays
 $v$ zatoshi to the above P2SH multisig address, using a standard P2SH script
-of the form $\texttt{OP\_HASH160}$ $\mathsf{RedeemScriptHash}(\mathsf{height})$
-$\texttt{OP\_EQUAL}$ as the $\mathtt{scriptPubKey}$. $v$ zatoshi are added to
-the transparent transaction value pool of the coinbase transaction to fund
-this output, and deducted from the balance of the Deferred Dev Fund Lockbox.
+as specified in [^Bitcoin-Multisig]. $v$ zatoshi are added to the transparent
+transaction value pool of the coinbase transaction to fund this output, and
+deducted from the balance of the Deferred Dev Fund Lockbox.
 The latter deduction occurs before any other change to the Deferred Dev Fund
 Lockbox balance in the transaction, and MUST NOT cause the Deferred Dev Fund
 Lockbox balance to become negative at that point.
@@ -272,3 +271,4 @@ funds.
 
 [^draft-ecc-community-and-coinholder]: [draft-ecc-community-and-coinholder: Community and Coinholder Funding Model](draft-ecc-community-and-coinholder.md)
 
+[^Bitcoin-Multisig]: [Bitcoin Developer Documentation — Pay To Script Hash (P2SH) — Multisig](https://developer.bitcoin.org/devguide/transactions.html#multisig)

--- a/zips/draft-ecc-lockbox-disbursement.md
+++ b/zips/draft-ecc-lockbox-disbursement.md
@@ -56,7 +56,7 @@ Lockbox as of the activation height of this ZIP, plus any funds that later
 accrue to either the lockbox or to one or more transparent multisig addresses
 as specified by this ZIP.
 
-### One-time lockbox disbursement
+## One-time lockbox disbursement
 
 The coinbase transaction of the activation block of this ZIP MUST include an
 additional lockbox disbursement output to a 2-of-3 P2SH multisig with keys held
@@ -88,7 +88,7 @@ the point when the relevant consensus check is done in node implementations.
 If so, the specification should be written in terms of the precalculated
 value.
 
-#### Change to the Zcash Protocol Specification
+### Change to the Zcash Protocol Specification
 
 In section **7.1.2 Transaction Consensus Rules** [^protocol-txnconsensus], change:
 
@@ -105,14 +105,14 @@ to
 >   transparent funding stream outputs [[ZIP-207]](zip-0207), and lockbox
 >   disbursement outputs {{ reference to this ZIP section }}.
 
-### Option 1: Extend the lockbox funding stream
+## Option 1: Extend the lockbox funding stream
 
 The ``FS_DEFERRED`` lockbox funding stream is set to receive
 $\mathsf{stream\_value}\%$ of the block subsidy and is extended until block
 height $\mathsf{stream\_end\_height}$. Both of these parameters must be
 specified by the proposal under which this ZIP is activated.
 
-#### Rationale for Option 1
+### Rationale for Option 1
 
 Performing a one-time disbursement to a P2SH multisig address will provide a
 source of grant funding for a limited period, allowing time for a lockbox
@@ -135,7 +135,7 @@ from the lockbox — making it possible to address the need to rotate keys and/o
 alter the set of key holders in a way that reverting to hard-coded output
 addresses for repeated disbursements would not.
 
-### Option 2: Revert to hard-coded output address
+## Option 2: Revert to hard-coded output address
 
 A new funding stream consisting of $\mathsf{stream\_value}\%$ of the block
 subsidy is defined to begin when the existing ZIP 1015 funding streams
@@ -146,7 +146,7 @@ and funds from the one-time lockbox disbursement described above.
 
 Option 2 can be realized by either of the following mechanisms:
 
-#### Mechanism 2a: Classic funding stream
+### Mechanism 2a: Classic funding stream
 
 A new funding stream is defined that pays directly to the above-mentioned 3-of-5
 multisig address on a block-by-block basis. It is defined to start at the end
@@ -154,7 +154,7 @@ height of the existing ``FS_DEFERRED`` funding stream and end at
 $\mathsf{stream\_end\_height}$ and consists of $\mathsf{stream\_value}\%$ of the
 block subsidy.
 
-#### Mechanism 2b: Periodic lockbox disbursement
+### Mechanism 2b: Periodic lockbox disbursement
 
 Constant parameter $N = 35000$ blocks $=
 \mathsf{PostBlossomHalvingInterval}/48$ (i.e. approximately one month of
@@ -195,7 +195,7 @@ relevant privacy concerns related to this proposal; all disbursement of
 (but not necessarily subsequent distribution) of development funds is 
 transparent and auditable by any participant in the network.
 
-#### Security implications of the One-Time Lockbox Disbursement
+## Security implications of the One-Time Lockbox Disbursement
 
 After the activation block of this ZIP has been mined, all development funds
 previously accrued to the in-protocol lockbox will be held instead by a 2-of-3
@@ -209,7 +209,7 @@ additional loss or compromise occurs.
 Because this is a one-time disbursement, additional key rotation infrastructure
 is not required.
 
-#### Security implications for Option 1
+## Security implications for Option 1
 
 Funds will continue to securely accrue to the Deferred Development Lockbox
 until a disbursement mechanism for the lockbox is implemented in a future
@@ -218,7 +218,7 @@ in-protocol option for key rotation, such that it is not necessary to perform a
 network upgrade to recover from key loss or compromise, or to change the size
 of the signing set or the number of signatures required to reach threshold.
 
-#### Security implications for Mechanism 2a
+## Security implications for Mechanism 2a
 
 As of the activation height of this ZIP, development funds will begin accruing
 as additional outputs spendable by a 2-of-3 multisig address on a
@@ -237,7 +237,7 @@ In the case of key compromise or loss, it may be necessary to perform an
 emergency Network Upgrade to perform a manual key rotation to ensure that
 future development funds are not lost.
 
-#### Security implications for Mechanism 2b
+## Security implications for Mechanism 2b
 
 Due to the aggregation of funds recommended by Option 2b, it is no longer
 necessary to use scripts with spending privileges to perform shielding and/or

--- a/zips/zip-0207.rst
+++ b/zips/zip-0207.rst
@@ -87,13 +87,12 @@ Definitions
 -----------
 
 We use the following constants and functions defined in [#protocol-constants]_,
-[#protocol-diffadjustment]_, [#protocol-subsidies]_, and [#protocol-foundersreward]_:
+[#protocol-diffadjustment]_, and [#protocol-subsidies]_:
 
 - $\mathsf{BlossomActivationHeight}$
 - $\mathsf{PostBlossomHalvingInterval}$
 - $\mathsf{Halving}(\mathsf{height})$
 - $\mathsf{BlockSubsidy}(\mathsf{height})$
-- $\mathsf{RedeemScriptHash}(\mathsf{height})$.
 
 We also define the following function:
 
@@ -235,9 +234,8 @@ Once the Canopy network upgrade activates:
 - $\mathsf{fs.Recipient}(\mathsf{height})$ is defined as
   $\mathsf{fs.Recipients_{\,fs.RecipientIndex}}(\mathsf{height})$.
 
-- The "prescribed way" to pay a transparent P2SH address is to use a standard
-  P2SH script of the form ``OP_HASH160 RedeemScriptHash(height) OP_EQUAL`` as
-  the ``scriptPubKey``.
+- The "prescribed way" to pay a transparent multisig P2SH address is to use a
+  standard P2SH script as specified in [#Bitcoin-Multisig]_.
 
 - The "prescribed way" to pay a Sapling address is as defined in [#zip-0213]_.
   That is, all Sapling outputs in coinbase transactions (including, but not
@@ -311,3 +309,4 @@ References
 .. [#zip-1014] `ZIP 1014: Establishing a Dev Fund for ECC, ZF, and Major Grants <zip-1014.rst>`_
 .. [#zip-1015] `ZIP 1015: Block Subsidy Allocation for Non-Direct Development Funding <zip-1015.rst>`_
 .. [#zip-2001] `ZIP 2001: Lockbox Funding Streams <zip-2001.rst>`_
+.. [#Bitcoin-Multisig] `Bitcoin Developer Documentation — Pay To Script Hash (P2SH) — Multisig <https://developer.bitcoin.org/devguide/transactions.html#multisig>`


### PR DESCRIPTION
* Remove incorrect uses of $\mathsf{RedeemScript}(\mathsf{height})$ in ZIP 207 and draft-ecc-lockbox-disbursement.
* Add a change to the protocol spec to clarify an interaction with the coinbase maturity consensus rule.
* Correct the BCP 14 boilerplate.
* Fix a typo.

This is a follow-up to #1014.