### PR TITLE
ZIP 32: Specify string encoding of a seed fingerprint

### DIFF
--- a/zips/zip-0032.rst
+++ b/zips/zip-0032.rst
@@ -767,6 +767,9 @@ A "seed fingerprint" for the master seed $S$ of a hierarchical deterministic wal
 
 It MAY be used to uniquely identify a particular hierarchical deterministic wallet.
 
+The string encoding of a seed fingerprint uses Bech32m with the Human-Readable Part
+``zip32seedfp``, and the fingerprint bytes as the data.
+
 No corresponding short tag is defined.
 
 Note: a previous version of this specification did not have the length byte prefixing the seed.


### PR DESCRIPTION
Closes zcash/zips#1050.