### PR TITLE
[ZIP 230, ZIP 246] Fixing rendering issue, and removing TODO

### DIFF
--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -364,7 +364,7 @@ An OrchardZSA Asset Burn description is encoded in a transaction as an instance 
 The encodings of each of these elements are defined in ZIP 226 [#zip-0226]_.
 
 Transparent Sighash Information (``TransparentSighashInfo``)
----------------------------------------------------
+------------------------------------------------------------
 
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | Bytes                       | Name                         | Data Type                                      | Description                                                         |
@@ -502,6 +502,7 @@ References
 .. [#zip-0226] `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zip-0226.html>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.html>`_
 .. [#zip-0227-issuance-auth-sig] `ZIP 227: Issuance of Zcash Shielded Assets — Issuance Authorization Signature Scheme <zip-0227#issuance-authorization-signature-scheme>`_
+.. [#zip-0227-issuer-identifier] `ZIP 227: Issuance of Zcash Shielded Assets — Issuer Identifier <zip-0227#issuer-identifier>`_
 .. [#zip-0228] `ZIP 228: Asset Swaps for Zcash Shielded Assets <zip-0228.html>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0246-sighash-info] `ZIP 246: Digests for the Version 6 Transaction Format <zip-0246#zip-0246-sighash-info>`_

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -127,9 +127,6 @@ v0 Digests
 The v0 digests are based on the v5 transaction digest algorithm defined in
 ZIP 244 [#zip-0244]_.
 
-TODO: Update the Authorizing Data Commitment below for the ``sighashInfo``
-changes to the tx format.
-
 TxId Digest
 ===========
 


### PR DESCRIPTION
The rendered version of ZIP 230 had a system warning due to a short underline, and a missing reference. I added those in here. 

I also removed the TODO for the authorizing data commitment -- am I right that this specification has added that in satisfactorily (and that we can continue with the implementation changes using this version of the ZIP?)