### PR TITLE
Encourage node implementations to support Orchard funding recipients

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -14280,9 +14280,9 @@ The term \defining{\quotedPrescribedWay} is defined as follows:
         \defining{\xStandardRedeemScript} hashes are defined in \cite{Bitcoin-Multisig} for
         \PtoSHMultisigAddresses, or \cite{Bitcoin-P2SH} for other \PtoSHAddresses.
         \vspace{0.5ex}
-  \item The \defining{\prescribedWay} to pay a \Sapling \paymentAddress is defined in
-        \cite{ZIP-213}, using the post-\Heartwood consensus rules specified for \Sapling
-        outputs of \coinbaseTransactions in \crossref{txnconsensus}.
+  \item The \defining{\prescribedWay} to pay a \SaplingOrOrchard \paymentAddress is
+        defined in \cite{ZIP-213}, using the post-\Heartwood consensus rules specified
+        for \SaplingAndOrchard outputs of \coinbaseTransactions in \crossref{txnconsensus}.
 \end{itemize}
 } %canopyonward
 } %consensusrule
@@ -14298,6 +14298,11 @@ The term \defining{\quotedPrescribedWay} is defined as follows:
   \item For clarification, if there are multiple active \fundingStreams or
         \lockboxDisbursements with the same recipient identifier and/or value, there
         \MUST be least one distinct output for each of them.
+  \item Up to and including \NUSixOne there have been no \fundingStreams or
+        \lockboxDisbursements defined with a \shieldedPaymentAddress as a recipient.
+        That might change in future, so implementations are encouraged to support
+        \SaplingAndOrchard outputs as recipients, as permitted by \cite{ZIP-213}
+        and \cite{ZIP-207}.
 \end{pnotes}
 
 \vspace{-1ex}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -15220,7 +15220,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \lsection{Change History}{changehistory}
 
 
-\historyentry{2025.6.0}{}
+\historyentry{2025.6.0}{2025-09-08}
 
 \begin{itemize}
 \nusixone{

--- a/zips/zip-0207.rst
+++ b/zips/zip-0207.rst
@@ -271,6 +271,17 @@ Once the NU6 network upgrade activates:
   $\mathsf{fs.Value}(\mathsf{height})$ zatoshi in the prescribed way to
   the address represented by that recipient identifier.
 
+Rule 5 has subsequently been clarified as follows:
+
+- The "prescribed way" to pay a Sapling or Orchard address is as defined in
+  [#zip-0213]_, using the post-Heartwood consensus rules specified for Sapling
+  and Orchard outputs of coinbase transactions in [#protocol-txnconsensus]_.
+
+Note: Up to and including NU6.1 there have been no funding streams defined
+with a shielded payment address as a recipient. That might change in future,
+so implementations are encouraged to support Sapling and Orchard outputs as
+recipients, as permitted by [#zip-0213]_.
+
 These rules are reproduced in [#protocol-fundingstreams]_.
 
 The effect of the definition of $\mathsf{ChainValuePoolBalance^{Deferred}}$
@@ -321,6 +332,7 @@ References
 .. [#protocol-constants] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.3: Constants <protocol/protocol.pdf#constants>`_
 .. [#protocol-transparentaddrencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.6.1.1: Transparent Addresses <protocol/protocol.pdf#transparentaddrencoding>`_
 .. [#protocol-saplingpaymentaddrencoding] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 5.6.3.1: Sapling Payment Addresses <protocol/protocol.pdf#saplingpaymentaddrencoding>`_
+.. [#protocol-txnconsensus] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.1.2: Transaction Consensus Rules <protocol/protocol.pdf#txnconsensus>`_
 .. [#protocol-diffadjustment] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.7.3: Difficulty adjustment <protocol/protocol.pdf#diffadjustment>`_
 .. [#protocol-subsidies] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.8: Calculation of Block Subsidy, Funding Streams, and Founders’ Reward <protocol/protocol.pdf#subsidies>`_
 .. [#protocol-foundersreward] `Zcash Protocol Specification, Version 2025.6.0 [NU6.1 proposal]. Section 7.9: Payment of Founders’ Reward <protocol/protocol.pdf#foundersreward>`_

--- a/zips/zip-0271.md
+++ b/zips/zip-0271.md
@@ -246,6 +246,14 @@ to
 >
 > * The prescribed way to [...]
 
+Change the second bullet point defining the prescribed way to pay a Sapling payment
+address so that it also applies to Orchard, i.e.:
+
+> * The prescribed way to pay a Sapling or Orchard payment address is defined in
+>   [[ZIP-213]](zip-213), using the post-Heartwood consensus rules specified for
+>   Sapling and Orchard outputs of coinbase transactions in
+>   § 7.1.2 ‘Transaction Consensus Rules’ [^protocol-txnconsensus].
+
 Clarify the notes as follows:
 
 > * The funding stream addresses are not treated specially in any other way, and
@@ -257,6 +265,11 @@ Clarify the notes as follows:
 > * For clarification, if there are multiple active funding streams or lockbox
 >   disbursements with the same recipient identifier and/or value, there MUST be
 >   at least one distinct output for each of them.
+> * Up to and including NU6.1 there have been no funding streams or lockbox
+>   disbursements defined with a shielded payment address as a recipient.
+>   That might change in future, so implementations are encouraged to support
+>   Sapling and Orchard outputs as recipients, as permitted by [[ZIP-213]](zip-213)
+>   and [[ZIP-207]](zip-207).
 
 #### § 7.10.1 ‘ZIP 214 Funding Streams’ [^protocol-zip214fundingstreams]
 


### PR DESCRIPTION
This depends on #1069 (and so indirectly #1089 and #672). It releases protocol spec version 2025.6.0, which fixes #816.