### PR TITLE
Protocol spec: set correct release date

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -15220,7 +15220,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \lsection{Change History}{changehistory}
 
 
-\historyentry{2025.6.0}{2025-09-08}
+\historyentry{2025.6.0}{2025-09-17}
 
 \begin{itemize}
 \nusixone{


### PR DESCRIPTION
The release date of 2025.6.0 was intended to be 2025-09-17. Also the tag was pointing to the wrong place.