### PR TITLE
[ZIP 246] Updating `orchard_auth_digest` details to avoid nested loops

### DIFF
--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -314,7 +314,7 @@ The personalization field of this hash is set to::
 
   "ZTxId6OActC_Hash" (1 underscore character)
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-description]_.
+The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-description-orchardzsaaction]_.
 
 T.4a.ii: orchard_actions_noncompact_digest
 ..........................................
@@ -332,7 +332,7 @@ The personalization field of this hash is set to::
 
   "ZTxId6OActN_Hash" (1 underscore character)
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-description]_.
+The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-description-orchardzsaaction]_.
 
 
 T.4a.vi: orchard_burn_digest
@@ -644,10 +644,11 @@ References
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.html>`_
 .. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format. Specification: Transaction Format <zip-0230.html#transaction-format>`_
 .. [#zip-0230-orchardzsa-action-group-description] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Group Description  <zip-0230.html#orchardzsa-action-group-description>`_
-.. [#zip-0230-orchardzsa-action-description] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Description <zip-0230.html#orchardzsa-action-description>`_
+.. [#zip-0230-orchardzsa-action-description-orchardzsaaction] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Description <zip-0230.html#orchardzsa-action-description-orchardzsaaction>`_
 .. [#zip-0230-orchardzsa-asset-burn-description] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Asset Burn Description <zip-0230.html#orchardzsa-asset-burn-description>`_
 .. [#zip-0230-sapling-output-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Sapling Output Description (OutputDescriptionV6) <zip-0230.html#sapling-output-description-outputdescriptionv6>`_
 .. [#zip-0230-transparent-sighash-info-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Transparent Sighash Information <zip-0230.html#transparent-sighash-information-transparentsighashinfo>`_
+.. [#zip-0230-orchard-signature-orchardsignature] `ZIP 230: Version 6 Transaction Format. Specification: Orchard Signature <zip-0230.html#orchard-signature-orchardsignature>`_
 .. [#zip-0230-issuance-action-description-issueaction] `ZIP 230: Version 6 Transaction Format. Specification: Issuance Action Description <zip-0230.html#issuance-action-description-issueaction>`_
 .. [#zip-0230-issue-note-description-issuenotedescription] `ZIP 230: Version 6 Transaction Format. Specification: Issue Note Description <zip-0230.html#issue-note-description-issuenotedescription>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -581,7 +581,7 @@ The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-group-
 A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest
 ................................................
 
-This is a BLAKE2b-256 hash of the concatenation of ``OrchardSignature``s for the spend authorization signature of each OrchardZSA Action in the OrchardZSA Action Group (i.e. the contents of the ``vSpendAuthSigsOrchard`` field of the ``ActionGroupDescription``)::
+This is a BLAKE2b-256 hash of the concatenation of ``OrchardSignature`` encodings for the spend authorization signature of each OrchardZSA Action in the OrchardZSA Action Group (i.e. the contents of the ``vSpendAuthSigsOrchard`` field of the ``ActionGroupDescription``)::
 
     A.3a.ii.1: spendAuthSigsOrchard    (field encoding bytes)
 

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -566,14 +566,28 @@ Note that this means the encoding of ``bindingSigOrchard`` differs from that use
 A.3a: orchard_action_groups_auth_digest
 '''''''''''''''''''''''''''''''''''''''
 
-This is a BLAKE2b-256 hash of the ``proofsOrchard`` field of all OrchardZSA Action Groups belonging to the transaction; followed by the ``spendAuthSigsOrchard`` fields corresponding to every OrchardZSA Action in the OrchardZSA Action Group, for all OrchardZSA Action Groups belonging to the transaction::
+A BLAKE2b-256 hash of the subset of OrchardZSA Action Group information for all OrchardZSA Action Groups belonging to the transaction.
+For each OrchardZSA Action Group, this is a BLAKE2b-256 hash of the following values::
 
-    A.3a.i:  proofsOrchard               (field encoding bytes)
-    A.3a.ii: spendAuthSigsOrchard        (field encoding bytes)
+    A.3a.i:  proofsOrchard                              (field encoding bytes)
+    A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest    (32-byte hash output)
 
 The personalization field of this hash is set to::
 
     "ZTxAuthOrcAGHash"
+
+The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-field-encodings]_.
+
+A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest
+................................................
+
+This is a BLAKE2b-256 hash of the ``spendAuthSigsOrchard`` field of all OrchardZSA Actions belonging to the OrchardZSA Action Group::
+
+    A.3a.ii.1: spendAuthSigsOrchard    (field encoding bytes)
+
+The personalization field of this hash is set to::
+
+    "ZTxAuthOrSASHash"
 
 The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-field-encodings]_.
 Note that this means the encoding of ``spendAuthSigsOrchard`` differs from that used in ZIP 244.

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -314,7 +314,7 @@ The personalization field of this hash is set to::
 
   "ZTxId6OActC_Hash" (1 underscore character)
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-description]_.
 
 T.4a.ii: orchard_actions_noncompact_digest
 ..........................................
@@ -332,7 +332,7 @@ The personalization field of this hash is set to::
 
   "ZTxId6OActN_Hash" (1 underscore character)
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-description]_.
 
 
 T.4a.vi: orchard_burn_digest
@@ -353,7 +353,7 @@ $\mathsf{assetBurn}$ set is empty), the ``orchard_burn_digest`` is::
 
     BLAKE2b-256("ZTxIdOrcBurnHash", [])
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchard-asset-burn-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-asset-burn-description]_.
 
 
 T.5: issuance_digest
@@ -372,7 +372,7 @@ In case the transaction has no issuance components, ``issuance_digest`` is::
 
     BLAKE2b-256("ZTxIdSAIssueHash", [])
 
-The field encodings are specified in ZIP 230 [#zip-0230-transaction-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-transaction-format]_.
 
 T.5a: issue_actions_digest
 ''''''''''''''''''''''''''
@@ -386,7 +386,7 @@ The personalization field of this hash is set to::
 
   "ZTxIdIssuActHash"
 
-The field encodings are specified in ZIP 230 [#zip-0230-issue-actions-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-issuance-action-description-issueaction]_.
 
 T.5a.i: issue_notes_digest
 ..........................
@@ -405,7 +405,7 @@ In case the transaction has no Issue Notes, ``issue_notes_digest`` is::
 
     BLAKE2b-256("ZTxIdIAcNoteHash", [])
 
-The field encodings are specified in ZIP 230 [#zip-0230-issue-notes-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-issue-note-description-issuenotedescription]_.
 
 T.6: memo_digest
 ````````````````
@@ -422,7 +422,7 @@ In case the transaction has no memo chunks, ``memo_digest`` is::
 
     BLAKE2b-256("ZTxIdMemo___Hash", [])
 
-The field encodings are specified in ZIP 230 [#zip-0230-transaction-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-transaction-format]_.
 
 T.6b: memo_chunks_digest
 ''''''''''''''''''''''''
@@ -446,7 +446,7 @@ The personalization field of this hash is set to::
 
   "ZTxIdMemoCk_Hash" (1 underscore character)
 
-The field encodings are specified in ZIP 230 [#zip-0230-issue-actions-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-transaction-format]_.
 
 
 Signature Digest
@@ -523,7 +523,7 @@ A BLAKE2b-256 hash of the following values ::
 The personalization field of this hash remains the same as in ZIP 244.
 
 Note that while the structure of ``sapling_auth_digest`` remains the same as in ZIP 244, the field encodings of some of its components 
-(viz. ``spend_auth_sigs`` and ``binding_sig``) differ due to changes to their field encodings in ZIP 230 [#zip-0230-transaction-field-encodings]_.
+(viz. ``spend_auth_sigs`` and ``binding_sig``) differ due to changes to their field encodings in ZIP 230 [#zip-0230-transaction-format]_.
 
 
 A.1: transparent_auth_digest
@@ -560,7 +560,7 @@ In case that the transaction has no OrchardZSA Action Groups, ``orchard_auth_dig
 
     BLAKE2b-256("ZTxAuthOrchaHash", [])
 
-The field encodings are specified in ZIP 230 [#zip-0230-transaction-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-transaction-format]_.
 Note that this means the encoding of ``bindingSigOrchard`` differs from that used in ZIP 244.
 
 A.3a: orchard_action_groups_auth_digest
@@ -576,7 +576,7 @@ The personalization field of this hash is set to::
 
     "ZTxAuthOrcAGHash"
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-orchardzsa-action-group-description]_.
 
 A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest
 ................................................
@@ -607,7 +607,7 @@ In the case that the transaction has no Orchard Actions, ``issuance_auth_digest`
 
   BLAKE2b-256("ZTxAuthZSAOrHash", [])
 
-The field encodings are specified in ZIP 230 [#zip-0230-transaction-field-encodings]_.
+The field encodings are specified in ZIP 230 [#zip-0230-transaction-format]_.
 
 
 =========
@@ -642,14 +642,14 @@ References
 .. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2024.5.1 [NU6]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2022.3.8. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.html>`_
-.. [#zip-0230-transaction-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Transaction Format <zip-0230.html#transaction-format>`_
-.. [#zip-0230-orchard-action-group-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Group Description  <zip-0230.html#orchardzsa-action-group-description>`_
-.. [#zip-0230-orchard-action-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Description <zip-0230.html#orchardzsa-action-description>`_
-.. [#zip-0230-orchard-asset-burn-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Asset Burn Description <zip-0230.html#orchardzsa-asset-burn-description>`_
+.. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format. Specification: Transaction Format <zip-0230.html#transaction-format>`_
+.. [#zip-0230-orchardzsa-action-group-description] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Group Description  <zip-0230.html#orchardzsa-action-group-description>`_
+.. [#zip-0230-orchardzsa-action-description] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Action Description <zip-0230.html#orchardzsa-action-description>`_
+.. [#zip-0230-orchardzsa-asset-burn-description] `ZIP 230: Version 6 Transaction Format. Specification: OrchardZSA Asset Burn Description <zip-0230.html#orchardzsa-asset-burn-description>`_
 .. [#zip-0230-sapling-output-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Sapling Output Description (OutputDescriptionV6) <zip-0230.html#sapling-output-description-outputdescriptionv6>`_
 .. [#zip-0230-transparent-sighash-info-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Transparent Sighash Information <zip-0230.html#transparent-sighash-information-transparentsighashinfo>`_
-.. [#zip-0230-issue-actions-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Issuance Action Description <zip-0230.html#issuance-action-description>`_
-.. [#zip-0230-issue-notes-field-encodings] `ZIP 230: Version 6 Transaction Format. Specification: Issue Note Description <zip-0230.html#issue-note-description>`_
+.. [#zip-0230-issuance-action-description-issueaction] `ZIP 230: Version 6 Transaction Format. Specification: Issuance Action Description <zip-0230.html#issuance-action-description-issueaction>`_
+.. [#zip-0230-issue-note-description-issuenotedescription] `ZIP 230: Version 6 Transaction Format. Specification: Issue Note Description <zip-0230.html#issue-note-description-issuenotedescription>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0244-sigdigest] `ZIP 244: Transaction Identifier Non-Malleability: Signature Digest <zip-0244.html#signature-digest>`_
 .. [#zip-0244-authcommitment] `ZIP 244: Transaction Identifier Non-Malleability: Authorizing Data Commitment <zip-0244.html#authorizing-data-commitment>`_

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -581,7 +581,7 @@ The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-fie
 A.3a.ii: orchard_zsa_spend_auth_sigs_auth_digest
 ................................................
 
-This is a BLAKE2b-256 hash of the ``spendAuthSigsOrchard`` field of all OrchardZSA Actions belonging to the OrchardZSA Action Group::
+This is a BLAKE2b-256 hash of the concatenation of ``OrchardSignature``s for the spend authorization signature of each OrchardZSA Action in the OrchardZSA Action Group (i.e. the contents of the ``vSpendAuthSigsOrchard`` field of the ``ActionGroupDescription``)::
 
     A.3a.ii.1: spendAuthSigsOrchard    (field encoding bytes)
 
@@ -589,7 +589,7 @@ The personalization field of this hash is set to::
 
     "ZTxAuthOrSASHash"
 
-The field encodings are specified in ZIP 230 [#zip-0230-orchard-action-group-field-encodings]_.
+The encoding of ``OrchardSignature`` is specified in ZIP 230 [#zip-0230-orchard-signature-orchardsignature]_.
 Note that this means the encoding of ``spendAuthSigsOrchard`` differs from that used in ZIP 244.
 
 A.4: issuance_auth_digest


### PR DESCRIPTION
The existing specification happened to contain a nested for loop in the `orchard_action_groups_auth_digest`. 

This PR makes a change to remove this nesting via an additional digest, viz the `orchard_zsa_spend_auth_sigs_auth_digest` to aggregate the spend authorization signatures from each Action in the Action Group into its own digest.