### PR TITLE
Use "removing from circulation" consistently for the ZIP 233 mechanism

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,9 +67,9 @@ The following ZIPs are under consideration for inclusion in NU7:
 - `ZIP 227: Issuance of Zcash Shielded Assets <zips/zip-0227.rst>`__
 - `ZIP 230: Version 6 Transaction Format <zips/zip-0230.rst>`__
 - `ZIP 231: Memo Bundles <zips/zip-0231.md>`__
-- `ZIP 233: Network Sustainability Mechanism: Burning <zips/zip-0233.md>`__
+- `ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation <zips/zip-0233.md>`__
 - `ZIP 234: Network Sustainability Mechanism: Issuance Smoothing <zips/zip-0234.md>`__
-- `ZIP 235: Network Sustainability Mechanism: Burn 60% of Transaction Fees <zips/zip-0235.md>`__
+- `ZIP 235: Network Sustainability Mechanism: Remove 60% of Transaction Fees From Circulation <zips/zip-0235.md>`__
 - `ZIP 246: Digests for the Version 6 Transaction Format <zips/zip-0246.rst>`__
 - `ZIP 2002: Explicit Fees <zips/zip-2002.rst>`__
 - `ZIP 2003: Disallow version 4 transactions <zips/zip-2003.rst>`__

--- a/README.template
+++ b/README.template
@@ -67,9 +67,9 @@ The following ZIPs are under consideration for inclusion in NU7:
 - `ZIP 227: Issuance of Zcash Shielded Assets <zips/zip-0227.rst>`__
 - `ZIP 230: Version 6 Transaction Format <zips/zip-0230.rst>`__
 - `ZIP 231: Memo Bundles <zips/zip-0231.md>`__
-- `ZIP 233: Network Sustainability Mechanism: Burning <zips/zip-0233.md>`__
+- `ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation <zips/zip-0233.md>`__
 - `ZIP 234: Network Sustainability Mechanism: Issuance Smoothing <zips/zip-0234.md>`__
-- `ZIP 235: Network Sustainability Mechanism: Burn 60% of Transaction Fees <zips/zip-0235.md>`__
+- `ZIP 235: Network Sustainability Mechanism: Remove 60% of Transaction Fees From Circulation <zips/zip-0235.md>`__
 - `ZIP 246: Digests for the Version 6 Transaction Format <zips/zip-0246.rst>`__
 - `ZIP 2002: Explicit Fees <zips/zip-2002.rst>`__
 - `ZIP 2003: Disallow version 4 transactions <zips/zip-2003.rst>`__

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -103,7 +103,8 @@ Transaction Format
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 8                           |``fee``                       |``uint64``                                      |The fee to be paid by this transaction, in zatoshis.                 |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
-| 8                           |``burnAmount``                |``uint64``                                      |The value to be burned in this transaction, in zatoshis.             |
+| 8                           |``zip233Amount``              |``uint64``                                      |The value to be removed from circulation in this transaction, in     |
+|                             |                              |                                                |zatoshis. [#zip-0233]_                                               |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | **Transparent Transaction Fields**                                                                                                                                                |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
@@ -511,6 +512,7 @@ References
 .. [#zip-0227-issuer-identifier] `ZIP 227: Issuance of Zcash Shielded Assets — Issuer Identifier <zip-0227#issuer-identifier>`_
 .. [#zip-0228] `ZIP 228: Asset Swaps for Zcash Shielded Assets <zip-0228.html>`_
 .. [#zip-0231-memo-encryption] `ZIP 231: Memo Bundles — Memo Encryption <zip-0231#memo-encryption>`_
+.. [#zip-0233] `ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation <zip-0233.html>`_
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.html>`_
 .. [#zip-0246-sighash-info] `ZIP 246: Digests for the Version 6 Transaction Format <zip-0246#zip-0246-sighash-info>`_
 .. [#draft-arya-deploy-nu7] `draft-arya-deploy-nu7: Deployment of the NU7 Network Upgrade <draft-arya-deploy-nu7.md>`_

--- a/zips/zip-0233.md
+++ b/zips/zip-0233.md
@@ -107,8 +107,8 @@ The $\mathsf{zip233\_amount}$ of a transaction is defined to be the value of the
 Notes:
 
 * If both this ZIP and ZIP 2002 are selected for inclusion in the same Network
-  Upgrade, then the ambiguity in ordering of the fields added by these ZIPs
-  would need to be resolved.
+  Upgrade, then the ordering of fields in the transaction format will be ``fee``
+  and then ``zip233Amount``.
 * Older transaction versions can continue to be supported after a network
   upgrade, but removing funds from circulation is not possible for these
   transactions. For example, NU5 supports both v4 and v5 transaction formats,

--- a/zips/zip-0234.md
+++ b/zips/zip-0234.md
@@ -170,15 +170,16 @@ in whether or not funds removed from circulation are accounted for
 up-front). This means with the pre-defined constant parameter approach,
 issuance will jump _up_ some amount at activation. This amount should be
 equivalent to all ZEC removed from circulation prior to that height times
-$\mathsf{BLOCK\_SUBSIDY\_FRACTION}$. For example, if a total of 100,000 ZEC were
-burnt prior to the pre-defined constant activation height, then at activation
-the issuance would be larger than BTC-style issuance by $100\_000\textsf{ ZEC}
-\cdot \mathsf{BLOCK\_SUBSIDY\_FRACTION}$, which we calculate equals $0.04126$
-ZEC. This example is chosen to demonstrate that a very large amount removed from
-circulation (much larger than expected) would elevate issuance by a relatively
-small amount. For this reason, we believe a pre-defined constant is a better
-approach to achieving Key Objective 6 than a "dynamic latch" logic because it is
-so much simpler to implement and reason about.
+$\mathsf{BLOCK\_SUBSIDY\_FRACTION}$. For example, if a total of 100,000 ZEC
+were removed from circulation prior to the pre-defined constant activation
+height, then at activation the issuance would be larger than BTC-style
+issuance by $100\_000\textsf{ ZEC} \cdot \mathsf{BLOCK\_SUBSIDY\_FRACTION}$,
+which we calculate equals $0.04126$ ZEC. This example is chosen to
+demonstrate that a very large amount removed from circulation (much larger
+than expected) would elevate issuance by a relatively small amount. For this
+reason, we believe a pre-defined constant is a better approach to achieving
+Key Objective 6 than a "dynamic latch" logic because it is so much simpler
+to implement and reason about.
 
 ## BLOCK_SUBSIDY_FRACTION
 
@@ -276,6 +277,6 @@ Circulation" [^zip-0233]).
 
 [^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
 
-[^zip-0233]: [ZIP 233: Network Sustainability Mechanism: Burning](zip-0233.md)
+[^zip-0233]: [ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation](zip-0233.md)
 
 [^draft-arya-deploy-nu7]: [draft-arya-deploy-nu7: Deployment of the NU7 Network Upgrade](draft-arya-deploy-nu7.md)

--- a/zips/zip-2002.rst
+++ b/zips/zip-2002.rst
@@ -81,8 +81,8 @@ transaction format after  ``nExpiryHeight`` [#zip-0230-transaction-format]_:
 +-------+---------+------------+------------------------------------------------------+
 
 Note: If both this ZIP and ZIP 233 are selected for inclusion in the same
-Network Upgrade, then the ambiguity in ordering of the fields added by these
-ZIPs would need to be resolved.
+Network Upgrade, then the ordering of fields in the transaction format will
+be ``fee`` and then ``zip233Amount``.
 
 Changes to the Zcash Protocol Specification
 -------------------------------------------


### PR DESCRIPTION
## ZIPs 230, 234, and `README.template`
* Eliminate remaining references to "burning" for the ZIP 233 mechanism (the preferred terminology is "removing from circulation"). This does not affect references to "burning" ZSA assets; changing that would be a separate decision.

## ZIPs 233 and 2002
* Resolve the ordering of ``fee`` and ``zip233Amount`` as already done in ZIP 230.