### PR TITLE
[ZIP 315] Fixing render warnings in ZIP 315

### DIFF
--- a/zips/zip-0315.rst
+++ b/zips/zip-0315.rst
@@ -238,6 +238,7 @@ respectively. The following confirmation policy is RECOMMENDED:
 
 Wallets SHOULD NOT permit the spending of TXOs with fewer than 3 confirmations,
 with the exception of:
+
 * transparent UTXOs that are spent in shielding transactions
 * ephemeral transparent UTXOs created in the process of sending funds from
   the shielded pools to a TEX recipient address [#zip-0320]_.
@@ -283,10 +284,14 @@ wallet state, if and only if all of the following are true in that state:
 * the wallet has sufficient contextual information to be able to effect the
   spend (i.e. it is able to construct required witnesses, etc.); and
 * one of the following is true:
+
   * the TXO is not an output of a wallet-internal shielding transaction, and either:
+
     * it is trusted and has at least the required confirmations for trusted TXOs
     * it is untrusted and has at least the required confirmations for untrusted TXOs.
+
   * the TXO is the output of a wallet-internal shielding transaction, and both:
+  
     * the transparent UTXOs spent in the shielding transaction have at least
       `(untrusted_confirmations - trusted_confirmations)` confirmations
     * the wallet-internal shielding transaction has at least `trusted_confirmations`


### PR DESCRIPTION
I noticed a few render warnings in ZIP 315, due to missing newlines between bullet points. This fixes that. 