### PR TITLE
[ZIP 227] Fixing incorrect typing of `EncodeAssetId`, `ik_encoding` and `issueAuthSig`

### DIFF
--- a/zips/zip-0227.rst
+++ b/zips/zip-0227.rst
@@ -178,7 +178,7 @@ Define $\mathsf{IssueAuthSig.DerivePublic} \;{\small ⦂}\; (\mathsf{isk} \;{\sm
 where the $\textit{PubKey}$ algorithm is defined in BIP 340 [#bip-0340]_, and the output of the algorithm is in big-endian order as defined in BIP 340.
 
 The encoding of this validating key, $\mathsf{ik\_encoding}$, includes an initial byte indicating the signature scheme, which MUST be $\mathtt{0x00}$ indicating BIP 340.
-That is, $\mathsf{ik\_encoding} = \mathtt{0x00} \,||\, \mathsf{ik}$. This enables future ZIPs to specify alternative signature schemes.
+That is, $\mathsf{ik\_encoding} = [\mathtt{0x00}] \,||\, \mathsf{ik}$. This enables future ZIPs to specify alternative signature schemes.
 Note that this encoding currently only appears in the ``issuer`` field of an issuance bundle.
 
 It is possible for the $\textit{PubKey}$ algorithm to fail with very low probability, which means that $\mathsf{IssueAuthSig.DerivePublic}$ could return $\bot$ with very low probability.
@@ -206,7 +206,7 @@ Define $\mathsf{IssueAuthSig.Validate} \;{\small ⦂}\; (\mathsf{ik} \;{\small �
 where the $\mathsf{Verify}$ algorithm is defined in BIP 340 [#bip-0340]_.
 
 The $\mathtt{issueAuthSig}$ field of an issuance bundle encodes the signature with an initial byte indicating the signature scheme, which MUST be $\mathtt{0x00}$ indicating BIP 340.
-That is, $\mathtt{issueAuthSig} = \mathtt{0x00} \,||\, \text{σ}$. This enables future ZIPs to specify alternative signature schemes.
+That is, $\mathtt{issueAuthSig} = [\mathtt{0x00}] \,||\, \text{σ}$. This enables future ZIPs to specify alternative signature schemes.
 
 
 Specification: Asset Identifier, Asset Digest, and Asset Base
@@ -258,7 +258,7 @@ and define their canonical encoding as
 
 .. math::
 
-    \mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{issuer}, \mathsf{assetDescHash})) := \mathtt{0x00} \,||\, \mathsf{issuer}\,||\,\mathsf{assetDescHash}
+    \mathsf{EncodeAssetId}(\mathsf{AssetId}) = \mathsf{EncodeAssetId}((\mathsf{issuer}, \mathsf{assetDescHash})) := [\mathtt{0x00}] \,||\, \mathsf{issuer}\,||\,\mathsf{assetDescHash}
 
 Note that the initial $\mathtt{0x00}$ byte is a version byte, enabling future ZIPs to specify alternative issuance protocols and Asset Identifiers. (This should not be confused with the first byte of $\mathsf{issuer}$, currently equal to the first byte of $\mathsf{ik\_encoding}$, that indicates the issuance signature scheme.)
 


### PR DESCRIPTION
The use of `0x00` instead of `[0x00]` leads to incorrect typing in the above three places, as was noted in #1108. This PR fixes the typing.

Fixes #1108 