### PR TITLE
[ZIP 246] Rewriting `orchard_digest` and `orchard_action_groups_digest` specification for clarity

### DIFF
--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -267,12 +267,9 @@ The field encodings are specified in ZIP 230 [#zip-0230-sapling-output-field-enc
 
 T.4: orchard_digest
 ```````````````````
-When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of the ``orchard_action_groups_digest`` 
-for each Action Group in the transaction, followed by the encoding of the ``valueBalanceOrchard`` field.
-That is, we compute the ``orchard_action_groups_digest`` for each Action Group in the transaction, 
-concatenate these digests together in the order the Action Groups appear in the transaction,
-append the field encoding of ``valueBalanceOrchard`` to this concatenation, 
-and compute the BLAKE2b-256 hash of the resulting byte sequence.
+When OrchardZSA Actions Groups are present in the transaction, this digest is a BLAKE2b-256 hash of:
+all ``orchard_action_groups_digest`` values concatenated in transaction order, 
+followed by the 64-bit little-endian encoding of ``valueBalanceOrchard``.
 
 The computation of ``orchard_action_groups_digest`` is specified in `T.4a: orchard_action_groups_digest`_.
 


### PR DESCRIPTION
This PR makes it clear that we perform the `orchard_action_groups_digest` for each Action Group, and we concatenate the results for each Action Group at the `orchard_digest` level.

This makes unambiguous the behaviour for multiple Action Groups (and does not change the behaviour for NU7, as there is only a single Action Group). It also allows reuse of the `orchard_action_groups_digest` for a "v1 Signature Digest" in the Asset Swaps context. 