### PR TITLE
Rendering fix: Set `.gitignore` to not ignore `rendered/` before using add-and-commit

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,6 +41,7 @@ jobs:
           git config --global user.name 'github_actions'
           git config --global user.email 'actions@github.com'
           git config --global --add safe.directory /github/workspace
+          # Merge preferring the version in main.
           git merge -s recursive -Xtheirs origin/main --commit -m 'Auto-deploy: merging "main" branch'
 
       - name: Set base ref
@@ -50,6 +51,10 @@ jobs:
 
       - name: Compile ZIPs and Zcash Protocol Specification
         uses: ./.github/actions/render
+
+      - name: Set `.gitignore` to not ignore `rendered/`
+        # This needs to be afer rendering so that it is not considered to make the tree dirty.
+        run: sed -i 's@^rendered/$@@' .gitignore
 
       - name: Commit and push to `publish` branch
         uses: EndBug/add-and-commit@v9.1.4


### PR DESCRIPTION
The fix to the deployment workflow in #1131 was incomplete. Previously this workflow was relying on the version of `.gitignore` on the `publish` branch differing from the `main` branch by not including the line `rendered/`. When `temp/` was added on an adjacent line in #1120, that caused deployment to break because the merge of `main` into the `publish` branch would conflict.

#1131 changed the `git merge` command to use `-s recursive -Xtheirs`, which favoured the version of `.gitignore` from `main`. That's fine by itself: it is less fragile for `.gitignore` to be the same in the `main` and `publish` branches; it will avoid future potential merge conflicts in this file; and it's the correct behaviour for other files that get out of sync for any reason. However, the presence of `rendered/` in `.gitignore` caused the `add-and-commit` step that would normally push the rendered output to fail.

In this PR we take the approach of using `sed` to edit `.gitignore` in place to remove that line (leaving that edit unmerged), but only after the rendering step. If we did it before rendering, then the tree would be dirty and that would adversely affect the protocol spec version string. The edit will not be committed to the `publish` branch because the `add-and-commit` step only commits changes to the `rendered/` directory.