### PR TITLE
Ensure that the protocol spec is rendered when publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
           if ! ( grep -E '^[0-9a-f]{40}$' base_ref ); then exit 1; fi
 
       - name: Compile ZIPs and Zcash Protocol Specification
-        uses: ./.github/actions/render
+        uses: ./.github/actions/render-protocol
 
       - name: Set `.gitignore` to not ignore `rendered/`
         # This needs to be afer rendering so that it is not considered to make the tree dirty.


### PR DESCRIPTION
Publishing of the rendered protocol spec was broken by the last commit of #1120, which changed the behaviour of the `render` action to render only ZIPs. It wasn't noticed because files that are no longer present in the rendering won't be automatically deleted from the `publish` branch (as currently intended, but see #1140), and that was the case for the protocol spec PDFs.