### PR TITLE
Find the correct tag to describe the version of the protocol spec

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,8 +41,12 @@ jobs:
           git config --global user.name 'github_actions'
           git config --global user.email 'actions@github.com'
           git config --global --add safe.directory /github/workspace
+          version="$(git describe --tags --abbrev=6 --always main |sed 's/-1-g.*//')"
           # Merge preferring the version in main.
           git merge -s recursive -Xtheirs origin/main --commit -m 'Auto-deploy: merging "main" branch'
+          # Apply a tag to the merge commit, otherwise the uses of `git describe` in `protocol/Makefile`
+          # won't find it. Any existing tag of the same name will be overwritten.
+          git tag -f "${version}-auto"
 
       - name: Set base ref
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Set base ref
         run: |
-          git show --format=%H --no-notes --no-patch origin/main -- |tee base_ref
+          git show --format=%H --no-notes --no-patch 'HEAD^' -- |tee base_ref
           if ! ( grep -E '^[0-9a-f]{40}$' base_ref ); then exit 1; fi
 
       - name: Compile ZIPs and Zcash Protocol Specification

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -88,7 +88,7 @@ $(PDFDIR)/protocol-dark.pdf: protocol.tex zcash.bib jubjub.png key_components_sa
 
 .PHONY: auxsapling sapling
 auxsapling:
-	printf '\\toggletrue{issapling}\n\\renewcommand{\\docversion}{Version %s [\\SaplingSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{issapling}\n\\renewcommand{\\docversion}{Version %s [\\SaplingSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/sapling.*
 	cp mymakeindex.sh aux
@@ -101,7 +101,7 @@ sapling:
 
 .PHONY: auxblossom blossom
 auxblossom:
-	printf '\\toggletrue{isblossom}\n\\renewcommand{\\docversion}{Version %s [\\BlossomSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{isblossom}\n\\renewcommand{\\docversion}{Version %s [\\BlossomSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/blossom.*
 	cp mymakeindex.sh aux
@@ -114,7 +114,7 @@ blossom:
 
 .PHONY: auxheartwood heartwood
 auxheartwood:
-	printf '\\toggletrue{isheartwood}\n\\renewcommand{\\docversion}{Version %s [\\HeartwoodSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{isheartwood}\n\\renewcommand{\\docversion}{Version %s [\\HeartwoodSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/heartwood.*
 	cp mymakeindex.sh aux
@@ -127,7 +127,7 @@ heartwood:
 
 .PHONY: auxcanopy canopy
 auxcanopy:
-	printf '\\toggletrue{iscanopy}\n\\renewcommand{\\docversion}{Version %s [\\CanopySpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{iscanopy}\n\\renewcommand{\\docversion}{Version %s [\\CanopySpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/canopy.*
 	cp mymakeindex.sh aux
@@ -140,7 +140,7 @@ canopy:
 
 .PHONY: auxnu5 nu5
 auxnu5:
-	printf '\\toggletrue{isnufive}\n\\renewcommand{\\docversion}{Version %s [\\NUFiveSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{isnufive}\n\\renewcommand{\\docversion}{Version %s [\\NUFiveSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/nu5.*
 	cp mymakeindex.sh aux
@@ -153,7 +153,7 @@ nu5:
 
 .PHONY: auxnu6 nu6
 auxnu6:
-	printf '\\toggletrue{isnusix}\n\\renewcommand{\\docversion}{Version %s [\\NUSixSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{isnusix}\n\\renewcommand{\\docversion}{Version %s [\\NUSixSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/nu6.*
 	cp mymakeindex.sh aux
@@ -166,7 +166,7 @@ nu6:
 
 .PHONY: auxnu6_1 nu6_1
 auxnu6_1:
-	printf '\\toggletrue{isnusixone}\n\\renewcommand{\\docversion}{Version %s [\\NUSixOneSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{isnusixone}\n\\renewcommand{\\docversion}{Version %s [\\NUSixOneSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/nu6_1.*
 	cp mymakeindex.sh aux
@@ -179,7 +179,7 @@ nu6_1:
 
 .PHONY: auxnu6_1-dark nu6_1-dark
 auxnu6_1-dark:
-	printf '\\toggletrue{darkmode}\\toggletrue{isnusixone}\n\\renewcommand{\\docversion}{Version %s [\\NUSixOneSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//')" |tee protocol.ver
+	printf '\\toggletrue{darkmode}\\toggletrue{isnusixone}\n\\renewcommand{\\docversion}{Version %s [\\NUSixOneSpec]}\n' "$$(git describe --tags --abbrev=6 --always |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
 	rm -f aux/nu6_1-dark.*
 	cp mymakeindex.sh aux


### PR DESCRIPTION
The uses of `git describe` in `protocol/Makefile` were not finding the correct tag for the publish workflow because that tag was an indirect ancestor. We work around this by explicitly tagging the merge from `main`. We append `-auto` to the tag name to avoid a collision with the original tag, and strip this in `protocol/Makefile`.

This may or may not be sufficient to fix #1097, but it should improve the behaviour.

Also, in the publish workflow, set `base_ref` to be the parent on the `publish` branch of the merge from `main`, not the commit of `main` itself. This should help with correctly detecting whether files under `protocol` have changed. (The conditional building of the spec is still disabled, but I will be able to tell from the logs whether it can be re-enabled.)