### PR TITLE
Updates in ZIP-233: added privacy implications and requirements

### DIFF
--- a/zips/zip-0233.md
+++ b/zips/zip-0233.md
@@ -73,6 +73,17 @@ design shared by Bitcoin-like systems:
    users in proportion to their holdings — without requiring them to opt into any
    scheme, introducing extra risk, active oversight, or accounting complexity.
 
+# Privacy Implications
+
+ZIP 233 adds a new type of transparent transaction event that is fully visible to chain
+observers, and linked to other events performed in the transaction. The removal of
+funds from circulation does not affect shielded outputs, and therefore does not alter
+the privacy properties of shielded funds.
+
+# Requirements
+
+- The mechanism enables users to remove funds from the circulating supply, and each removal event is explicitly specified in the corresponding transaction.
+- The process is publicly auditable, allowing network participants to verify the amount and occurrence of funds removed from circulation.
 
 # Specification
 
@@ -122,6 +133,11 @@ implementing the specification in [ZIP-233 Amount].
 In § 7.1 ‘Transaction Encoding and Consensus’ [^protocol-txnconsensus], add:
 
 > [NU7 onward] $\mathsf{zip233\_amount}$ MUST be in the range $\{ 0 .. \mathsf{MAX\_MONEY} \}$.
+
+In § 7.1.2 ‘Transaction Consensus Rules’ [^protocol-txnconsensus], add a note:
+
+> [NU7 onward] $\mathsf{zip233\_amount}$ does not result in an output being produced in any
+chain value pool.
 
 ## Modifications relative to ZIP 244 [^zip-0244]
 


### PR DESCRIPTION
Based on the ZIP-233 audit report, this PR updates the ZIP-233 with the following:

* adds privacy implications and requirements
* updates the Changes to the Zcash Protocol Specification part
 
