### PR TITLE
publish.yaml: use the commit description from `origin/main` for the auto tag

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
           git config --global user.name 'github_actions'
           git config --global user.email 'actions@github.com'
           git config --global --add safe.directory /github/workspace
-          version="$(git describe --tags --abbrev=6 main |sed 's/-1-g.*//')"
+          version="$(git describe --tags --abbrev=6 origin/main |sed 's/-1-g.*//')"
           # Merge preferring the version in main.
           git merge -s recursive -Xtheirs origin/main --commit -m 'Auto-deploy: merging "main" branch'
           # Apply a tag to the merge commit, otherwise the uses of `git describe` in `protocol/Makefile`


### PR DESCRIPTION
It is incorrect to pass `main` to `git describe` in order to find the commit description used for the `*-auto` tag, because that branch will not be present locally.