### PR TITLE
CI: Ensure that `origin/main` is available alongside `origin/publish`

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v5.0.1
         with:
           ref: publish
-          fetch-depth: 100
+          fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Verify nonexistence of `base_ref`


### PR DESCRIPTION
The only configuration option that ensures branch refs other than the explicitly-specified one are present, is `fetch-depth: 0`. Unfortunately a side-effect of this is that we check out the entire history of the repository including all past binary versions of the protocol spec PDF, which will slow down the render workflow, but until we come up with a different approach for performing the merge from `origin/main` to `origin/publish`, we need to bear the performance hit.