### PR TITLE
[ZIP 230] Updating the description for the flagsOrchard field

### DIFF
--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -274,8 +274,11 @@ The OrchardZSA Action Group Description is encoded in a transaction as an instan
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 372 × ``nActionsOrchard``   |``vActionsOrchard``           |``OrchardZSAAction[nActionsOrchard]``           |A sequence of OrchardZSA Action descriptions in the Action Group.    |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
-| 1                           |``flagsOrchard``              |``byte``                                        |As defined in §7.1 ‘Transaction Encoding and Consensus’              |
-|                             |                              |                                                |[#protocol-txnencoding]_.                                            |
+|``1``                        |``flagsOrchard``              |``byte``                                        |An 8-bit value representing a set of flags. Ordered from LSB to MSB: |
+|                             |                              |                                                | * ``enableSpendsOrchard``                                           |
+|                             |                              |                                                | * ``enableOutputsOrchard``                                          |
+|                             |                              |                                                | * ``enableZSAs``                                                    |
+|                             |                              |                                                | * The remaining bits are set to :math:`0\!`.                        |
 +-----------------------------+------------------------------+------------------------------------------------+---------------------------------------------------------------------+
 | 32                          |``anchorOrchard``             |``byte[32]``                                    |As defined in §7.1 ‘Transaction Encoding and Consensus’              |
 |                             |                              |                                                |[#protocol-txnencoding]_.                                            |


### PR DESCRIPTION
I noticed that I seem to have mistakenly removed the description of the `flagsOrchard` field some time ago (in https://github.com/QED-it/zips/commit/9322489479ed415088d8c84a0682d7c3fa44130d to be specific). 

This means that at present, there is no specification of where the `enableZSAs` flag is encoded in the transaction format. This PR fixes that. 