### PR TITLE
[ZIP-234] Update Motivations

### DIFF
--- a/zips/zip-0234.md
+++ b/zips/zip-0234.md
@@ -170,6 +170,8 @@ All of these changes apply identically to Mainnet and Testnet.
 
 * Using an exponential decay function satisfies **Requirements 1** and **2** above.
 * We round up to the next zatoshi to satisfy **Requirement 3** above.
+* The issuance formula depends only on `MoneyReserveAfter(height - 1)` and a
+  single constant fraction, making it simple to implement, explain, and verify.
 
 ## Parameters
 


### PR DESCRIPTION
This PR adds additional motivation to ZIP-234, mostly around difficulty changes after historical halvings using the ZecHub data [here](https://github.com/ZecHub/zechub-wiki/raw/refs/heads/main/public/data/zcash/difficulty.json). 

Drive-by updates include:
- `should` -> `MUST` under issuance calculation
- New rationale based on simplicity