### PR TITLE
[ZIP 204] The `relay` field of the `version` message is optional

### DIFF
--- a/zips/zip-0204.rst
+++ b/zips/zip-0204.rst
@@ -472,7 +472,7 @@ The ``version`` message payload has the following format:
 |        |         |                  | (``int32``).                                   |
 +--------+---------+------------------+------------------------------------------------+
 | varies | 1       | ``relay``        | Whether the sender wants transaction relay     |
-|        |         |                  | (``uint8``; 0 for false, nonzero for true).    |
+|        |         | (optional)       | (``uint8``; 0 for false, nonzero for true).    |
 +--------+---------+------------------+------------------------------------------------+
 
 The ``addr_recv`` and ``addr_from`` fields use the ``CAddress`` encoding *without*
@@ -484,8 +484,10 @@ The ``nonce`` field is used for self-connection detection. If a node receives a
 The ``user_agent`` string MUST NOT exceed 256 bytes. A node SHOULD disconnect peers
 that send a longer user agent.
 
-A node SHOULD reject ``version`` messages in which the ``relay`` field has a value
-other than 0 or 1.
+The ``relay`` field is optional; if not present, its value MUST be interpreted as true.
+A node SHOULD reject ``version`` messages in which the ``relay`` field is present with
+a value other than 0 or 1. Nodes SHOULD create `version` messages with this field
+present.
 
 Version Validation
 ``````````````````


### PR DESCRIPTION
See also https://github.com/ZcashFoundation/zebra/issues/5713 .