### PR TITLE
Quantum recoverability fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ written.
     <tr> <td>2002</td> <td class="left"><a href="zips/zip-2002.rst">Explicit Fees</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/803">zips#803</a></td>
     <tr> <td>2003</td> <td class="left"><a href="zips/zip-2003.rst">Disallow version 4 transactions</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/825">zips#825</a></td>
     <tr> <td>2004</td> <td class="left"><a href="zips/zip-2004.rst">Remove the dependency of consensus on note encryption</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/917">zips#917</a></td>
-    <tr> <td>2005</td> <td class="left"><a href="zips/zip-2005.md">Quantum Recoverability</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1135">zips#1135</a></td>
+    <tr> <td>2005</td> <td class="left"><a href="zips/zip-2005.md">Orchard Quantum Recoverability</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1135">zips#1135</a></td>
     <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td>template</td> <td class="left"><a href="zips/zip-template.md">{Template for new ZIPs}</a></td> <td>Draft</td> <td class="left"></td>
@@ -388,7 +388,7 @@ Index of ZIPs
     <tr> <td>2002</td> <td class="left"><a href="zips/zip-2002.rst">Explicit Fees</a></td> <td>Draft</td>
     <tr> <td>2003</td> <td class="left"><a href="zips/zip-2003.rst">Disallow version 4 transactions</a></td> <td>Draft</td>
     <tr> <td>2004</td> <td class="left"><a href="zips/zip-2004.rst">Remove the dependency of consensus on note encryption</a></td> <td>Draft</td>
-    <tr> <td>2005</td> <td class="left"><a href="zips/zip-2005.md">Quantum Recoverability</a></td> <td>Draft</td>
+    <tr> <td>2005</td> <td class="left"><a href="zips/zip-2005.md">Orchard Quantum Recoverability</a></td> <td>Draft</td>
     <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td>
     <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td>
     <tr> <td>template</td> <td class="left"><a href="zips/zip-template.md">{Template for new ZIPs}</a></td> <td>Draft</td>

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -882,10 +882,11 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\primeOrderCurve}{\term{prime-order curve}}
 \newcommand{\primeOrderCurves}{\terms{prime-order curve}}
 \newcommand{\hashToCurve}{\term{hash-to-curve}}
-\newcommand{\xDiscreteLogarithmProblem}{\term{Discrete Logarithm Problem}}
-\newcommand{\xDiscreteLogarithm}{\termandindex{Discrete Logarithm}{Discrete Logarithm Problem}}
-\newcommand{\xDecisionalDiffieHellmanProblem}{\term{Decisional Diffie--Hellman Problem}}
-\newcommand{\xDecisionalDiffieHellman}{\termandindex{Decisional Diffie--Hellman}{Decisional Diffie--Hellman Problem}}
+\newcommand{\discreteLogarithm}{\term{discrete logarithm}}
+\newcommand{\DiscreteLogarithmProblem}{\term{Discrete Logarithm Problem}}
+\newcommand{\DiscreteLogarithmIndependence}{\term{Discrete Logarithm Independence}}
+\newcommand{\DecisionalDiffieHellmanProblem}{\term{Decisional Diffie--Hellman Problem}}
+\newcommand{\DecisionalDiffieHellmanAssumption}{\termandindex{Decisional Diffie--Hellman assumption}{Decisional Diffie--Hellman Problem}}
 \newcommand{\partitioningOracleAttack}{\term{partitioning oracle attack}}
 \newcommand{\partitioningOracleAttacks}{\terms{partitioning oracle attack}}
 \newcommand{\sideChannel}{\term{side-channel}}
@@ -4970,15 +4971,15 @@ can be heuristically modelled as \randomOracles.
         a sequence of \emph{distinct} inputs $m_{\alln} \typecolon \typeexp{\SubgroupGHashInput}{n}$
         and a sequence of nonzero $x_{\alln} \typecolon \typeexp{\GFstar{\ParamG{r}}}{n}$
         such that $\ssum{i = 1}{n}\!\Big(\scalarmult{x_i}{\SubgroupGHash{\URS}(m_i)}\Big) = \ZeroG{}$.
-  \item Under the \xDiscreteLogarithm assumption on $\SubgroupG{}$, a \randomOracle almost surely satisfies
-        Discrete Logarithm Independence. Discrete Logarithm Independence implies \collisionResistance\!,
-        since a collision $(m_1, m_2)$ for $\SubgroupGHash{\URS}$ trivially gives a
-        discrete logarithm relation with $x_1 = 1$ and $x_2 = -1$.
+  \item Assuming hardness of the \DiscreteLogarithmProblem on $\SubgroupG{}$, a \randomOracle almost
+        surely satisfies \DiscreteLogarithmIndependence. \DiscreteLogarithmIndependence implies
+        \collisionResistance\!, since a collision $(m_1, m_2)$ for $\SubgroupGHash{\URS}$ trivially
+        gives a \discreteLogarithm relation with $x_1 = 1$ and $x_2 = -1$.
   \item $\GroupJHash{}$ is used in \crossref{concretediversifyhash} to instantiate $\DiversifyHash{Sapling}$.
         We do not know how to prove the Unlinkability property defined in that section
         in the standard model, but in a model where $\GroupJHash{}$ (restricted to
         inputs for which it does not return $\bot$) is taken as a \randomOracle,
-        it is implied by the \xDecisionalDiffieHellman assumption on $\SubgroupJ$\nufive{,
+        it is implied by the \DecisionalDiffieHellmanAssumption on $\SubgroupJ$\nufive{,
         and similarly for $\GroupPHash$}.
   \item $\URS$ is a \defining{\uniformRandomString}; we chose it verifiably at random
         (see \crossref{beacon}), after fixing the concrete group hash algorithm to be used.
@@ -6404,7 +6405,7 @@ $\MerkleNode{\MerkleDepth{}}{i}$ is in a tree with a given \merkleRoot $\rt{} = 
         $\ZeroP$. Allowing the validity check to pass in that case models the fact that
         incomplete addition is used to implement Sinsemilla in the circuit. As proven in
         \theoremref{thmsinsemillaex}, a $\bot$ output from $\SinsemillaHash$ yields a
-        nontrivial discrete logarithm relation. Since we assume finding such a relation to be
+        nontrivial \discreteLogarithm relation. Since we assume finding such a relation to be
         infeasible, we can argue that it is safe to allow an adversary to create a proof that
         passes the Merkle validity check in such a case.
 } %nufive
@@ -6679,7 +6680,7 @@ $\BindingSigValidate{Sapling}{\BindingPublic{Sapling}}(\SigHash, \bindingSig{Sap
 We now explain why this works.
 
 \vspace{1ex}
-A \saplingBindingSignature proves knowledge of the discrete logarithm $\BindingPrivate{Sapling}$
+A \saplingBindingSignature proves knowledge of the \discreteLogarithm $\BindingPrivate{Sapling}$
 of $\BindingPublic{Sapling}$ with respect to $\ValueCommitRandBase{Sapling}$.
 That is, $\BindingPublic{Sapling} = \scalarmult{\BindingPrivate{Sapling}}{\ValueCommitRandBase{Sapling}}$.
 So the value $0$ and randomness $\BindingPrivate{Sapling}$ is an opening of the \xPedersenCommitment
@@ -6714,7 +6715,7 @@ Let $\vSum = \vsum{i=1}{n} \vOld{i} - \vsum{j=1}{m} \vNew{j} - \vBalance{Sapling
 
 Suppose that $\vSum = \vBad \neq 0 \pmod{\ParamJ{r}}$.
 Then $\BindingPublic{Sapling} = \ValueCommit{Sapling}{\BindingPrivate{Sapling}}(\vBad)$.
-If the adversary were able to find the discrete logarithm of this $\BindingPublic{Sapling}$
+If the adversary were able to find the \discreteLogarithm of this $\BindingPublic{Sapling}$
 with respect to $\ValueCommitRandBase{Sapling}$, say ${\BindingPrivate{}}'$ (as needed to
 create a valid \saplingBindingSignature), then $(\vBad, \BindingPrivate{Sapling})$ and
 $(0, {\BindingPrivate{}}')$ would be distinct openings of $\BindingPublic{Sapling}$ to different
@@ -6873,7 +6874,7 @@ for completeness we spell it out, since there are minor differences due to the n
 value commitments, and a different bound on the net value sum $\vSum$.
 
 \vspace{1ex}
-An \orchardBindingSignature proves knowledge of the discrete logarithm $\BindingPrivate{Orchard}$
+An \orchardBindingSignature proves knowledge of the \discreteLogarithm $\BindingPrivate{Orchard}$
 of $\BindingPublic{Orchard}$ with respect to $\ValueCommitRandBase{Orchard}$.
 That is, $\BindingPublic{Orchard} = \scalarmult{\BindingPrivate{Orchard}}{\ValueCommitRandBase{Orchard}}$.
 So the value $0$ and randomness $\BindingPrivate{Orchard}$ is an opening of the \xPedersenCommitment
@@ -6904,7 +6905,7 @@ Let $\vSum = \vsum{i=1}{n} \vNet{i} - \vBalance{Orchard}$.
 
 Suppose that $\vSum = \vBad \neq 0 \pmod{\ParamJ{r}}$.
 Then $\BindingPublic{Orchard} = \ValueCommit{Orchard}{\BindingPrivate{Orchard}}(\vBad)$.
-If the adversary were able to find the discrete logarithm of this $\BindingPublic{Orchard}$
+If the adversary were able to find the \discreteLogarithm of this $\BindingPublic{Orchard}$
 with respect to $\ValueCommitRandBase{Orchard}$, say ${\BindingPrivate{}}'$ (as needed to
 create a valid \orchardBindingSignature), then $(\vBad, \BindingPrivate{Orchard})$ and
 $(0, {\BindingPrivate{}}')$ would be distinct openings of $\BindingPublic{Orchard}$ to different
@@ -7682,7 +7683,7 @@ For details of the form and encoding of \actionStatement proofs, see \crossref{h
         assumed to allow them to control the output. (The formal output of $\SinsemillaHashToPoint$
         is $\bot$ in such a case, while the output computed by the circuit would be nondeterministic.)
         But as proven in \theoremref{thmsinsemillaex}, these exceptional cases allow immediately
-        finding a nontrivial discrete logarithm relation. If the \xDiscreteLogarithmProblem is hard on the
+        finding a nontrivial \discreteLogarithm relation. If the \DiscreteLogarithmProblem is hard on the
         \pallasCurve, then finding such a case is infeasible.
 \end{nnotes}
 } %nufive
@@ -8891,8 +8892,8 @@ the third address was derived from.
   \item Suppose that $\GroupJHash{}$ (restricted to inputs for which it does not
         return $\bot$) is modelled as a \randomOracle from \diversifiers to points
         of order $\ParamJ{r}$ on the \jubjubCurve. In this model, Unlinkability
-        of $\DiversifyHash{Sapling}$ holds under the \xDecisionalDiffieHellman assumption on the
-        \primeOrderSubgroup of points on the \jubjubCurve.
+        of $\DiversifyHash{Sapling}$ holds under the \DecisionalDiffieHellmanAssumption
+        on the \primeOrderSubgroup of points on the \jubjubCurve.
 
         To prove this, consider the ElGamal encryption scheme \cite{ElGamal1985}
         on this \primeOrderSubgroup, restricted to encrypting plaintexts encoded
@@ -8911,11 +8912,10 @@ the third address was derived from.
         of the candidate \diversifiedPaymentAddresses.)
         So if ElGamal is \keyPrivate, then $\DiversifyHash{Sapling}$ is Unlinkable under the
         same conditions.
-        \cite[Appendix A]{BBDP2001} gives a security proof for \keyPrivacy
-        (both \nh{IK-CPA} and \nh{IK-CCA}) of ElGamal under the \xDecisionalDiffieHellman
-        assumption on the relevant group. (In fact the proof needed is the
-        ``small modification'' described in the last paragraph in which the generator
-        is chosen at random for each key.)
+        \cite[Appendix A]{BBDP2001} gives a security proof for \keyPrivacy (both \nh{IK-CPA}
+        and \nh{IK-CCA}) of ElGamal under the \DecisionalDiffieHellmanAssumption on the
+        relevant group. (In fact the proof needed is the ``small modification'' described in
+        the last paragraph in which the generator is chosen at random for each key.)
 
   \item It is assumed (also for the security of other uses of
         the group hash, such as Pedersen hashes and commitments) that the discrete
@@ -8969,7 +8969,7 @@ the third address was derived from.
 
 $\PedersenHash$ is an algebraic \hashFunction with \collisionResistance
 (for fixed input length) derived from assumed hardness of the
-\xDiscreteLogarithmProblem on the \jubjubCurve.
+\DiscreteLogarithmProblem on the \jubjubCurve.
 It is based on the work of David Chaum, Ivan Damgård, Jeroen van de Graaf,
 Jurgen Bos, George Purdy, Eugène van Heijst and Birgit Pfitzmann in
 \cite{CDvdG1987}, \cite{BCP1988} and \cite{CvHP1991},
@@ -9146,7 +9146,7 @@ See \crossref{cctmixinghash} for efficient circuit implementation of this functi
 \vspace{-2ex}
 \defining{$\SinsemillaHash$} is an algebraic \hashFunction with
 \collisionResistance (for fixed input length) derived from assumed hardness
-of the \xDiscreteLogarithmProblem. It is designed by Sean Bowe and \nh{Daira-Emma} Hopwood.
+of the \DiscreteLogarithmProblem. It is designed by Sean Bowe and \nh{Daira-Emma} Hopwood.
 The motivation for introducing a new discrete-logarithm-based hash function (rather than
 using $\PedersenHash$) is to make efficient use of the lookups available in recent
 proof systems including \HaloTwo.
@@ -9266,7 +9266,7 @@ No other security properties commonly associated with \hashFunctions are needed.
 \vspace{-2.5ex}
 We show a correspondence between Sinsemilla and a vector Pedersen hash, which allows using the
 security argument from \cite{BGG1995} to show that collision-resistance can be tightly reduced
-to the \xDiscreteLogarithmProblem in $\mathbb{P}$.
+to the \DiscreteLogarithmProblem in $\mathbb{P}$.
 
 \vspace{1ex}
 Define $\delta(a, b) = \begin{cases}
@@ -9300,7 +9300,7 @@ due to the requirement that $2^n \leq 2^c \leq \frac{\ParamP{r}-1}{2}$. The clai
 Let $D \typecolon \byteseqs$ be a personalization input, and let $\ell \typecolon \range{0}{k \mult c}$.
 Finding a collision $M, M' \typecolon \bitseq{\ell}$ with $M \neq M'$ such that
 $\SinsemillaHashToPoint(D, M) = \SinsemillaHashToPoint(D, M') \neq \bot$ efficiently yields a nontrivial
-discrete logarithm relation, and similarly for $\SinsemillaHash(D, M) = \SinsemillaHash(D, M') \neq \bot$.
+\discreteLogarithm relation, and similarly for $\SinsemillaHash(D, M) = \SinsemillaHash(D, M') \neq \bot$.
 \end{theorem}
 
 \begin{proof}
@@ -9321,9 +9321,9 @@ This is a Pedersen vector hash of the $\chi(m)$ elements, with a fixed offset $\
 The fixed offset does not affect \collisionResistance in this context. (See below for why
 it cannot be eliminated for $\SinsemillaHash$, or when using incomplete addition.)
 \theoremref{thmsinsemillaex} will prove that a $\bot$ output from $\SinsemillaHashToPoint$
-yields a nontrivial discrete log relation. It follows that the \collisionResistance of
+yields a nontrivial \discreteLogarithm relation. It follows that the \collisionResistance of
 $\SinsemillaHashToPoint$ can be tightly reduced, via the proof in \cite[Appendix A]{BGG1995},
-to the \xDiscreteLogarithmProblem over $\GroupP$.
+to the \DiscreteLogarithmProblem over $\GroupP$.
 
 Note that \cite{BGG1995} requires for their main scheme that the scalars are nonzero, which
 is not necessarily the case in our context. However, their proof in Appendix A does not depend
@@ -9335,7 +9335,7 @@ we do not.
 Now we consider $\SinsemillaHash$. We want to prove that, for given $D$, if we can find two distinct
 messages $M$ and $M'$ such that $\ExtractPbot\smash{\big(\SinsemillaHashToPoint(D, M)\kern-0.1em\big)} =
 \ExtractPbot\smash{\big(\SinsemillaHashToPoint(D, M')\kern-0.1em\big)} \neq \bot$ then we can efficiently
-extract a discrete logarithm.
+extract a \discreteLogarithm.
 
 The inputs to $\ExtractPbot$ are not $\bot$, therefore they are in $\GroupP$.
 $\ExtractPbot$ maps $P, Q \in \GroupP$ to the same output if and only if $P = \pm Q$.
@@ -9351,12 +9351,12 @@ $\scalarmult{2^{n+1}}{\SinsemillaGenInit(D)} + \ssum{j=0}{{2^k}-1} \scalarmult{\
 
 \vspace{1ex}
 Because $2^{n+1} \leq \ParamP{r}-1$, the coefficients $\!\!\pmod{\ParamP{r}}$ are not all zero, and therefore
-this is a nontrivial discrete logarithm relation between independent bases.
+this is a nontrivial \discreteLogarithm relation between independent bases.
 \end{proof}
 
 \begin{nnotes}
-  \item \cite[Lemma 3]{JT2020} proves a tight reduction from finding a nontrivial discrete logarithm
-        relation in a \primeOrderGroup to solving the \xDiscreteLogarithmProblem in that group.
+  \item \cite[Lemma 3]{JT2020} proves a tight reduction from finding a nontrivial \discreteLogarithm
+        relation in a \primeOrderGroup to solving the \DiscreteLogarithmProblem in that group.
   \item The above theorem easily extends to the case where additional scalar multiplication terms with
         independent bases may be added to the $\SinsemillaHashToPoint$ output before applying $\ExtractPbot$.
         This is needed to show security of the $\SinsemillaShortCommitAlg$ \commitmentScheme defined in
@@ -9370,7 +9370,7 @@ this is a nontrivial discrete logarithm relation between independent bases.
 
 \introsection
 \theoremlabel{thmsinsemillaex}
-\begin{theorem}[A $\bot$ output from $\SinsemillaHashToPoint$ yields a nontrivial discrete log relation]\end{theorem}
+\begin{theorem}[$\SinsemillaHashToPoint(\ldots) = \bot$ yields a nontrivial \discreteLogarithm relation]\end{theorem}
 
 \begin{proof}
 For convenience of reference, we repeat the algorithm for $\SinsemillaHashToPoint$ in terms
@@ -9401,7 +9401,7 @@ $\Acc_{i-1} = -\SinsemillaGenBase(m_i)$) or $\alpha = 2$ (for $\Acc_{i-1} + \Sin
 \vspace{-0.5ex}
 $\Acc_i$ has a representation $\scalarmult{2^i}{\SinsemillaGenInit(D)} + \ssum{j=0}{2^k - 1} \,\scalarmult{X_{i,j+1}}{\SinsemillaGenBase(j)}$
 for some $X_i \typecolon \typeexp{\binaryrange{i}}{2^j}$.
-So given $m$ that results in an exceptional case, the nontrivial discrete logarithm relation
+So given $m$ that results in an exceptional case, the nontrivial \discreteLogarithm relation
 $\scalarmult{\alpha \mult 2^i}{\SinsemillaGenInit(D)} + \Big(\ssum{j=0}{\smash{2^k - 1}} \,\scalarmult{\alpha \mult X_{i,j+1}}{\SinsemillaGenBase(j)}\kern-0.15em\Big) + \SinsemillaGenBase(m_i) = \ZeroP$
 is easily computable from $m$. The coefficients in this representation do not overflow since
 $X_{i,j+1} < 2^i$ for all $i \in \range{1}{n}$ and $j \in \binaryrange{k}$; and
@@ -9409,10 +9409,10 @@ $|\alpha \mult 2^i| \leq \ParamP{r}-1$ for all $i \in \range{1}{n}$ and $\alpha 
 \end{proof}
 
 \vspace{-0.5ex}
-Similarly, a $\bot$ output from $\SinsemillaHash$ yields a nontrivial discrete logarithm relation,
+Similarly, a $\bot$ output from $\SinsemillaHash$ yields a nontrivial \discreteLogarithm relation,
 because $\ExtractPbot$ only returns $\bot$ when its input is $\bot$.
 
-Since by assumption it is hard to find a nontrivial discrete logarithm relation,
+Since by assumption it is hard to find a nontrivial \discreteLogarithm relation,
 we can argue that it is safe to use incomplete additions when computing Sinsemilla
 inside a circuit.
 } %nufive
@@ -9491,7 +9491,7 @@ by \texttt{calc\_round\_numbers.py} in that implementation, for a $128$-bit secu
         against a potential discrete-log-breaking adversary. Given the weak assumption
         that the $\PoseidonHash$ sponge produces output that preserves sufficient entropy
         from the inputs $\NullifierKey$ and $\NoteUniqueRand$, this nullifier
-        construction would still be secure under a \xDecisionalDiffieHellman assumption
+        construction would still be secure under a \DecisionalDiffieHellmanAssumption
         on the \Pallas curve, even if the $\Poseidon$-based PRF were distinguishable from
         an ideal PRF.
   \item The constant $2^{65}$ comes from \cite[section 4.2]{GKRRS2019}:
@@ -10464,7 +10464,7 @@ without key \reRandomization, using generator $\GenG{} = \ValueCommitRandBase{Or
 \vspace{-2ex}
 \securityrequirement{
 \nufive{Each instantiation of} $\BindingSig{}$ must be a \nh{SUF-CMA-secure} \keyMonomorphicSignatureScheme
-as defined in \crossref{abstractsigmono}. A signature must prove knowledge of the discrete logarithm of
+as defined in \crossref{abstractsigmono}. A signature must prove knowledge of the \discreteLogarithm of
 the \validatingKey with respect to the base $\ValueCommitRandBase{Sapling}$\nufive{ or
 $\ValueCommitRandBase{Orchard}$}.
 } %securityrequirement
@@ -10724,7 +10724,7 @@ implementation of this function.
 
 \vspace{1ex}
 The probability of $\SinsemillaHashToPoint$ returning $\bot$ is insignificant
-(and would yield a nontrivial discrete logarithm relation).
+(and would yield a nontrivial \discreteLogarithm relation).
 The \binding property of $\SinsemillaCommitAlg$ follows from \collisionResistance of
 $\SinsemillaHashToPoint$ proven in \theoremref{thmsinsemillacr}, given that
 $\GroupPHash\Of{D \bconcat \ascii{-r}, \ascii{}}$ is independent of any of the bases
@@ -10803,7 +10803,7 @@ is not square in $\GF{\ParamP{q}}$.
         $\NoteCommitAlg{Orchard}$ in this specification, the implementation in the
         \actionCircuit constrains the result to an unspecified set of values when an
         input results in an exceptional case for any incomplete addition. If this
-        occurs then it yields a nontrivial discrete logarithm relation for the
+        occurs then it yields a nontrivial \discreteLogarithm relation for the
         \pallasCurve, as proven in \theoremref{thmsinsemillaex}. We can therefore
         assume that it is infeasible to find such inputs with nonnegligible probability.
   \item There are also no points in $\GroupP$ with \affineSW $x$-coordinate
@@ -14775,7 +14775,7 @@ weaknesses in either (see \cite[Section 3.5 Nullifiers]{Zcash-Orchard} and
 \crossref{rhoandnullifiers}).
 
 Resistance to Faerie Gold attacks, on the other hand, depends entirely on hardness
-of the \xDiscreteLogarithmProblem. The $\NoteUniqueRand$ value of a \note created
+of the \DiscreteLogarithmProblem. The $\NoteUniqueRand$ value of a \note created
 in a given \actionTransfer is obtained from the \nullifier of the \note spent in
 that \actionTransfer; this ensures (without any cryptographic assumption) that all
 $\NoteUniqueRand$ values of \notes added to the \noteCommitmentTree are unique.
@@ -14784,7 +14784,7 @@ commitment on input that includes $\NoteUniqueRand$, so that the \binding proper
 that \commitmentScheme ensures that \Orchard \nullifiers will be unique. (Specifically,
 this is a Sinsemilla commitment with an additional term having base $\NullifierBaseOrchard$,
 truncated to its $x$-coordinate. The $x$-coordinate truncation cannot harm
-\collisionResistance because, assuming hardness of the \xDiscreteLogarithmProblem
+\collisionResistance because, assuming hardness of the \DiscreteLogarithmProblem
 on the \pallasCurve, \crossref{sinsemillasecurity} covers the case where the
 additional term is added.) Roadblock attacks are not possible because $\NoteUniqueRand$
 does not repeat for \notes in the \noteCommitmentTree, and by a corresponding argument
@@ -14863,7 +14863,7 @@ In \Sapling, \xPedersenOrSinsemillaCommitments are used instead of \shaCompress.
 These commitments are statistically \hiding, and so ``everlasting anonymity''
 is supported for \SaplingAndOrchard notes under the same conditions as in \Zerocash
 (by the protocol, not necessarily by \zcashd). Note that
-\diversifiedPaymentAddresses can be linked if the \xDecisionalDiffieHellmanProblem
+\diversifiedPaymentAddresses can be linked if the \DecisionalDiffieHellmanProblem
 on the \jubjubCurve\nufive{ or the \pallasCurve} can be broken.
 } %saplingonward
 
@@ -15688,7 +15688,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           \crossref{inbandrationale}:\!\!
           \begin{itemize}
             \item The argument for decryption with an \incomingViewingKey does not need to
-                  depend on the \xDecisionalDiffieHellmanProblem, since $\DiversifiedTransmitBase$
+                  depend on the \DecisionalDiffieHellmanProblem, since $\DiversifiedTransmitBase$
                   is committed to by the \noteCommitment as well as $\DiversifiedTransmitPublic$.
             \item It is necessary to say that the \noteCommitment is always checked for a
                   successful decryption.
@@ -15997,8 +15997,8 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
     \item Clarify the distinction between \Orchard \incomingViewingKeys and $\KA{Orchard}$
           \privateKeys.
     \item Add a note in \crossref{concretesinsemillahash} that \cite[Lemma 3]{JT2020} proves
-          a tight reduction from finding a nontrivial discrete logarithm relation to the
-          \xDiscreteLogarithmProblem.
+          a tight reduction from finding a nontrivial \discreteLogarithm relation to the
+          \DiscreteLogarithmProblem.
 } %nufive
 \sapling{
     \item Add a note to \crossref{merklepath} clarifying the encoding of $\rt{Sapling}$
@@ -16033,8 +16033,8 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           a non-null $\prevoutField$ field.
     \item Caveat how the result of \cite{GG2015} applies to analysis of $\PRFnf{Orchard}{}$ in
           \crossref{concreteprfs}.
-    \item Unlinkability of \diversifiedPaymentAddresses depends on the \xDecisionalDiffieHellmanProblem,
-          not the \xDiscreteLogarithmProblem.
+    \item Unlinkability of \diversifiedPaymentAddresses depends on the \DecisionalDiffieHellmanProblem,
+          not the \DiscreteLogarithmProblem.
     \item Add a paragraph to \crossref{truncation} covering \Orchard.
     \item Clarify the definition of $\pad$ in \crossref{concretesinsemillahash} by
           disambiguating $\Mpieces$ from $\Mpadded$.
@@ -18521,7 +18521,7 @@ considered justified for \Sapling.
 The specification of the \xPedersenHashes used in \Sapling is given in
 \crossref{concretepedersenhash}. It is based on the scheme from
 \cite[section 5.2]{CvHP1991} --for which a tighter security reduction to
-the \xDiscreteLogarithmProblem was given in \cite{BGG1995}-- but tailored
+the \DiscreteLogarithmProblem was given in \cite{BGG1995}-- but tailored
 to allow several optimizations in the circuit implementation.
 
 \xPedersenHashes are the single most commonly used primitive in the

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -422,6 +422,21 @@ li ol {
   margin-top: 0.25ex;
 }
 
+/*
+Default nested-ordered-list numbering for Markdown ZIPs (which have no way
+to set `<ol type="...">` from source): ordered list levels are numeric, then
+alphabetic, then lower-roman (e.g. 1. a. i.). The `:not([type])` qualifier
+preserves explicit type attributes emitted by the RST renderer or inline HTML,
+which can be semantically significant.
+*/
+li ol:not([type]) {
+  list-style-type: lower-alpha;
+}
+
+li ol:not([type]) li ol:not([type]) {
+  list-style-type: lower-roman;
+}
+
 li ul {
   margin-top: 0.25ex;
 }

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -42,6 +42,8 @@ Abstract
 This ZIP (ZIP 226) proposes the Orchard Zcash Shielded Assets (OrchardZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The OrchardZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
 While the proposed OrchardZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.
 
+This ZIP is defined relative to the Zcash protocol with the changes specified in ZIP 2005 [#zip-2005]_ applied. ZIP 2005 (Orchard Quantum Recoverability) is expected to deploy before any ZSA activation; the references in this document to $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{\text{ψ},Orchard}}$, recoverable note plaintexts (lead byte $\mathtt{0x03}$), and related constructs are to be interpreted as defined by ZIP 2005's modifications to the protocol specification.
+
 Motivation
 ==========
 
@@ -156,6 +158,8 @@ The nullifier is generated in the same manner as in the Orchard protocol §4.16 
 
 The OrchardZSA note plaintext also includes the Asset Base $\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}$ in addition to the components in the Orchard note plaintext [#protocol-notept]_.
 The explicit encoding of the note plaintext is provided in ZIP 230 [#zip-0230-orchard-note-plaintext]_.
+
+When § 4.7.3 'Sending Notes (Orchard)' [#protocol-orchardsend]_ or § 4.8.3 'Dummy Notes (Orchard)' [#protocol-orcharddummynotes]_ are invoked directly or indirectly in the computation of $\text{ρ}$ and $\text{ψ}$ for an OrchardZSA note, $\mathsf{leadByte}$ MUST be set to $\mathtt{0x03}$.
 
 The explicit order of addition of the note commitments to the note commitment tree is specified in ZIP 227 [#zip-0227-note-commitment-order]_.
 
@@ -290,7 +294,7 @@ For Split Notes, the nullifier is generated as follows:
 
 .. math:: \mathsf{nf_{old}} = \mathsf{Extract}_{\mathbb{P}} ([(\mathsf{PRF^{nfOrchard}_{nk}} (\text{ρ}^{\mathsf{old}}) + \text{ψ}^{\mathsf{nf}}) \bmod q_{\mathbb{P}}]\,\mathcal{K}^\mathsf{Orchard} + \mathsf{cm^{old}} + \mathcal{L}^\mathsf{Orchard})
 
-where $\text{ψ}^{\mathsf{nf}}$ is sampled uniformly at random on $\mathbb{F}_{q_{\mathbb{P}}}$, $\mathcal{K}^{\mathsf{Orchard}}$ is the Orchard Nullifier Base as defined in §4.16 ‘Computing ρ values and Nullifiers’ [#protocol-rhoandnullifiers]_, and $\mathcal{L}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{“z.cash:Orchard”}, \texttt{“L”})$.
+where $\text{ψ}^{\mathsf{nf}}$ is computed as $\mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed\_nf}}([\mathtt{0x0A}] \,||\, \underline{\text{ρ}^{\mathsf{old}}})\kern-0.1em\big)$ for $\mathsf{rseed\_nf}$ sampled uniformly at random on $\mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[32]}$, $\mathcal{K}^{\mathsf{Orchard}}$ is the Orchard Nullifier Base as defined in §4.16 ‘Computing ρ values and Nullifiers’ [#protocol-rhoandnullifiers]_, and $\mathcal{L}^{\mathsf{Orchard}} := \mathsf{GroupHash^{\mathbb{P}}}(\texttt{“z.cash:Orchard”}, \texttt{“L”})$. The first-byte domain separator $\mathtt{0x0A}$ for $\mathsf{PRF^{expand}}$ is reserved by ZIP 2005 [#zip-2005]_ for this use.
 
 Rationale for Split Notes
 `````````````````````````
@@ -388,8 +392,8 @@ The following requirements on wallets are specified and motivated in ZIP 230
   ZEC asset. For other consequences see ZIP 230.
 
 * *All* wallets should be ready to receive funds in outputs of v6 transactions as soon
-  as ZSAs activate — in particular to support decrypting note plaintexts with lead-byte
-  $\mathtt{0x03}$ [#zip-0230-note-plaintexts]_. The consequence of not doing so would
+  as ZSAs activate — in particular to support decrypting recoverable note plaintexts
+  (lead byte $\mathtt{0x03}$) [#zip-0230-note-plaintexts]_. The consequence of not doing so would
   be that funds sent to Orchard addresses of a wallet without this support could be
   temporarily inaccessible, until the wallet is upgraded to fully support v6 and to
   rescan outputs since v6 activation.
@@ -459,11 +463,12 @@ References
 .. [#zip-0244] `ZIP 244: Transaction Identifier Non-Malleability <zip-0244.rst>`_
 .. [#zip-0246] `ZIP 246: Digests for the Version 6 Transaction Format <zip-0246.rst>`_
 .. [#zip-0307] `ZIP 307: Light Client Protocol for Payment Detection <zip-0307.rst>`_
-.. [#zip-2005] `ZIP 2005: Quantum Recoverability <zip-2005.md>`_
+.. [#zip-2005] `ZIP 2005: Orchard Quantum Recoverability <zip-2005.md>`_
 .. [#protocol] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1] or later. <protocol/protocol.pdf>`_
 .. [#protocol-notes] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 3.2: Notes <protocol/protocol.pdf#notes>`_
 .. [#protocol-actions] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 3.7: Action Transfers and their Descriptions <protocol/protocol.pdf#actions>`_
 .. [#protocol-abstractcommit] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.1.8: Commitment <protocol/protocol.pdf#abstractcommit>`_
+.. [#protocol-orchardsend] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.7.3: Sending Notes (Orchard) <protocol/protocol.pdf#orchardsend>`_
 .. [#protocol-orcharddummynotes] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.8.3: Dummy Notes (Orchard) <protocol/protocol.pdf#orcharddummynotes>`_
 .. [#protocol-orchardbalance] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.14: Balance and Binding Signature (Orchard) <protocol/protocol.pdf#orchardbalance>`_
 .. [#protocol-rhoandnullifiers] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.16: Computing ρ values and Nullifiers <protocol/protocol.pdf#rhoandnullifiers>`_

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1,6 +1,6 @@
 
     ZIP: 2005
-    Title: Quantum Recoverability
+    Title: Orchard Quantum Recoverability
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
             Jack Grigg <thestr4d@gmail.com>
     Credits: Sean Bowe

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1231,7 +1231,7 @@ $\mathsf{SinsemillaShortCommit}$ which is not post-quantum binding.
 There are two cases depending on $\mathsf{use\_qsk}$ (the adversary can
 choose to attack either):
 
-* Case $\mathsf{use\_qsk} = 0$: The spender must prove knowledge of
+* Case $\text{not } \mathsf{use\_qsk}$: The spender must prove knowledge of
   $\mathsf{sk}$, and that $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$
   are derived correctly from $\mathsf{sk}$. This works because the
   derivations use post-quantum hashes (and $\mathsf{ask} \rightarrow \mathsf{ak}$
@@ -1248,10 +1248,10 @@ choose to attack either):
   $T \ll r_{\mathbb{P}}$. This is also infeasible for a quantum adversary
   using a Grover search for reasonable values of $T$.
 
-* Case $\mathsf{use\_qsk} = 1$: This case is almost the same except that
+* Case $\mathsf{use\_qsk}$: This case is almost the same except that
   $\mathsf{ivk}$ is now an essentially random function of
   $(\mathsf{nk}, \mathsf{ak}, \mathsf{qk})$. The success probability
-  in terms of $T$ is also the same as for $\mathsf{use\_qsk} = 0$.
+  in terms of $T$ is also the same as for $\text{not } \mathsf{use\_qsk}$.
 
 ## Security argument for Spendability
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -220,8 +220,8 @@ graph BT
 
 The bold lines are changes introduced by this ZIP, which all take the form
 of additional inputs to derivation functions or alternative derivations.
-The derivations shown in the box labelled "Potential recovery circuit" are,
-roughly speaking, those enforced by the [Proposed Recovery Protocol].
+The derivations shown in the box labelled [Proposed Recovery Statement](#proposedrecoverystatement)
+are, roughly speaking, those enforced by the section of that name.
 
 ```mermaid
 graph BT
@@ -234,7 +234,7 @@ graph BT
   classDef spacer opacity:0;
 
   PostQC:::circuit
-  subgraph PostQC[<div style="margin:1.1em;font-size:20px"><b>Potential recovery circuit</b></div>]
+  subgraph PostQC[<div style="margin:1.1em;font-size:20px"><b>Proposed Recovery Statement</b></div>]
     direction BT
     rivk_ext([rivk_ext]) --> Hrivk_int[H<sup>rivk_int</sup>]:::func
     ak([ak]) --> Hrivk_int[H<sup>rivk_int</sup>]:::func
@@ -845,6 +845,8 @@ The proposed Recovery Protocol works, roughly speaking, by enforcing the
 derivations given in the [Flow diagram for the Orchard and OrchardZSA protocols],
 and we suggest having that diagram open in another window to refer to it.
 
+### Proposed Recovery Statement
+
 Import this definition from § 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents]:
 
 > Define $\mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{qk}}\big([\mathtt{0x0D}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak}) \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})\kern-0.1em\big)\kern-0.15em\big)$.
@@ -872,7 +874,7 @@ Import this definition from § 5.4.7.1 ‘Spend Authorization Signature (Saplin
 
 > Define $\mathcal{G}^{\mathsf{Orchard}} = \mathsf{GroupHash}^{\mathbb{P}}(\texttt{“z.cash:Orchard”}, \texttt{“G”})$.
 
-A valid instance of a Recovery statement assures that given a primary input:
+A valid instance of a Recovery Statement assures that given a primary input:
 
 $\begin{array}{rl}
   \hspace{4.1em} ( \mathsf{rt^{Orchard}} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,q_{\mathbb{P}}-1 \}, \\
@@ -955,7 +957,7 @@ So, supporting "$\mathsf{use\_qsk}$" in addition to
 "not $\mathsf{use\_qsk}$" costs very little extra.
 
 All of the operations below need to be implemented with complete additions,
-even if they are incomplete in the current Orchard[ZSA] circuit.
+even if they are incomplete in the current Orchard[ZSA] statement/circuit.
 
 * 7 BLAKE2b-512 compressions:
   * 3 multiplexed between $\mathsf{H^{rivk\_ext}}$ when $\mathsf{use\_qsk}$ is true (1 compression),
@@ -1112,9 +1114,9 @@ TODO: discuss [^CBHSU2017] (sponge security), [^Unruh2015] [^Unruh2016]
 (collapse-binding property).
 
 The above security argument means that provided we also check the uses of
-$\mathsf{H^{rcm}}$ and $\mathsf{H}^{\text{ψ}}$ in the post-quantum recovery
-circuit, Orchard note commitments can be considered binding on all of the
-note fields.
+$\mathsf{H^{rcm}}$ and $\mathsf{H}^{\text{ψ}}$ in the post-quantum
+[Recovery Statement](#proposedrecoverystatement), Orchard note commitments
+can be considered binding on all of the note fields.
 
 Note that the argument associated with
 [Theorem 5.4.4](https://zips.z.cash/protocol/protocol.pdf#thmsinsemillaex)
@@ -1124,8 +1126,8 @@ yields a nontrivial discrete logarithm relation." and
 relation, we can argue that it is safe to use incomplete additions when
 computing Sinsemilla inside a circuit.") is not applicable when it is
 necessary to defend against a discrete-log-breaking or quantum adversary.
-Therefore, the post-quantum recovery circuit will need to use complete
-curve additions to implement Sinsemilla.
+Therefore, the post-quantum [Recovery Statement](#proposedrecoverystatement)
+will need to use complete curve additions to implement Sinsemilla.
 
 ### Attacks against binding of ivk
 
@@ -1220,15 +1222,15 @@ that hash, which would not hold against a discrete-log-breaking
 adversary.
 
 Does this mean it is possible to break Spendability for the given
-Recovery circuit? As it turns out, no, but the argument is somewhat
+Recovery Statement? As it turns out, no, but the argument is somewhat
 involved.
 
 TODO: this argument is too handwavy and depends on the ROM; it needs
 further work for a quantum adversary.
 
-Since each function in the Recovery circuit is deterministic, the
+Since each function in the Recovery Statement is deterministic, the
 free variables that the adversary can control are the sources of the
-derivation digraph within that circuit and either $\mathsf{SoK^{sk}}$
+derivation digraph within that statement and either $\mathsf{SoK^{sk}}$
 or $\mathsf{SoK^{qk}}$. That is, the adversary can control:
 
 * $(\text{ρ}, \mathsf{g_d}, \mathsf{rseed}, \mathsf{is\_internal\_rivk}, \mathsf{use\_qsk})$ and
@@ -1240,7 +1242,7 @@ $\mathsf{rcm}$ binds $\mathsf{rseed}$ and $\mathsf{pre\_rcm}$, and all
 of the other inputs to $\mathsf{NoteCommit}$ are also included in
 $\mathsf{pre\_rcm}$. Therefore, given the independence assumption between
 $\mathsf{H^{rcm}}$ and $f$ described earlier, $\mathsf{cm}$ binds all
-of the values in the Recovery circuit that the adversary can control.
+of the values in the Recovery Statement that the adversary can control.
 
 We can then analyze $\mathsf{DeriveNullifier}$ in essentially the same
 way we analyzed $\mathsf{NoteCommit}$.
@@ -1310,7 +1312,7 @@ identify the precise set of nullifiers for recoverable notes: an Orchard action
 in a v6 transaction could be spending either a recoverable or non-recoverable
 note, and their nullifier sets are indistinguishable.
 
-On the other hand, within the recovery circuit we know that the
+On the other hand, within the Recovery Statement we know that the
 note being spent is recoverable.
 
 # Deployment

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -282,6 +282,17 @@ graph BT
 
 # Specification
 
+## Usage with Zcash Shielded Assets
+
+This proposal has been designed to activate either at the same time as, or prior
+to any possible activation of ZSAs [^zip-0226] [^zip-0227].
+
+Whether or not ZSAs are deployed at the same time, the proposal anticipates that an
+$\mathsf{AssetBase}$ field will be added to note plaintexts with lead byte $\mathtt{0x03}$.
+This field will be set to the 32-byte constant
+$\mathsf{LEBS2OSP}_{\ell_{\mathbb{P}}}​​\big(\mathsf{repr}_{\mathbb{P}​}(\mathcal{V}^{\mathsf{Orchard}})\kern-0.1em\big)$
+as long as ZSAs are not deployed.
+
 ## Usage with FROST
 
 When generating Orchard keys for FROST, $\mathsf{ak}$ will be derived jointly
@@ -424,10 +435,9 @@ wallet.
 ## Specification Updates
 
 This is written as a set of changes to version 2025.6.2 of the protocol
-specification, and to the contents of ZIPs at the time of writing in
-October 2025 (as proposed for the NU6.1 upgrade). It will need to be merged
-with other changes for v6 transactions (memo bundles [^zip-0231] and
-ZSAs [^zip-0226] [^zip-0227]).
+specification, and to the contents of ZIPs as of February 2026. It will need
+to be merged with other potential changes for v6 transactions (memo bundles
+[^zip-0231] and ZSAs [^zip-0226] [^zip-0227]).
 
 ### Changes to the Protocol Specification
 
@@ -499,11 +509,6 @@ Add
 Add $\ell_{\mathsf{qsk}}$ and $\ell_{\mathsf{qk}}$ to the constants obtained
 from § 5.3 ‘Constants’.
 
-Insert after the definition of $\mathsf{ToScalar^{Orchard}}$:
-
-> Define $\mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{qk}}([\mathtt{0x0D}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak})$
-> $\hspace{23.9em} ||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})))$.
-
 Replace from "From this spending key" up to and including the line
 "let $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$"
 in the algorithm with:
@@ -538,6 +543,7 @@ in the algorithm with:
 > * $\mathsf{H^{rivk}}(\mathsf{sk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{sk}}([\mathtt{0x08}])\kern-0.1em\big)$
 > * $\mathsf{H^{qsk}}(\mathsf{sk}) = \mathsf{truncate}_{32}\big(\mathsf{PRF^{expand}_{sk}}([\mathtt{0x0C}])\kern-0.1em\big)$
 > * $\mathsf{H^{qk}}(\mathsf{qsk}) = \textsf{BLAKE2s\kern0.1em-256}(\texttt{“Zcash\_qk”}, \mathsf{qsk})$.
+> * $\mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{qk}}\big([\mathtt{0x0D}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak}) \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})\kern-0.1em\big)\kern-0.15em\big)$.
 > 
 > $\mathsf{ask} \;{\small ⦂}\; \mathbb{F}^{*}_{r_{\mathbb{P}}}$,
 > the Spend validating key $\mathsf{ak} \;{\small ⦂}\; \{ 1\,..\,q_{\mathbb{P}}-1 \}$,
@@ -611,16 +617,25 @@ Replace the lines deriving $\mathsf{rcm}$ and $\mathsf{esk}$ with
 
 #### § 4.7.3 ‘Sending Notes (Orchard)’
 
-Add after the definition of $\mathsf{leadByte}$:
+If this proposal is to be deployed without ZSAs, add after the definition of
+$\mathsf{leadByte}$:
 
-> Define $\mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star])\kern-0.1em\big) =$
+> Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
+> § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
+
+If it is deployed at the same time as ZSAs, it is assumed that $\mathsf{AssetBase}$
+will have been defined by the ZSA-related changes to § 4.7.3.
+
+Add before "For each Action description":
+
+> Define $\mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big) =$
 >   $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
 >
 > where $\mathsf{pre\_rcm} = \begin{cases}
 >   [\mathtt{0x05}] \,||\, \underline{\text{ρ}},&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
 >   [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \\
 >   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \\
->   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]}\,[\,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.08em\star)],&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+>   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
 > \end{cases}$
 >
 > Define $\mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
@@ -631,11 +646,14 @@ Add after the definition of $\mathsf{leadByte}$:
 >   \mathtt{0x0A}&\text{if } \mathsf{split\_flag} = 1\text{.}
 > \end{cases}$
 
+If this proposal is to be deployed without ZSAs, replace $\mathsf{split\_domain}$ with
+$\mathtt{0x09}$ above and elide its definition.
+
 Insert before the derivation of $\mathsf{esk}$:
 
 > Let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$,
-> $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}) [$,
-> and $\mathsf{AssetBase}\kern0.08em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})]$.
+> $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$,
+> and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
 
 and use these in the inputs to $\mathsf{NoteCommit^{Orchard}}$.
 
@@ -644,7 +662,7 @@ with
 
 > Derive $\mathsf{esk} = \mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}})$
 
-> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star]))$
+> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big)$
 
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, \mathsf{split\_flag})$
 
@@ -661,6 +679,12 @@ Replace the line deriving $\mathsf{rcm}$ with
 
 #### § 4.8.3 ‘Dummy Notes (Orchard)’
 
+If this proposal is to be deployed without ZSAs, add after the definition of
+$\mathsf{leadByte}$:
+
+> Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
+> § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
+
 Insert before "The spend-related fields ...":
 
 > Let $\mathsf{H^{rcm,Orchard}}$ and $\mathsf{H^{\text{ψ},Orchard}}$ be
@@ -669,10 +693,10 @@ Insert before "The spend-related fields ...":
 Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 
 > Let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$,
-> $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}) [$,
-> and $\mathsf{AssetBase}\kern0.08em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})]$.
+> $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$,
+> and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
 >
-> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star]))$
+> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big)$
 >
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$
 
@@ -682,7 +706,16 @@ $\mathsf{NoteCommit^{Orchard}}$.
 
 #### § 4.20.2 and § 4.20.3 ‘Decryption using an Incoming/Full Viewing Key (Sapling and Orchard)’
 
-For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
+If this proposal is to be deployed without ZSAs, add after the definition of
+$\mathsf{leadByte}$:
+
+> Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
+> § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
+
+If it is deployed at the same time as ZSAs, it is assumed that $\mathsf{AssetBase}$
+will have been defined by the ZSA-related changes to § 4.20.2 and § 4.20.3.
+
+For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
 
 > Let $\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{\text{esk},Sapling}}$
 > be as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
@@ -735,11 +768,11 @@ with
 > $\hspace{2.5em}$     if $\mathsf{repr}_{\mathbb{G}}(\mathsf{KA.DerivePublic}(\mathsf{esk}, \mathsf{g_d})) \neq \mathtt{ephemeralKey}$, return $\bot$ <br>
 > 
 > $\hspace{1.0em}$ let $\mathsf{pk_d} = \mathsf{KA.DerivePublic}(\mathsf{ivk}, \mathsf{g_d})$ <br>
-> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}) [$, and $\mathsf{AssetBase}\kern0.08em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})]$ <br>
+> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{H^{rcm,protocol}_{rseed}}(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star])),&\!\!\!\text{otherwise}
+>                    \mathsf{H^{rcm,protocol}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big),&\!\!\!\text{otherwise}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -761,11 +794,11 @@ For § 4.20.3, replace
 with
 
 > $\hspace{1.0em}$ let $\mathsf{g_d} = \mathsf{DiversifyHash}(\mathsf{d})$. if (for Sapling) $\mathsf{g_d} = \bot$, return $\bot$ <br>
-> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}) [$, and $\mathsf{AssetBase}\kern0.08em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})]$ <br>
+> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{H^{rcm,protocol}_{rseed}}(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star])),&\!\!\!\text{otherwise}
+>                    \mathsf{H^{rcm,protocol}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big),&\!\!\!\text{otherwise}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -850,34 +883,36 @@ The proposed Recovery Protocol works, roughly speaking, by enforcing the
 derivations given in the [Flow diagram for the Orchard and OrchardZSA protocols],
 and we suggest having that diagram open in another window to refer to it.
 
-Import this definition from § 4.7.3 ‘Sending Notes (Orchard)’:
+Import this definition from § 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents]:
 
-> Let $\mathsf{leadByte}$ be the note plaintext lead byte, chosen
-> according to § 3.2.1 ‘Note Plaintexts and Memo Fields’ with
-> $\mathsf{protocol} = \mathsf{Orchard}$.
->
-> Define $\mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star])\kern-0.1em\big) =$
-> $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
+> Define $\mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{qk}}\big([\mathtt{0x0D}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak}) \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})\kern-0.1em\big)\kern-0.15em\big)$.
+
+Import this definition from ZIP 32 [^zip-0032-orchard-internal-key-derivation]:
+
+> $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rivk\_ext}}([\mathtt{0x83}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak})$
+> $\hspace{21.58em} ||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})))$
+
+Import these definitions from § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend], specialized to $\mathsf{leadByte} = \mathtt{0x03}$:
+
+> Define $\mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big) =$
+>   $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
 >
 > where $\mathsf{pre\_rcm} = \begin{cases}
->   [\mathtt{0x05}] \,||\, \underline{\text{ρ}},&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
+>   \sout{[\mathtt{0x05}] \,||\, \underline{\text{ρ}},}&\!\!\!\sout{\text{if } \mathsf{leadByte} = \mathtt{0x02}} \\
 >   [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \\
 >   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \\
->   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]}\,[\,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.08em\star)],&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}\text{.} \\
+>   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+> \end{cases}$
+>
+> Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, \mathsf{split\_flag}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathsf{split\_domain}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
+> where $\mathsf{split\_domain} = \begin{cases}
+>   \mathtt{0x09},&\!\!\!\text{if } \mathsf{split\_flag} = 0 \\
+>   \mathtt{0x0A},&\!\!\!\text{if } \mathsf{split\_flag} = 1\text{.}
 > \end{cases}$
 
-Define:
+Import this definition from § 5.4.7.1 ‘Spend Authorization Signature (Sapling and Orchard)’ [^protocol-concretespendauthsig]:
 
-* $\mathsf{H}^{\text{ψ},\mathsf{Orchard}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}, \mathsf{split\_flag}) = \mathsf{ToBase^{Orchard}}(\mathsf{PRF}^{\mathsf{expand}}_{\mathsf{r}\text{ψ}}([\mathsf{split\_domain}] \,||\, \underline{\text{ρ}}))$ <br>
-  where $\mathsf{split\_domain} = \begin{cases}
-    \mathtt{0x09},&\!\!\!\text{if } \mathsf{split\_flag} = 0 \\
-    \mathtt{0x0A},&\!\!\!\text{if } \mathsf{split\_flag} = 1\text{.}
-  \end{cases}$
-* $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rivk\_ext}}([\mathtt{0x83}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak})$
-  $\hspace{21.58em} ||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})))$
-* $\mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{\rlap{qk}{\hphantom{rivk\_ext}}}}([\mathtt{0x84}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak})$
-  $\hspace{21.58em} ||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})))$
-* $\mathcal{G}^{\mathsf{Orchard}} = \mathsf{GroupHash}^{\mathbb{P}}(\texttt{“z.cash:Orchard”}, \texttt{“G”})$
+> Define $\mathcal{G}^{\mathsf{Orchard}} = \mathsf{GroupHash}^{\mathbb{P}}(\texttt{“z.cash:Orchard”}, \texttt{“G”})$.
 
 A valid instance of a Recovery statement assures that given a primary input:
 
@@ -933,7 +968,7 @@ $\begin{array}{l}
 \wedge\; \mathsf{ivk} \not\in \{0, \bot\} \\
 \wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \\
 \wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}, \mathsf{split\_flag}) \\
-\wedge\; \text{let } \mathsf{note\_repr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star]\big) \\
+\wedge\; \text{let } \mathsf{note\_repr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \\
 \wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{note\_repr}\big) \\
 \wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{note\_repr}) \\
 \wedge\; \mathsf{cm} \neq \bot \\
@@ -1030,7 +1065,7 @@ Balance property.
 
 We prefer to fix this without changing $\mathsf{NoteCommit^{Orchard}}$ itself.
 Instead we change how $\mathsf{rcm}$ is computed to be a hash of $\mathsf{rseed}$ and
-$\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}[, \mathsf{AssetBase}\kern0.08em\star])$,
+$\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)$,
 as detailed in the [Specification] section.
 Specifically, when $\mathsf{leadByte} = \mathtt{0x03}$ we have:
 
@@ -1375,9 +1410,21 @@ manipulate the note selection algorithm to some extent.
 
 [^protocol-networks]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
 
+[^protocol-orchardkeycomponents]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.2.3: Orchard Key Components](protocol/protocol.pdf#orchardkeycomponents)
+
+[^protocol-saplingsend]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.7.2: Sending Notes (Sapling)](protocol/protocol.pdf#saplingsend)
+
+[^protocol-orchardsend]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.7.3: Sending Notes (Orchard)](protocol/protocol.pdf#orchardsend)
+
+[^protocol-saplingandorchardinband]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.20: In-band secret distribution (Sapling and Orchard)](protocol/protocol.pdf#saplingandorchardinband)
+
+[^protocol-constants]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 5.3: Constants](protocol/protocol.pdf#constants)
+
 [^protocol-concretesinsemillahash]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 5.4.1.9: Sinsemilla Hash Function](protocol/protocol.pdf#concretesinsemillahash)
 
 [^protocol-sinsemillasecurity]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 5.4.1.9: Sinsemilla Hash Function — Security argument](protocol/protocol.pdf#sinsemillasecurity)
+
+[^protocol-concretespendauthsig]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 5.4.7.1: Spend Authorization Signature (Sapling and Orchard)](protocol/protocol.pdf#concretespendauthsig)
 
 [^zip-0032-sapling-child-key-derivation]: [ZIP 32: Shielded Hierarchical Deterministic Wallets — Sapling child key derivation](zip-0032.rst#sapling-child-key-derivation)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -52,12 +52,12 @@ many of its design decisions are intentionally left open.
 
 # Abstract
 
-This ZIP proposes a change to the construction of Orchard[ZSA] notes
-starting with v6 transactions, designed to improve Zcash's long-term
-resilience against a significant potential threat to its security from
-quantum computers. It does not by itself make the protocol secure against
-quantum adversaries, but is intended to support a smoother transition to
-future versions of Zcash designed to be so.
+This ZIP proposes a change to the construction of Orchard[ZSA] notes,
+designed to improve Zcash's long-term resilience against a significant
+potential threat to its security from quantum computers. It does not
+by itself make the protocol secure against quantum adversaries, but is
+intended to support a smoother transition to future versions of Zcash
+designed to be so.
 
 Specifically, if it were necessary to disable the current Orchard[ZSA]
 shielded protocol in order to prevent a discrete-log-breaking adversary
@@ -114,8 +114,8 @@ Sapling [^zip-0032-sapling-child-key-derivation] [^zip-0032-sapling-internal-key
 and Orchard [^zip-0032-orchard-child-key-derivation] [^zip-0032-orchard-internal-key-derivation].)
 
 This proposal is implementable at low risk, and required changes to existing
-libraries and wallets are small. It can be folded into other changes
-necessary to implement ZSAs [^zip-0226] and Memo Bundles [^zip-0231].
+libraries and wallets are small. It can optionally be done at the same time
+as changes necessary to implement Memo Bundles [^zip-0231] and/or ZSAs [^zip-0226].
 
 
 # Requirements
@@ -165,15 +165,16 @@ necessary to implement ZSAs [^zip-0226] and Memo Bundles [^zip-0231].
 
 This subsection and the flow diagram below are non-normative.
 
-In order to support ZSAs [^zip-0226] [^zip-0227] and memo bundles
-[^zip-0231], v6 transactions require in any case a new note plaintext
-format, with lead byte $\mathtt{0x03}.$ This gives us an opportunity
-to change the way that the $\mathsf{pre\_rcm}$ value is computed for
-this new format, by including all of the note fields in $\mathsf{pre\_rcm}$.
-The resulting $\mathsf{rcm}$ is essentially a random function of the
-note fields — this allows us to argue that the overall commitment
-scheme is post-quantum binding, as long as the new derivation of
-$\mathsf{rcm}$ is checked in the Recovery Protocol.
+The Quantum Recoverability proposal was originally designed to be
+deployed alongside ZSAs [^zip-0226] [^zip-0227] and memo bundles
+[^zip-0231]. Whether or not that is still the case, we retain the
+same approach of defining a new note plaintext format, with lead byte
+$\mathtt{0x03}.$ The $\mathsf{pre\_rcm}$ value is computed differently
+for this new format, by including all of the note fields in
+$\mathsf{pre\_rcm}$. The resulting $\mathsf{rcm}$ is essentially a
+random function of the note fields — this allows us to argue that the
+overall commitment scheme is post-quantum binding, as long as the new
+derivation of $\mathsf{rcm}$ is checked in the Recovery Protocol.
 
 Essentially the same technique also needs to be applied to the
 function $\mathsf{Commit^{ivk}}$ that is used to derive Orchard
@@ -282,8 +283,8 @@ graph BT
 
 ## Usage with Zcash Shielded Assets
 
-This proposal has been designed to activate either at the same time as, or prior
-to any possible activation of ZSAs [^zip-0226] [^zip-0227].
+This proposal has been designed to activate either prior to, or at the same
+time as, any possible activation of ZSAs [^zip-0226] [^zip-0227].
 
 Whether or not ZSAs are deployed at the same time, the proposal anticipates that an
 $\mathsf{AssetBase}$ field will be added to note plaintexts with lead byte $\mathtt{0x03}$.
@@ -433,9 +434,10 @@ wallet.
 ## Specification Updates
 
 This is written as a set of changes to version 2025.6.2 of the protocol
-specification, and to the contents of ZIPs as of February 2026. It will need
-to be merged with other potential changes for v6 transactions (memo bundles
-[^zip-0231] and ZSAs [^zip-0226] [^zip-0227]).
+specification, and to the contents of ZIPs as of February 2026. If other
+changes for v6 transactions (memo bundles [^zip-0231], ZSAs [^zip-0226]
+[^zip-0227]) are deployed simultaneously, these changes will need to be
+merged with theirs.
 
 ### Changes to the Protocol Specification
 
@@ -1298,13 +1300,13 @@ $\mathsf{H^{rcm,Orchard}}$ can be modelled as a random oracle.
 TBD: explain that such attacks can break Balance and Spendability, including
 Spendability for transactions after switching to the Recovery Protocol.
 
-Note that we can identify the precise set of note commitments for
-recoverable (lead byte $\mathtt{0x03}$) Orchard notes, since they are
-the commitments for Orchard outputs of v6 transactions.
-However, we cannot identify the precise set of nullifiers for
-recoverable notes: an Orchard action in a v6 transaction could be
-spending either a recoverable or non-recoverable note, and their
-nullifier sets are indistinguishable.
+Note that with [Deployment](#deployment) option 2 (deploying at the same time as
+v6 transactions), we can identify the precise set of note commitments for
+recoverable (lead byte $\mathtt{0x03}$) Orchard notes, since they are exactly
+the commitments for Orchard outputs of v6 transactions. However, we cannot
+identify the precise set of nullifiers for recoverable notes: an Orchard action
+in a v6 transaction could be spending either a recoverable or non-recoverable
+note, and their nullifier sets are indistinguishable.
 
 On the other hand, within the recovery circuit we know that the
 note being spent is recoverable.
@@ -1329,19 +1331,30 @@ doing it this way involves fewer components. This also allows us to avoid
 any security compromise and use 256-bit cryptovalues for both integrity
 and randomization, which would otherwise have been difficult.
 
-It is suggested to deploy this change with v6 transactions. That is,
-every Orchard output of a v6-onward transaction will be a recoverable
-note. This implies that when the pre-quantum protocol is turned off,
-v5 and earlier outputs will no longer be spendable. Since v6 already
-changes the note encryption in order to support memo bundles and ZSAs,
-this approach to deployment reduces the risk of the kind of difficulties
-that occurred with [ZIP 212](https://zips.z.cash/zip-0212), where some
-wallets were following the old protocol after the Canopy upgrade and
-sending non-conformant note plaintexts.
+There are two options for deployment:
 
-When a compliant wallet receives an Orchard note in a v5 or earlier
-transaction, the associated funds are not recoverable and need to be
-spent to v6 in order to make them so.
+1. Deploy this change prior to the next network upgrade. This would
+   optimize time-to-deployment. An activation height is still needed
+   so that wallets do not start sending recoverable note plaintexts
+   before the receiving wallet can have been expected to upgrade.
+2. Deploy this change at the same time as the next network upgrade (NU7),
+   at the same time as v6 transactions.
+
+With either option, it is proposed to enforce this change with v6
+transactions. That is, every Orchard output of a v6-onward transaction
+will be a recoverable note. This implies that when the pre-quantum
+protocol is turned off, v5 and earlier outputs will no longer be spendable.
+
+Deploying via a transaction-version bump (rather than as a soft addition
+within v5) reduces the risk of the kind of difficulties that occurred with
+[ZIP 212](https://zips.z.cash/zip-0212), where some wallets were following
+the old protocol after the Canopy upgrade and sending non-conformant note
+plaintexts. If memo bundles or ZSAs are deployed simultaneously, those
+changes share the same version-bump signal.
+
+When a compliant wallet receives an Orchard note with lead byte
+$\mathtt{0x02}$, the associated funds are not recoverable and need to be
+spent to a recoverable note in order to make them so.
 
 Note: if we prioritize spending non-recoverable notes, it is
 conceivable that an adversary could exploit this to improve

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1373,7 +1373,7 @@ $\mathsf{use\_qsk} = \mathsf{false}$ case in
 
 FROST distributed key generation requires the $\mathsf{use\_qsk} = \mathsf{true}$ case.
 There is no significant existing deployment of FROST, so we can
-[write this into ZIP 312](https://github.com/zcash/zips/pull/883/files)
+[write this into ZIP 312](https://github.com/zcash/zips/pull/895/files)
 from the start.
 
 The part of the protocol that is new is the different input for

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -39,8 +39,10 @@ The term "Orchard[ZSA]" in this document refers to the Orchard shielded
 protocol before the deployment of ZSAs, and to the OrchardZSA shielded
 protocol after the deployment of ZSAs.
 
-The term "recoverable Orchard[ZSA] note" refers to an Orchard or OrchardZSA
-note that was created according to this proposal.
+The terms "recoverable note" and "recoverable note plaintext" refer to a
+note or note plaintext that was created according to this proposal. As
+initially deployed, these are necessarily Orchard or OrchardZSA notes or
+note plaintexts.
 
 The term "Recovery Protocol" refers to a potential new shielded protocol
 that would allow recovery of funds held in recoverable Orchard[ZSA] notes.
@@ -1328,7 +1330,7 @@ any security compromise and use 256-bit cryptovalues for both integrity
 and randomization, which would otherwise have been difficult.
 
 It is suggested to deploy this change with v6 transactions. That is,
-every Orchard output of a v6-onward transaction will be a pq-recoverable
+every Orchard output of a v6-onward transaction will be a recoverable
 note. This implies that when the pre-quantum protocol is turned off,
 v5 and earlier outputs will no longer be spendable. Since v6 already
 changes the note encryption in order to support memo bundles and ZSAs,
@@ -1338,10 +1340,10 @@ wallets were following the old protocol after the Canopy upgrade and
 sending non-conformant note plaintexts.
 
 When a compliant wallet receives an Orchard note in a v5 or earlier
-transaction, the associated funds are not pq-recoverable and need to be
+transaction, the associated funds are not recoverable and need to be
 spent to v6 in order to make them so.
 
-Note: if we prioritize spending non-pq-recoverable notes, it is
+Note: if we prioritize spending non-recoverable notes, it is
 conceivable that an adversary could exploit this to improve
 [arity leakage attacks](https://github.com/zcash/zcash/issues/4332).
 On the other hand, adversaries can already choose note values to

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -407,29 +407,101 @@ graph BT
 ```
 
 When $\mathsf{use\_qsk}$ is used, on the other hand, it is possible for
-the Recovery Protocol to support spend authorization using a much smaller
-circuit that only uses $\mathsf{H^{qk}}$ and a commitment scheme.
-For example, for some hiding and collapse binding commitment
-$c = \mathsf{LinkCommit}_r(\mathsf{qk}, \mathsf{sighash}),$
+the Recovery Protocol to support spend authorization using a simpler
+statement that only uses $\mathsf{H^{qk}}$ and a commitment scheme.
+For example, for some hiding and collapse-binding commitment
+$$\mathsf{c_{link}} = \mathsf{LinkCommit}_r(\mathsf{qk}, \mathsf{sighash})$$
 the hardware wallet could prove knowledge of $(\mathsf{qsk}, r)$ such that
-$c = \mathsf{LinkCommit}_r(\mathsf{H^{qk}}(\mathsf{qsk}), \mathsf{sighash}).$
-This circuit is relatively small and it might be feasible to do the proof in
-quite constrained hardware.
+$$\mathsf{c_{link}} = \mathsf{LinkCommit}_r(\mathsf{H^{qk}}(\mathsf{qsk}), \mathsf{sighash}).$$
+This statement, labelled as $\mathsf{SoK^{qsk}}$ in the diagram, can be
+implemented in a much smaller circuit, so it might be feasible to do the
+proof in quite constrained hardware.
 
-The host wallet would be given $\mathsf{nk},$ $\mathsf{ak},$ and $\mathsf{qk}$
-for use in the main Recovery circuit (discussed later). The commitment $c$ would
-be a public input opened to $(\mathsf{qk}, \mathsf{sighash})$ in that circuit,
-ensuring that the hardware wallet has authorized the spend for the correct key.
-Because $\mathsf{LinkCommit}$ is hiding and the proofs are zero knowledge, no
-information is leaked about which $\mathsf{qk}$ is being used.
+The commitment $\mathsf{c_{link}}$ would be a public input opened to
+$(\mathsf{qk}, \mathsf{sighash})$ in the [Recovery Statement](#proposedrecoverystatement),
+ensuring that the hardware wallet has authorized the spend for the correct
+key. Because $\mathsf{LinkCommit}$ is hiding and the proofs are zero knowledge,
+no information is leaked about which $\mathsf{qk}$ is being used.
 
-Alternatively, if the hardware wallet is unable to support making proofs at
-all, it could be updated to permit exporting $\mathsf{qsk}$. This is less
-secure against a quantum adversary that is able to obtain $\mathsf{qsk}$, but
-it allows the funds to be transferred to another key or protocol. A quantum
-adversary would have to break RedDSA in order to steal funds even if it were
-to obtain $\mathsf{qsk}$, since $\mathsf{ask}$ would remain on the hardware
-wallet.
+### Key storage options and analysis
+
+By *host wallet*, we mean the device that builds the spend transaction and
+produces the rest of the Recovery Statement proof. In a multi-signer FROST
+setup, this would be the Coordinator [^zip-0312-threat-model]. The host wallet
+is given $\mathsf{nk},$ $\mathsf{ak},$ and (assuming $\mathsf{use\_qsk}$ is true)
+$\mathsf{qk}$, for use in the Recovery Statement. Then two options are possible
+for storage of $\mathsf{qsk}$:
+
+**Option A** — The $\mathsf{SoK^{qsk}}$ proof is produced inside the hardware
+wallet, and $\mathsf{qsk}$ is retained there.
+
+**Option B** — Alternatively, if the hardware wallet is unable to support
+proving $\mathsf{SoK^{qsk}}$, it could be updated to permit exporting
+$\mathsf{qsk}$ to the host wallet, and the $\mathsf{SoK^{qsk}}$ proof would be
+produced there.
+
+In either option, $\mathsf{ask}$ would remain on the hardware wallet which
+would continue to produce RedDSA spend authorization signatures (or its part
+of the FROST multi-signing protocol).
+
+#### Threat model
+
+The [Recovery Statement](#proposedrecoverystatement) is assumed below to
+require both of:
+
+* an $\mathsf{SoK^{qsk}}$ proof verifying knowledge of $\mathsf{qsk}$
+  such that $\mathsf{H^{qk}}(\mathsf{qsk}) = \mathsf{qk}$ for the
+  spent note's $\mathsf{qk}$; and
+* a RedDSA signature on $\mathsf{ak}$, which under FROST is
+  constructed by cooperation of $t$-of-$n$ hardware-wallet signers,
+  each contributing using its share of $\mathsf{ask}$.
+
+Under this assumed structure, with FROST + hardware-wallet deployment,
+spend authorization is broken only by either:
+
+1. **$\mathsf{qsk}$ possession + finding discrete logarithms on the
+   Pallas curve.** The variants differ only in *how* $\mathsf{qsk}$
+   is obtained:
+
+    <!-- rendered as a., b., c. -->
+    1. the adversary is an authorized FROST signer — they hold a copy
+       of $\mathsf{qsk}$ by construction;
+    2. $\mathsf{qsk}$ is extracted from a hardware wallet, defeating
+       Option A by a physical-device or side-channel attack;
+    3. $\mathsf{qsk}$ is obtained after export to the host wallet, by
+       compromising the host wallet or intercepting it during export.
+
+2. **Breaking a primitive or scheme.** RedDSA, FROST, the DKG, or the
+   proving system has a cryptographic weakness or implementation flaw.
+
+#### Choosing between Options A and B
+
+Option A is preferred where the target hardware wallet is capable of
+proving $\mathsf{SoK^{qsk}}$ on-device. Option B is a fallback for
+cases where it cannot — for instance, due to memory or secure-element
+constraints, uncertainty about the proof system that will be chosen
+and what will be tractable on small devices, or the device having been
+obsoleted before firmware support could be added.
+
+Under Option A, the host wallet holds only the full viewing key
+($\mathsf{ak}$, $\mathsf{nk}$) —which the pre-Quantum-Recoverability
+protocol already entrusted to it— plus $\mathsf{qk}$. The $\mathsf{qsk}$
+attack surface is then 1.a. or 1.b. only.
+
+Option B additionally places $\mathsf{qsk}$ on the host wallet, admitting
+case 1.c. as well. This has the disadvantage that host-wallet compromise
+is a substantially larger attack surface than hardware-wallet extraction.
+However, even with $\mathsf{qsk}$ in hand, an adversary would still need
+to break RedDSA or find discrete logarithms on the Pallas curve to steal
+funds.
+
+Note: with ZIP 32 hierarchical derivation, $\mathsf{qsk}$ need not be
+backed up separately from the seed phrase. When $\mathsf{use\_qsk}$ is
+true, $\mathsf{qsk} = \mathsf{H^{qsk}}(\mathsf{sk})$ where $\mathsf{sk}$
+is the HD-derived spending key, and so $\mathsf{qsk}$ can be re-derived
+from the seed phrase (with or without SLIP 39 Shamir backup [^slip-0039]).
+A deployment that does not use ZIP 32 is responsible for the security of
+its own backup arrangements.
 
 ## Specification Updates
 
@@ -1399,6 +1471,8 @@ manipulate the note selection algorithm to some extent.
 
 [^zip-0032-orchard-internal-key-derivation]: [ZIP 32: Shielded Hierarchical Deterministic Wallets — Orchard internal key derivation](zip-0032.rst#orchard-internal-key-derivation)
 
+[^slip-0039]: [SLIP-0039: Shamir's Secret-Sharing for Mnemonic Codes](https://github.com/satoshilabs/slips/blob/master/slip-0039.md)
+
 [^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
 
 [^zip-0226]: [ZIP 226: Transfer and Burn of Zcash Shielded Assets](zip-0226.rst)
@@ -1414,6 +1488,8 @@ manipulate the note selection algorithm to some extent.
 [^zip-0312]: [ZIP 312: FROST for Spend Authorization Multisignatures](zip-0312.rst)
 
 [^zip-0312-key-generation]: [ZIP 312: FROST for Spend Authorization Multisignatures — Key Generation](zip-0312.rst#key-generation)
+
+[^zip-0312-threat-model]: [ZIP 312: FROST for Spend Authorization Multisignatures — Threat Model](zip-0312.rst#threat-model)
 
 [^zcash-security]: Understanding Zcash Security ([video](https://www.youtube.com/watch?v=f6UToqiIdeY), [slides](https://raw.githubusercontent.com/daira/zcash-security/main/zcash-security.pdf)). Presentation by Daira-Emma Hopwood at Zcon3.
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1245,7 +1245,7 @@ choose to attack either):
   $T \ll r_{\mathbb{P}}$. This is also infeasible for a quantum adversary
   using a Grover search for reasonable values of $T$.
 
-* Case $\mathsf{use\_qsk} = 0$: This case is almost the same except that
+* Case $\mathsf{use\_qsk} = 1$: This case is almost the same except that
   $\mathsf{ivk}$ is now an essentially random function of
   $(\mathsf{nk}, \mathsf{ak}, \mathsf{qk})$. The success probability
   in terms of $T$ is also the same as for $\mathsf{use\_qsk} = 0$.

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -472,28 +472,26 @@ In the list of places where $\mathsf{PRF^{expand}}$ is used:
 
 Replace
 
-> * [**NU5** onward] in § 4.2.3 ‘Orchard Key Components’, with inputs
->   $[\mathtt{0x06}]$, $[\mathtt{0x07}]$, $[\mathtt{0x08}]$, and with
->   first byte $\mathtt{0x82}$ (the last of these is also specified in
->   [[ZIP-32]](https://zips.z.cash/zip-0032));
-> * in the processes of sending (§ 4.7.2 ‘Sending Notes (Sapling)’ and
->   § 4.7.3 ‘Sending Notes (Orchard)’) and of receiving
->   (§ 4.20 ‘In-band secret distribution (Sapling and Orchard)’) notes,
->   for Sapling with inputs $[\mathtt{0x04}]$ and $[\mathtt{0x05}]$,
+> * [**NU5** onward] in § 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents],
+>   with inputs $[\mathtt{0x06}]$, $[\mathtt{0x07}]$, $[\mathtt{0x08}]$, and with
+>   first byte $\mathtt{0x82}$;
+> * in the processes of sending (§ 4.7.2 ‘Sending Notes (Sapling)’ [^protocol-saplingsend]
+>   and § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend]) and of receiving
+>   (§ 4.20 ‘In-band secret distribution (Sapling and Orchard)’ [^protocol-saplingandorchardinband])
+>   notes, for Sapling with inputs $[\mathtt{0x04}]$ and $[\mathtt{0x05}]$,
 >   and for Orchard $[t] || \underline{\text{ρ}}$ with
 >   $t \in \{ \mathtt{0x05}, \mathtt{0x04}, \mathtt{0x09} \}$;
 
 with
 
-> * [**NU5** onward] in § 4.2.3 ‘Orchard Key Components’, with inputs
->   $[\mathtt{0x06}]$, $[\mathtt{0x07}]$, $[\mathtt{0x08}]$, with first
->   byte in $\{ \mathtt{0x0C}, \mathtt{0x0D} \}$ (also specified in
->   {{ reference to this ZIP }}), and with first byte $\mathtt{0x82}$
->   (also specified in [[ZIP-32]](https://zips.z.cash/zip-0032));
-> * in the processes of sending (§ 4.7.2 ‘Sending Notes (Sapling)’ and
->   § 4.7.3 ‘Sending Notes (Orchard)’) and of receiving
->   (§ 4.20 ‘In-band secret distribution (Sapling and Orchard)’) notes,
->   for Sapling with inputs $[\mathtt{0x04}]$ and $[\mathtt{0x05}]$,
+> * [**NU5** onward] in § 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents],
+>   with inputs $[\mathtt{0x06}]$, $[\mathtt{0x07}]$, $[\mathtt{0x08}]$, and with
+>   first byte in $\{ \mathtt{0x0C}, \mathtt{0x0D}, \mathtt{0x82} \}$
+>   ($\mathtt{0x0C}$ and $\mathtt{0x0D}$ are also specified in [ZIP 2005]);
+> * in the processes of sending (§ 4.7.2 ‘Sending Notes (Sapling)’ [^protocol-saplingsend]
+>   and § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend]) and of receiving
+>   (§ 4.20 ‘In-band secret distribution (Sapling and Orchard)’ [^protocol-saplingandorchardinband])
+>   notes, for Sapling with inputs $[\mathtt{0x04}]$ and $[\mathtt{0x05}]$,
 >   and for Orchard with first byte in
 >   $\{ \mathtt{0x05}, \mathtt{0x04}, \mathtt{0x09}, \mathtt{0x0A}, \mathtt{0x0B} \}$
 >   ($\mathtt{0x0A}$ and $\mathtt{0x0B}$ are also specified in [ZIP 2005]);

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -597,12 +597,12 @@ in the algorithm with:
 > [[ZIP 2005, Usage with hardware wallets]](#usagewithhardwarewallets)).
 > The derivation from $\mathsf{qsk}$ can also be used in that case.
 >
-> Let $\mathsf{use\_qsk} \;{\small ⦂}\; \mathbb{B}$ be a flag that is set
-> to true when the derivation from $\mathsf{qsk}$ is used, or false if
-> $\mathsf{ask}$ is derived directly from $\mathsf{sk}$. (In cases where
-> it is desired for the generation of key components to match versions of
-> this specification prior to {{ fill in version }}, $\mathsf{use\_qsk}$
-> needs to be set to false.)
+> Let $\mathsf{use\_qsk} \;{\small ⦂}\; \mathbb{B}$ be a flag indicating
+> whether $\mathsf{qsk}$ and $\mathsf{qk}$ are generated and used in the
+> derivation of $\mathsf{rivk}$. (In cases where it is desired for the
+> generation of key components to match versions of this specification
+> prior to {{ fill in version }}, $\mathsf{use\_qsk}$ needs to be set to
+> false.)
 >
 > Define:
 > * $\mathsf{H^{ask}}(\mathsf{sk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{sk}}([\mathtt{0x06}])\kern-0.1em\big)$
@@ -625,9 +625,12 @@ in the algorithm with:
 >
 > $\hspace{1.0em}$ let $\mathsf{nk} = \mathsf{H^{nk}}(\mathsf{sk})$ <br>
 > $\hspace{1.0em}$ if $\mathsf{use\_qsk}$: <br>
-> $\hspace{2.5em}$     generate $\mathsf{ask} \;{\small ⦂}\; \mathbb{F}^{*}_{r_{\mathbb{P}}}$ and corresponding $\mathsf{SpendAuthSig^{Orchard}}$ public key $\mathsf{ak}^{\mathbb{P}} \;{\small ⦂}\; \mathbb{P}^*$ <br>
-> $\hspace{3.5em}$     using any suitably secure method that ensures the last bit of $\mathsf{repr}_{\mathbb{P}}(\mathsf{ak}_{\mathbb{P}})$ is $0$. <br>
-> $\hspace{2.5em}$     let $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}_{\mathbb{P}})$ <br>
+> $\hspace{2.5em}$     obtain a $\mathsf{SpendAuthSig^{Orchard}}$ public key $\mathsf{ak}^{\mathbb{P}} \;{\small ⦂}\; \mathbb{P}^*$ by any suitably secure method <br>
+> $\hspace{3.5em}$     that ensures the last bit of $\mathsf{repr}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$ is $0$. Possible methods include direct generation <br>
+> $\hspace{3.5em}$     of an Orchard spend-authorizing key $\mathsf{ask} \;{\small ⦂}\; \mathbb{F}^{*}_{r_{\mathbb{P}}}$ followed by $\mathsf{ak}^{\mathbb{P}} = \mathsf{SpendAuthSig^{Orchard}.DerivePublic}(\mathsf{ask})$, <br>
+> $\hspace{3.5em}$     or FROST distributed key generation [^zip-0312-key-generation] in which the corresponding spend-authorization <br>
+> $\hspace{3.5em}$     material is $t$-of-$n$ shared among the participants. <br>
+> $\hspace{2.5em}$     let $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$ <br>
 > $\hspace{2.5em}$     let $\mathsf{qsk} = \mathsf{H^{qsk}}(\mathsf{sk})$ <br>
 > $\hspace{2.5em}$     let $\mathsf{qk} = \mathsf{H^{qk}}(\mathsf{qsk})$ <br>
 > $\hspace{2.5em}$     let $\mathsf{rivk} = \mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk})$ <br>
@@ -644,26 +647,19 @@ in the algorithm with:
 Add the following notes:
 
 > * If $\mathsf{ask}$, $\mathsf{ak}$, $\mathsf{nk}$, $\mathsf{rivk}$, and
->   $\mathsf{rivk_{internal}}$ are not generated as specified in this
->   section, then it may not be possible to recover the resulting notes as
->   specified in [ZIP 2005] in the event that attacks using quantum computers
->   become practical. In addition, to recover notes it is necessary to
->   retain, or be able to rederive the following information.
+>   $\mathsf{rivk\_internal}$ are not generated as specified in this section,
+>   then it may not be possible to recover the resulting notes as specified in
+>   [ZIP 2005] in the event that attacks using quantum computers become
+>   practical. In addition, to recover notes it is necessary to retain, or be
+>   able to rederive $\mathsf{sk}$, and also to know whether $\mathsf{use\_qsk}$
+>   was used to derive the $\mathsf{ivk}$ and addresses. When FROST is being
+>   used, it is also necessary to retain the group verifying key $\mathsf{ak}$
+>   and (collectively among the signers) the key material needed to make
+>   spend authorization signatures that can be verified using $\mathsf{ak}$.
 >
->    * When $\mathsf{use\_qsk}$ is $\mathsf{false}$: the secret key $\mathsf{sk}$.
->      This will be the case when $\mathsf{sk}$ is generated according to
->      [[ZIP-32]](https://zips.z.cash/zip-0032), and the master seed *or*
->      any secret key and chain code above $\mathsf{sk}$ in the derivation
->      hierarchy is retained.
->    * When $\mathsf{use\_qsk}$ is $\mathsf{true}$: the combination of the
->      full viewing key $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$, the
->      quantum spending key $\mathsf{qsk}$, and the ability to make spend
->      authorization signatures with $\mathsf{ask}$.
->
->    When the latter option is used, see
->    [[ZIP 2005, Usage with hardware wallets]](#usagewithhardwarewallets)
->    for recommendations on the storage of, and access to $\mathsf{qsk}$
->    and $\mathsf{qk}$.
+>   See [[ZIP 2005, Key storage options and analysis]](#keystorageoptionsandanalysis)
+>   for further discussion of storage requirements for $\mathsf{sk}$ and
+>   $\mathsf{qsk}$.
 
 #### § 4.7.2 ‘Sending Notes (Sapling)’
 
@@ -876,7 +872,7 @@ in the diagram in section ‘Orchard internal key derivation’
 > the diagram are not the only possibility. For further detail see
 > § 4.2.3 ‘Orchard Key Components’ in the protocol specification.
 > However, if $\mathsf{ask}$, $\mathsf{ak}$, $\mathsf{nk}$, $\mathsf{rivk}$,
-> and $\mathsf{rivk_{internal}}$ are not generated as in the diagram, then
+> and $\mathsf{rivk\_internal}$ are not generated as in the diagram, then
 > it may not be possible to recover the resulting notes as specified in
 > [ZIP 2005] in the event that attacks using quantum computers become
 > practical.

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -987,8 +987,9 @@ post-quantum knowledge-sound.
 
 $\mathsf{MerkleCRH^{Orchard}}$ is instantiated using
 $\mathsf{SinsimillaHash}$ [^protocol-concretesinsemillahash].
-Its collision resistance depends on the discrete log relation problem
-on the Pallas curve [^protocol-sinsemillasecurity], and so it is not
+Its collision resistance depends on the Discrete Logarithm Relation
+Problem on the Pallas curve [^protocol-sinsemillasecurity], and so it
+is not
 post-quantum collision-resistant or collapsing. However, because the note
 commitment tree is public, it is possible to re-hash all of its leaves to
 construct a new Merkle tree using a collapsing hash function.
@@ -1008,9 +1009,10 @@ note.
 ### Attacks against binding of note commitments
 
 We still face the problem that $\mathsf{NoteCommit^{Orchard}}$ is not
-binding against a discrete-log-breaking adversary: given the discrete log
-relations between bases, we can easily write a linear equation in the
-scalar field with multiple solutions of the inputs for a given commitment.
+binding against a discrete-log-breaking adversary: given the discrete
+logarithm relations between bases, we can easily write a linear equation
+in the scalar field with multiple solutions of the inputs for a given
+commitment.
 
 This allows an adversary to find two distinct notes corresponding to
 openings of $\mathsf{NoteCommit^{Orchard}}$ on the same commitment.
@@ -1116,9 +1118,9 @@ note fields.
 
 Note that the argument associated with
 [Theorem 5.4.4](https://zips.z.cash/protocol/protocol.pdf#thmsinsemillaex)
-in the protocol specification ("A $\bot$ output from
-$\mathsf{SinsemillaHashToPoint}$ yields a nontrivial discrete log relation."
-and "Since by assumption it is hard to find a nontrivial discrete logarithm
+in the protocol specification ("$\mathsf{SinsemillaHashToPoint}(\ldots) = \bot$
+yields a nontrivial discrete logarithm relation." and
+"Since by assumption it is hard to find a nontrivial discrete logarithm
 relation, we can argue that it is safe to use incomplete additions when
 computing Sinsemilla inside a circuit.") is not applicable when it is
 necessary to defend against a discrete-log-breaking or quantum adversary.

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -834,27 +834,6 @@ Add a note before the Abstract:
 This ZIP reflects the changes made to note encryption for the Canopy upgrade.
 It does not include subsequent changes in [ZIP 2005].
 
-#### ZIP 226
-
-Add the following to the section [Note Structure and Commitment](https://zips.z.cash/zip-0226#note-structure-and-commitment):
-
-> When § 4.7.3 ‘Sending Notes (Orchard)’ or § 4.8.3 ‘Dummy Notes (Orchard)’
-> are invoked directly or indirectly in the computation of $\text{ρ}$ and
-> $\text{ψ}$ for an OrchardZSA note, $\mathsf{leadByte}$ MUST be set to
-> $\mathtt{0x03}$.
-
-In section [Split Notes](https://zips.z.cash/zip-0226#split-notes), change:
-
-> where $\text{ψ}^{\mathsf{nf}}$ is sampled uniformly at random on
-> $\mathbb{F}_{q_{\mathbb{P}}}$, ...
-
-to
-
-> where $\text{ψ}^{\mathsf{nf}}$ is computed as
-> $\mathsf{H^{\text{ψ},Orchard}_{rseed\_nf}}(\underline{\text{ρ}}, 1) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed\_nf}}([\mathtt{0x0A}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$
-> for $\mathsf{rseed\_nf}$ sampled uniformly at random on $\mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[32]}$, ...
-
-
 # Rationale
 
 ## Cryptographic background

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -137,9 +137,7 @@ as changes necessary to implement Memo Bundles [^zip-0231] and/or ZSAs [^zip-022
   of that protocol's pre-quantum security.
 * The Recovery Protocol should ensure no loss of security against
   pre-quantum adversaries — including when FROST multisignatures and/or
-  hardware wallets are used. (This is motivated by the fact that there
-  is likely to be a period during which quantum attacks may be possible
-  but very difficult.)
+  hardware wallets are used.
 * Recovery of funds from hardware wallets that support this protocol
   should not require exposing the pre-quantum spend authorizing key
   $\mathsf{ask}$ to theft.
@@ -171,9 +169,11 @@ deployed alongside ZSAs [^zip-0226] [^zip-0227] and memo bundles
 same approach of defining a new note plaintext format, with lead byte
 $\mathtt{0x03}.$ The $\mathsf{pre\_rcm}$ value is computed differently
 for this new format, by including all of the note fields in
-$\mathsf{pre\_rcm}$. The resulting $\mathsf{rcm}$ is essentially a
-random function of the note fields — this allows us to argue that the
-overall commitment scheme is post-quantum binding, as long as the new
+$\mathsf{pre\_rcm}$. This means that an adversary constrained to treat
+the PRF used to derive $\mathsf{rcm}$ from $\mathsf{pre\_rcm}$ as a
+random oracle, could not vary any note field without producing a
+different $\mathsf{rcm}$. This lets us argue that the overall
+commitment scheme is post-quantum binding, as long as the new
 derivation of $\mathsf{rcm}$ is checked in the Recovery Protocol.
 
 Essentially the same technique also needs to be applied to the
@@ -345,33 +345,31 @@ and when the current Orchard protocol is disabled.
 
 The Recovery Protocol will still require a RedDSA signature verifiable by
 the Spend validating key $\mathsf{ak}$, in addition to knowledge of
-$\mathsf{qsk}$. Although RedDSA is not secure in the long term against a
-quantum or discrete-log-breaking adversary, the most likely eventuality is
-that attacks against it will be difficult for some years after the current
-Orchard protocol is disabled. During this period, checking this RedDSA
-signature in the Recovery Protocol will ensure that spend authorization by
-a $t$-of-$n$ threshold of participants continues to be needed against
-classical adversaries. This retains the usual advantage of FROST that the
-parties can sign using their shares *without* reconstructing the Spend
-authorizing key $\mathsf{ask}$. Coalitions of fewer than $t$ of the
-participants will be unable to authorize spends as long as they do not
-have access to a sufficiently powerful quantum computer.
+$\mathsf{qsk}$. RedDSA is not secure in the long term against a quantum
+or discrete-log-breaking adversary. However, during any period in which
+the adversary cannot find discrete logarithms on the Pallas curve,
+checking this RedDSA signature will ensure that spend authorization
+continues to require a $t$-of-$n$ threshold of participants.
+An important advantage of FROST —that the parties can sign using their
+shares *without* reconstructing $\mathsf{ask}$, the Spend authorizing
+key— is retained.
 
 Note that a quantum adversary may be able to steal the funds with only
-access to $\mathsf{qsk}$, which is held by every participant. Therefore,
-it is RECOMMENDED that as soon as a fully post-quantum protocol that
-supports multisignatures is available, all funds held under FROST keys
+access to $\mathsf{qsk}$, which is held by every participant (see below
+for more detail on [Key storage options](#keystorageoptionsandanalysis)).
+Therefore, it is RECOMMENDED that as soon as a fully post-quantum protocol
+that supports multisignatures is available, all funds held under FROST keys
 be transferred into that protocol's shielded pool.
 
 ## Usage with hardware wallets
 
 The same $\mathsf{use\_qsk}$ option can help to improve the efficiency of
-using the Recovery Protocol with hardware wallets. If the keys
-$\mathsf{rivk\_ext},$ $\mathsf{nk},$ and $\mathsf{ak}$ are generated from
-$\mathsf{sk},$ then the circuit for the Recovery Protocol will need to
-prove their correct derivation using $\mathsf{H^{rivk\_legacy}},$
-$\mathsf{H^{nk}},$ $\mathsf{H^{ask}},$ and $\mathsf{DerivePublic}$ as
-shown in the $\mathsf{SoK^{sk}}$ box of the diagram below.
+using the [Recovery Protocol](#proposedrecoveryprotocol) with hardware
+wallets. If the keys $\mathsf{rivk\_ext},$ $\mathsf{nk},$ and $\mathsf{ak}$
+are generated from $\mathsf{sk},$ then the circuit for the Recovery Protocol
+will need to prove their correct derivation using $\mathsf{H^{rivk\_legacy}},$
+$\mathsf{H^{nk}},$ $\mathsf{H^{ask}},$ and $\mathsf{DerivePublic}$ as shown
+in the $\mathsf{SoK^{sk}}$ box of the diagram below.
 
 ```mermaid
 graph BT
@@ -993,16 +991,16 @@ $\begin{array}{l}
 \hspace{6.7em} \wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})\,\big) \\
 \wedge\; \text{not } \mathsf{use\_qsk} \Rightarrow \mathsf{SoK^{sk}.Validate}\big((\mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}), \mathsf{SigHash}, \sigma_{\mathsf{sk}}\big) \\
 \wedge\; \mathsf{rivk} = \begin{cases}
-\mathsf{rivk\_ext}&\text{if } \mathsf{is\_rivk\_internal} = 0 \\
-\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})&\text{if } \mathsf{is\_rivk\_internal} = 1 \end{cases} \\
+\mathsf{rivk\_ext},&\text{if not } \mathsf{is\_internal\_rivk} \\
+\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}),&\text{if } \mathsf{is\_internal\_rivk} \end{cases} \\
 \wedge\; \mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}) \\
 \wedge\; \text{let } \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \\
 \wedge\; \mathsf{ivk} \not\in \{0, \bot\} \\
 \wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \\
 \wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}) \\
-\wedge\; \text{let } \mathsf{note\_repr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \\
-\wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{note\_repr}\big) \\
-\wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{note\_repr}) \\
+\wedge\; \text{let } \mathsf{noterepr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \\
+\wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{noterepr}\big) \\
+\wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) \\
 \wedge\; \mathsf{cm} \neq \bot \\
 \wedge\; \text{let } \mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}(\mathsf{cm}) \\
 \wedge\; \text{let } \mathsf{leaf} = \mathsf{MerkleCRH}(\mathsf{cm}_x, \text{ρ}) \\
@@ -1230,13 +1228,16 @@ desirable to switch to new addresses.
 
 ## Informal Security Argument
 
-The argument is that if $\mathsf{H^{rcm}}$ and $\mathsf{H^{\text{φ}}}$ are
-random oracles, $\mathsf{rcm}$ is an unpredictable function of the note fields.
-There are two values of $\mathsf{cm}$ that match $\mathsf{cm}_x$ in their
-$x$-coordinate. Because the output of $\mathsf{NoteCommit^{Orchard}}$ is of
-the form $\mathsf{cm} = F(\mathsf{note}) + [\mathsf{rcm}]\, \mathcal{R}$,
-for any given note we have exactly two values of $\mathsf{rcm}$ that will
-pass the commitment check.
+The informal security argument that we can only spend valid notes goes as
+follows:
+
+If $\mathsf{H^{rcm}}$ and $\mathsf{H^{\text{φ}}}$ are treated as random oracles,
+$\mathsf{rcm}$ is an unpredictable function of the note fields. There are two
+values of $\mathsf{cm}$ that match $\mathsf{cm}_x$ in their $x$-coordinate.
+Because the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$ is
+of the form $\mathsf{cm} = F(\mathsf{noterepr}) + [\mathsf{rcm}]\, \mathcal{R}$,
+for any given note we have exactly two values of $\mathsf{rcm}$ that will pass
+the commitment check.
 
 Suppose there are $N$ legitimate notes in the tree. The adversary is trying
 to find (possibly using a Grover search) a note that will pass the commitment

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -244,11 +244,7 @@ graph BT
     Commitivk ---> ivk([ivk])
     gd ---> ivkmul[［ivk］g<sub>d</sub>&nbsp;]:::func
     ivk --> ivkmul
-    split_flag([split_flag]) --> Hpsi
-    rsplit([rsplit]) -->|split_flag| rpsi{{rψ}}
-    rsplit ~~~ split_flag
-    rseed -->|¬split_flag| rpsi
-    rpsi --> Hpsi[H<sup>ψ</sup>]:::func
+    rseed --> Hpsi[H<sup>ψ</sup>]:::func
     rho --> Hpsi
     leadByte([leadByte]) ==> pre_rcm
     v([v, AssetBase]) ===> pre_rcm([pre_rcm])
@@ -614,14 +610,10 @@ Replace the lines deriving $\mathsf{rcm}$ and $\mathsf{esk}$ with
 
 #### § 4.7.3 ‘Sending Notes (Orchard)’
 
-If this proposal is to be deployed without ZSAs, add after the definition of
-$\mathsf{leadByte}$:
+Add after the definition of $\mathsf{leadByte}$:
 
 > Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
 > § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
-
-If it is deployed at the same time as ZSAs, it is assumed that $\mathsf{AssetBase}$
-will have been defined by the ZSA-related changes to § 4.7.3.
 
 Add before "For each Action description":
 
@@ -637,14 +629,9 @@ Add before "For each Action description":
 >
 > Define $\mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 >
-> Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, \mathsf{split\_flag}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathsf{split\_domain}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
-> where $\mathsf{split\_domain} = \begin{cases}
->   \mathtt{0x09},&\!\!\!\text{if } \mathsf{split\_flag} = 0 \\
->   \mathtt{0x0A},&\!\!\!\text{if } \mathsf{split\_flag} = 1\text{.}
-> \end{cases}$
+> Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x09}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 
-If this proposal is to be deployed without ZSAs, replace $\mathsf{split\_domain}$ with
-$\mathtt{0x09}$ above and elide its definition.
+The first-byte domain separator $\mathtt{0x0A}$ for $\mathsf{PRF^{expand}}$ is reserved by this ZIP for use by split notes in ZIP 226 [^zip-0226-split-notes].
 
 Insert before the derivation of $\mathsf{esk}$:
 
@@ -661,7 +648,7 @@ with
 
 > Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big)$
 
-> Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, \mathsf{split\_flag})$
+> Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
 #### § 4.8.2 ‘Dummy Notes (Sapling)’
 
@@ -676,8 +663,7 @@ Replace the line deriving $\mathsf{rcm}$ with
 
 #### § 4.8.3 ‘Dummy Notes (Orchard)’
 
-If this proposal is to be deployed without ZSAs, add after the definition of
-$\mathsf{leadByte}$:
+Add after the definition of $\mathsf{leadByte}$:
 
 > Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
 > § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
@@ -695,7 +681,7 @@ Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 >
 > Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big)$
 >
-> Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$
+> Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
 and use $\mathsf{g}\star_{\mathsf{d}}$, $\mathsf{pk}\star_{\mathsf{d}}$,
 and $\mathsf{AssetBase}\kern0.05em\star$ in the inputs to
@@ -703,14 +689,10 @@ $\mathsf{NoteCommit^{Orchard}}$.
 
 #### § 4.20.2 and § 4.20.3 ‘Decryption using an Incoming/Full Viewing Key (Sapling and Orchard)’
 
-If this proposal is to be deployed without ZSAs, add after the definition of
-$\mathsf{leadByte}$:
+Add after the definition of $\mathsf{leadByte}$:
 
 > Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
 > § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
-
-If it is deployed at the same time as ZSAs, it is assumed that $\mathsf{AssetBase}$
-will have been defined by the ZSA-related changes to § 4.20.2 and § 4.20.3.
 
 For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
 
@@ -766,7 +748,7 @@ with
 > 
 > $\hspace{1.0em}$ let $\mathsf{pk_d} = \mathsf{KA.DerivePublic}(\mathsf{ivk}, \mathsf{g_d})$ <br>
 > $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
-> $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$ for Orchard or $\bot$ for Sapling <br>
+> $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
 >                    \mathsf{H^{rcm,protocol}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big),&\!\!\!\text{otherwise}
@@ -792,7 +774,7 @@ with
 
 > $\hspace{1.0em}$ let $\mathsf{g_d} = \mathsf{DiversifyHash}(\mathsf{d})$. if (for Sapling) $\mathsf{g_d} = \bot$, return $\bot$ <br>
 > $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
-> $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$ for Orchard or $\bot$ for Sapling <br>
+> $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
 >                    \mathsf{H^{rcm,protocol}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big),&\!\!\!\text{otherwise}
@@ -880,11 +862,7 @@ Import these definitions from § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol
 >   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
 > \end{cases}$
 >
-> Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, \mathsf{split\_flag}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathsf{split\_domain}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
-> where $\mathsf{split\_domain} = \begin{cases}
->   \mathtt{0x09},&\!\!\!\text{if } \mathsf{split\_flag} = 0 \\
->   \mathtt{0x0A},&\!\!\!\text{if } \mathsf{split\_flag} = 1\text{.}
-> \end{cases}$
+> Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x09}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 
 Import this definition from § 5.4.7.1 ‘Spend Authorization Signature (Sapling and Orchard)’ [^protocol-concretespendauthsig]:
 
@@ -943,7 +921,7 @@ $\begin{array}{l}
 \wedge\; \text{let } \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \\
 \wedge\; \mathsf{ivk} \not\in \{0, \bot\} \\
 \wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \\
-\wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}, \mathsf{split\_flag}) \\
+\wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}) \\
 \wedge\; \text{let } \mathsf{note\_repr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \\
 \wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{note\_repr}\big) \\
 \wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{note\_repr}) \\
@@ -956,10 +934,6 @@ $\begin{array}{l}
 \end{array}$
 
 and $\mathsf{nf}$ is the revealed nullifier.
-
-TODO: finish extending this to ZSAs. We need to add $\text{ψ}^{\mathsf{nf}}$,
-and enforce $\mathsf{rseed\_nf} = \mathsf{rseed\_old}$ only if this is a
-non-split note.
 
 (We don't need to check the derivation of $\mathsf{g_d}$ from $\mathsf{d}$.)
 
@@ -1244,15 +1218,14 @@ Recovery circuit? As it turns out, no, but the argument is somewhat
 involved.
 
 TODO: this argument is too handwavy and depends on the ROM; it needs
-further work for a quantum adversary. Also it is incomplete because
-it does not consider split notes.
+further work for a quantum adversary.
 
 Since each function in the Recovery circuit is deterministic, the
 free variables that the adversary can control are the sources of the
 derivation digraph within that circuit and either $\mathsf{SoK^{sk}}$
 or $\mathsf{SoK^{qk}}$. That is, the adversary can control:
 
-* $(\text{ρ}, \mathsf{g_d}, \mathsf{split\_flag}, \mathsf{rseed}, \mathsf{rsplit}, \mathsf{is\_internal\_rivk}, \mathsf{use\_qsk})$ and
+* $(\text{ρ}, \mathsf{g_d}, \mathsf{rseed}, \mathsf{is\_internal\_rivk}, \mathsf{use\_qsk})$ and
     * $\mathsf{sk}$, when $\mathsf{use\_qsk} = \mathsf{false}$;
     * $(\mathsf{nk}, \mathsf{ak}, \mathsf{qsk})$, when $\mathsf{use\_qsk} = \mathsf{true}$.
 
@@ -1266,8 +1239,6 @@ of the values in the Recovery circuit that the adversary can control.
 We can then analyze $\mathsf{DeriveNullifier}$ in essentially the same
 way we analyzed $\mathsf{NoteCommit}$.
 
-First consider $\mathsf{split\_flag} = \mathsf{false}$.
-
 Recall that $\mathsf{DeriveNullifier}$ is defined in
 § 4.16 ‘Computing ρ values and Nullifiers’ as:
 
@@ -1277,8 +1248,7 @@ Also recall from [Repairing note commitments] that we have
 
 $$\mathsf{cm} = [\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
-When $\mathsf{split\_flag} = \mathsf{false}$, $\text{ψ}$ is determined
-by $\mathsf{rseed}$. The nullifier corresponding to
+$\text{ψ}$ is determined by $\mathsf{rseed}$. The nullifier corresponding to
 $(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ is
 then
 $$\mathsf{Extract}_{\mathbb{P}}\big([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}) + g(\mathsf{nk}, \text{ρ}, \mathsf{rseed})]\, \mathcal{R}\big)$$
@@ -1296,8 +1266,7 @@ $\mathsf{cm}$ and $\mathsf{nf}$:
 * because $\mathsf{g_d} \mapsto \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d}$ is 1-1, any
   change to $\mathsf{ivk}$ for a given $\mathsf{g_d}$ results in a change to $\mathsf{pk_d}$,
   which goes through $\mathsf{H^{rcm}}$;
-* when $\mathsf{split\_flag} = \mathsf{false}$, $\mathsf{rseed}$ goes through $\mathsf{H}^{\text{ψ}}$
-  and then $\mathsf{H^{rcm}}$;
+* $\mathsf{rseed}$ goes through $\mathsf{H}^{\text{ψ}}$ and then $\mathsf{H^{rcm}}$;
 * $\mathsf{use\_qsk}$ only has two possible values, and therefore can't increase the adversary's
   advantage by more than a factor of $2$ provided that both alternatives are otherwise secure;
 * when $\mathsf{use\_qsk} = \mathsf{false}$:
@@ -1317,8 +1286,6 @@ that some affect only $\mathsf{H^{rcm,Orchard}}$ and $f$, and others affect only
 oracles on all of their inputs.) But $\mathsf{noterepr}$ includes $\text{ρ}$, and we have
 already established that $\mathsf{nk}$ cannot be varied without affecting $\mathsf{pk_d}$.
 So with a little work we can see that such splitting is not possible.
-
-TODO $\mathsf{split\_flag} = \mathsf{true}$.
 
 An adversary could also attempt to cause a collision in $\mathsf{nf}$ by causing a
 collision on $\mathsf{Extract}_{\mathbb{P}}$, but this is also not feasible if
@@ -1416,6 +1383,8 @@ manipulate the note selection algorithm to some extent.
 [^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
 
 [^zip-0226]: [ZIP 226: Transfer and Burn of Zcash Shielded Assets](zip-0226.rst)
+
+[^zip-0226-split-notes]: [ZIP 226: Transfer and Burn of Zcash Shielded Assets — Split Notes](zip-0226.rst#split-notes)
 
 [^zip-0227]: [ZIP 227: Issuance of Zcash Shielded Assets](zip-0227.rst)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -988,9 +988,11 @@ non-split note.
 
 ### Cost
 
-Note that in the "$\mathsf{use\_qsk}$" case, two BLAKE2b compressions
-are required to compute $\mathsf{rivk\_ext}$, and in the
-"not $\mathsf{use\_qsk}$" cases, three BLAKE2b compressions in total
+Note that in the "$\mathsf{use\_qsk}$" case, one BLAKE2b compression
+is required to compute $\mathsf{rivk\_ext}$ (provided $\ell_{\mathsf{qk}} \leq 504$
+bits, so that the input $\mathsf{qk} \,||\, [\mathtt{0x0D}] \,||\, \mathsf{ak} \,||\, \mathsf{nk}$
+fits in a single 128-byte BLAKE2b block), and in the
+"not $\mathsf{use\_qsk}$" case, three BLAKE2b compressions in total
 are required to compute $\mathsf{H^{ask}}$, $\mathsf{H^{nk}}$, and
 $\mathsf{H^{rivk\_legacy}}$. Since these cases are mutually exclusive,
 it is possible to multiplex the same three compression function instances.
@@ -1000,10 +1002,11 @@ So, supporting "$\mathsf{use\_qsk}$" in addition to
 All of the operations below need to be implemented with complete additions,
 even if they are incomplete in the current Orchard[ZSA] circuit.
 
-* 9 BLAKE2b-512 compressions:
-  * 3 to compute $\mathsf{rivk\_ext}$
-  * 2 to compute $\mathsf{H^{rivk\_int}}$
-  * 2 to compute $\mathsf{H^{\text{ψ}}}$
+* 7 BLAKE2b-512 compressions:
+  * 3 multiplexed between $\mathsf{H^{rivk\_ext}}$ when $\mathsf{use\_qsk}$ is true (1 compression),
+    and $\mathsf{H^{ask}}$ + $\mathsf{H^{nk}}$ + $\mathsf{H^{rivk\_legacy}}$ when $\mathsf{use\_qsk}$ is false (3 compressions)
+  * 1 to compute $\mathsf{H^{rivk\_int}}$
+  * 1 to compute $\mathsf{H^{\text{ψ}}}$
   * 2 to compute $\mathsf{H^{rcm}}$
     * we could potentially save these two by using Poseidon to implement $\mathsf{H^{rcm}}$, but it seems not worth it.
 * 1 use of $\mathsf{H^{qk}}$
@@ -1014,7 +1017,7 @@ even if they are incomplete in the current Orchard[ZSA] circuit.
 * 1 Merkle tree path check
 * 1 additional use of $\mathsf{MerkleCRH}$ to compute $\mathsf{leaf}$.
 
-The expensive parts of this are the 9 BLAKE2b compressions.
+The expensive parts of this are the 7 BLAKE2b compressions.
 
 ## Security analysis
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -25,7 +25,7 @@ The character § is used when referring to sections of the Zcash Protocol
 Specification. [^protocol]
 
 The terms "Mainnet" and "Testnet" are to be interpreted as described in
-§ 3.12 ‘Mainnet and Testnet’. [^protocol-networks]
+§ 3.12 ‘Mainnet and Testnet’. [^protocol-networks]
 
 We use the convention followed in the protocol specification that an
 $\underline{\mathsf{underlined}}$ variable indicates a byte sequence,
@@ -303,7 +303,7 @@ This ZIP further constrains FROST key generation for Orchard as follows:
 participants MUST privately agree on a value $\mathsf{sk}$, and then use it
 with $\mathsf{use\_qsk} = \mathsf{true}$ to derive $\mathsf{nk}$, $\mathsf{qsk}$,
 $\mathsf{qk}$, and (using the $\mathsf{ak}$ output by the DKG protocol)
-$\mathsf{rivk\_ext}$, as specified in § 4.2.3 ‘Orchard Key Components’.
+$\mathsf{rivk\_ext}$, as specified in § 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents].
 
 ```mermaid
 graph BT
@@ -334,7 +334,7 @@ graph BT
 
 The protocol MUST ensure that all participants obtain the same values for
 $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk\_ext}$. (Provided that the
-participants have followed § 4.2.3, this implies that they have the same
+participants have followed § 4.2.3, this implies that they have the same
 $\mathsf{qsk}$ and $\mathsf{qk}$, by collision resistance of $\mathsf{H^{qk}}$
 and $\mathsf{H^{rivk\_ext}}$.)
 
@@ -496,18 +496,17 @@ with
 >   for Sapling with inputs $[\mathtt{0x04}]$ and $[\mathtt{0x05}]$,
 >   and for Orchard with first byte in
 >   $\{ \mathtt{0x05}, \mathtt{0x04}, \mathtt{0x09}, \mathtt{0x0A}, \mathtt{0x0B} \}$
->   ($\mathtt{0x0A}$ and $\mathtt{0x0B}$ are also specified in
->   {{ reference to this ZIP }});
+>   ($\mathtt{0x0A}$ and $\mathtt{0x0B}$ are also specified in [ZIP 2005]);
 
 Add
 
-> * in {{ reference to this ZIP }}, with first byte in
+> * in [ZIP 2005], with first byte in
 >   $\{ \mathtt{0x0A}, \mathtt{0x0B}, \mathtt{0x0C}, \mathtt{0x0D} \}$.
 
 #### § 4.2.3 ‘Orchard Key Components’
 
 Add $\ell_{\mathsf{qsk}}$ and $\ell_{\mathsf{qk}}$ to the constants obtained
-from § 5.3 ‘Constants’.
+from § 5.3 ‘Constants’ [^protocol-constants].
 
 Replace from "From this spending key" up to and including the line
 "let $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$"
@@ -518,17 +517,17 @@ in the algorithm with:
 > directly from $\mathsf{sk}$. However, this might not be the case for
 > protocols that require distributed generation of shares of $\mathsf{ask}$,
 > such as FROST's Distributed Key Generation [^zip-0312-key-generation]
-> (see {{ reference to the [Usage with FROST] section of this ZIP }} for
-> further discussion). To support this we define an alternative derivation
-> method using an additional "quantum spending key", $\mathsf{qsk}$, and
+> (see [[ZIP 2005, Usage with Frost]](#usagewithfrost) for further
+> discussion). To support this we define an alternative derivation method
+> using an additional "quantum spending key", $\mathsf{qsk}$, and
 > "quantum intermediate key", $\mathsf{qk}$.
 >
 > There can also be advantages to not deriving $\mathsf{ask}$ directly from
 > $\mathsf{sk}$ for hardware wallets, in order to separate the authority to
 > make proofs for the Recovery Protocol from the spend authorization key
-> that is kept on the device (see {{ reference to the [Usage with hardware wallets]
-> section of this ZIP }}). The derivation from $\mathsf{qsk}$ can also be
-> used in that case.
+> that is kept on the device (see
+> [[ZIP 2005, Usage with hardware wallets]](#usagewithhardwarewallets)).
+> The derivation from $\mathsf{qsk}$ can also be used in that case.
 >
 > Let $\mathsf{use\_qsk} \;{\small ⦂}\; \mathbb{B}$ be a flag that is set
 > to true when the derivation from $\mathsf{qsk}$ is used, or false if
@@ -579,24 +578,24 @@ Add the following notes:
 > * If $\mathsf{ask}$, $\mathsf{ak}$, $\mathsf{nk}$, $\mathsf{rivk}$, and
 >   $\mathsf{rivk_{internal}}$ are not generated as specified in this
 >   section, then it may not be possible to recover the resulting notes as
->   specified in {{ reference to this ZIP }} in the event that attacks
->   using quantum computers become practical. In addition, to recover
->   notes it is necessary to retain, or be able to rederive the following
->   information.
->   * When $\mathsf{use\_qsk}$ is $\mathsf{false}$: the secret key $\mathsf{sk}$.
->     This will be the case when $\mathsf{sk}$ is generated according to
->     [[ZIP-32]](https://zips.z.cash/zip-0032), and the master seed *or*
->     any secret key and chain code above $\mathsf{sk}$ in the derivation
->     hierarchy is retained.
->   * When $\mathsf{use\_qsk}$ is $\mathsf{true}$: the combination of the
->     full viewing key $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$, the
->     quantum spending key $\mathsf{qsk}$, and the ability to make spend
->     authorization signatures with $\mathsf{ask}$.
+>   specified in [ZIP 2005] in the event that attacks using quantum computers
+>   become practical. In addition, to recover notes it is necessary to
+>   retain, or be able to rederive the following information.
 >
->   When the latter option is used, see {{ reference to the
->   [Usage with hardware wallets] section of this ZIP }} for
->   recommendations on the storage of, and access to $\mathsf{qsk}$
->   and $\mathsf{qk}$.
+>    * When $\mathsf{use\_qsk}$ is $\mathsf{false}$: the secret key $\mathsf{sk}$.
+>      This will be the case when $\mathsf{sk}$ is generated according to
+>      [[ZIP-32]](https://zips.z.cash/zip-0032), and the master seed *or*
+>      any secret key and chain code above $\mathsf{sk}$ in the derivation
+>      hierarchy is retained.
+>    * When $\mathsf{use\_qsk}$ is $\mathsf{true}$: the combination of the
+>      full viewing key $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$, the
+>      quantum spending key $\mathsf{qsk}$, and the ability to make spend
+>      authorization signatures with $\mathsf{ask}$.
+>
+>    When the latter option is used, see
+>    [[ZIP 2005, Usage with hardware wallets]](#usagewithhardwarewallets)
+>    for recommendations on the storage of, and access to $\mathsf{qsk}$
+>    and $\mathsf{qk}$.
 
 #### § 4.7.2 ‘Sending Notes (Sapling)’
 
@@ -642,8 +641,8 @@ Add before "For each Action description":
 >
 > Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, \mathsf{split\_flag}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathsf{split\_domain}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 > where $\mathsf{split\_domain} = \begin{cases}
->   \mathtt{0x09}&\text{if } \mathsf{split\_flag} = 0 \\
->   \mathtt{0x0A}&\text{if } \mathsf{split\_flag} = 1\text{.}
+>   \mathtt{0x09},&\!\!\!\text{if } \mathsf{split\_flag} = 0 \\
+>   \mathtt{0x0A},&\!\!\!\text{if } \mathsf{split\_flag} = 1\text{.}
 > \end{cases}$
 
 If this proposal is to be deployed without ZSAs, replace $\mathsf{split\_domain}$ with
@@ -671,7 +670,7 @@ with
 Add
 
 > Let $\mathsf{H^{rcm,Sapling}}$ be as defined in
-> § 4.7.2 ‘Sending Notes (Sapling)’.
+> § 4.7.2 ‘Sending Notes (Sapling)’.
 
 Replace the line deriving $\mathsf{rcm}$ with
 
@@ -688,7 +687,7 @@ $\mathsf{leadByte}$:
 Insert before "The spend-related fields ...":
 
 > Let $\mathsf{H^{rcm,Orchard}}$ and $\mathsf{H^{\text{ψ},Orchard}}$ be
-> as defined in § 4.7.3 ‘Sending Notes (Orchard)’.
+> as defined in § 4.7.3 ‘Sending Notes (Orchard)’.
 
 Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 
@@ -701,7 +700,7 @@ Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}, 0)$
 
 and use $\mathsf{g}\star_{\mathsf{d}}$, $\mathsf{pk}\star_{\mathsf{d}}$,
-and $\mathsf{AssetBase}\kern0.08em\star$ in the inputs to
+and $\mathsf{AssetBase}\kern0.05em\star$ in the inputs to
 $\mathsf{NoteCommit^{Orchard}}$.
 
 #### § 4.20.2 and § 4.20.3 ‘Decryption using an Incoming/Full Viewing Key (Sapling and Orchard)’
@@ -717,14 +716,14 @@ will have been defined by the ZSA-related changes to § 4.20.2 and § 4.20.3.
 
 For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
 
-> Let $\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{\text{esk},Sapling}}$
-> be as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
+> Let $\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{esk,Sapling}}$
+> be as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
 >
-> Let $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{\text{esk},Orchard}}$,
+> Let $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{esk,Orchard}}$,
 > and $\mathsf{H^{\text{ψ},Orchard}}$ be as defined in
-> § 4.7.3 ‘Sending Notes (Orchard)’.
+> § 4.7.3 ‘Sending Notes (Orchard)’.
 
-For § 4.20.3, replace
+For § 4.20.3, replace
 
 > $\hspace{1.0em}$ if $\mathsf{esk} \geq r_{\mathbb{G}}$ or $\mathsf{pk_d} = \bot$, return $\bot$
 
@@ -737,7 +736,7 @@ and in the note containing "However, this is technically redundant with the
 later check that returns $\bot$ if $\mathsf{pk_d} \not\in \mathbb{J}^{(r)*}$",
 delete the word "later".
 
-For both § 4.20.2 and § 4.20.3, replace
+For both § 4.20.2 and § 4.20.3, replace
 
 > $\hspace{1.0em}$ for Sapling, let $\mathsf{pre\_rcm} = [4]$ and $\mathsf{pre\_esk} = [5]$ <br>
 > $\hspace{1.0em}$ for Orchard, let $\underline{\text{ρ}} = \mathsf{I2LEOSP}_{256}(\mathsf{nf^{old}}$ from the same Action description $\!)$, $\mathsf{pre\_rcm} = [5] \,||\, \underline{\text{ρ}}$, and $\mathsf{pre\_esk} = [4] \,||\, \underline{\text{ρ}}$
@@ -746,17 +745,17 @@ with
 
 > $\hspace{1.0em}$ let $\underline{\text{ρ}} = \mathsf{I2LEOSP}_{256}(\mathsf{nf^{old}}$ from the same Action description $\!)$
 
-For § 4.20.2, replace
+For § 4.20.2, replace
 
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{ToScalar}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})),&\!\!\!\text{otherwise}
+>                    \mathsf{ToScalar}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big),&\!\!\!\text{otherwise}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$ <br>
 > $\hspace{1.0em}$ let $\mathsf{g_d} = \mathsf{DiversifyHash}(\mathsf{d})$. if (for Sapling) $\mathsf{g_d} = \bot$, return $\bot$ <br>
 > $\hspace{1.0em}$ [**Canopy** onward] if $\mathsf{leadByte} \neq \mathtt{0x01}$: <br>
-> $\hspace{2.5em}$     $\mathsf{esk} = \mathsf{ToScalar^{protocol}}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_esk}))$ <br>
-> $\hspace{2.5em}$     if $\mathsf{repr}_{\mathbb{G}}(\mathsf{KA.DerivePublic}(\mathsf{esk}, \mathsf{g_d})) \neq \mathtt{ephemeralKey}$, return $\bot$
+> $\hspace{2.5em}$     $\mathsf{esk} = \mathsf{ToScalar^{protocol}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_esk})\kern-0.1em\big)$ <br>
+> $\hspace{2.5em}$     if $\mathsf{repr}_{\mathbb{G}}\big(\mathsf{KA.DerivePublic}(\mathsf{esk}, \mathsf{g_d})\kern-0.1em\big) \neq \mathtt{ephemeralKey}$, return $\bot$
 > 
 > $\hspace{1.0em}$ let $\mathsf{pk_d} = \mathsf{KA.DerivePublic}(\mathsf{ivk}, \mathsf{g_d})$
 
@@ -765,7 +764,7 @@ with
 > $\hspace{1.0em}$ let $\mathsf{g_d} = \mathsf{DiversifyHash}(\mathsf{d})$. if (for Sapling) $\mathsf{g_d} = \bot$, return $\bot$ <br>
 > $\hspace{1.0em}$ [**Canopy** onward] if $\mathsf{leadByte} \neq \mathtt{0x01}$: <br>
 > $\hspace{2.5em}$     let $\mathsf{esk} = \mathsf{H^{esk,protocol}_{rseed}}(\underline{\text{ρ}})$ <br>
-> $\hspace{2.5em}$     if $\mathsf{repr}_{\mathbb{G}}(\mathsf{KA.DerivePublic}(\mathsf{esk}, \mathsf{g_d})) \neq \mathtt{ephemeralKey}$, return $\bot$ <br>
+> $\hspace{2.5em}$     if $\mathsf{repr}_{\mathbb{G}}\big(\mathsf{KA.DerivePublic}(\mathsf{esk}, \mathsf{g_d})\kern-0.1em\big) \neq \mathtt{ephemeralKey}$, return $\bot$ <br>
 > 
 > $\hspace{1.0em}$ let $\mathsf{pk_d} = \mathsf{KA.DerivePublic}(\mathsf{ivk}, \mathsf{g_d})$ <br>
 > $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
@@ -779,14 +778,14 @@ with
 The order of operations has to be altered because the derivation of
 $\mathsf{rcm}$ can depend on $\mathsf{g_d}$ and $\mathsf{pk_d}$.
 The definitions of $\mathsf{pre\_rcm}$ and $\mathsf{pre\_esk}$ are moved into
-§ 4.7.2 ‘Sending Notes (Sapling)’ and § 4.7.3 ‘Sending Notes (Orchard)’ which
+§ 4.7.2 ‘Sending Notes (Sapling)’ and § 4.7.3 ‘Sending Notes (Orchard)’ which
 define $\mathsf{H^{rcm,protocol}}$.
 
-For § 4.20.3, replace
+For § 4.20.3, replace
 
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{ToScalar}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})),&\!\!\!\text{otherwise}
+>                    \mathsf{ToScalar}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big),&\!\!\!\text{otherwise}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$ <br>
 > $\hspace{1.0em}$ let $\mathsf{g_d} = \mathsf{DiversifyHash}(\mathsf{d})$. if (for Sapling) $\mathsf{g_d} = \bot$ or $\mathsf{pk_d} \not\in \mathbb{J}^{(r)*}$ (see note below), return $\bot$
@@ -802,7 +801,7 @@ with
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
-and delete "where $\text{ψ} = \mathsf{ToBase^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}([9] \,||\, \underline{\text{ρ}}))$".
+and delete "where $\text{ψ} = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([9] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$".
 
 #### § 5.3 ‘Constants’
 
@@ -821,12 +820,12 @@ in the diagram in section ‘Orchard internal key derivation’
 
 > $\ast$ The derivations of $\mathsf{ask}$ and $\mathsf{rivk}$ shown in
 > the diagram are not the only possibility. For further detail see
-> § 4.2.3 ‘Orchard Key Components’ in the protocol specification.
+> § 4.2.3 ‘Orchard Key Components’ in the protocol specification.
 > However, if $\mathsf{ask}$, $\mathsf{ak}$, $\mathsf{nk}$, $\mathsf{rivk}$,
 > and $\mathsf{rivk_{internal}}$ are not generated as in the diagram, then
 > it may not be possible to recover the resulting notes as specified in
-> {{ reference to this ZIP }} in the event that attacks using quantum
-> computers become practical.
+> [ZIP 2005] in the event that attacks using quantum computers become
+> practical.
 
 #### ZIP 212
 
@@ -835,13 +834,13 @@ Add a note before the Abstract:
 <div class="note"></div>
 
 This ZIP reflects the changes made to note encryption for the Canopy upgrade.
-It does not include subsequent changes in {{ reference to this ZIP }}.
+It does not include subsequent changes in [ZIP 2005].
 
 #### ZIP 226
 
 Add the following to the section [Note Structure and Commitment](https://zips.z.cash/zip-0226#note-structure-and-commitment):
 
-> When § 4.7.3 ‘Sending Notes (Orchard)’ or § 4.8.3 ‘Dummy Notes (Orchard)’
+> When § 4.7.3 ‘Sending Notes (Orchard)’ or § 4.8.3 ‘Dummy Notes (Orchard)’
 > are invoked directly or indirectly in the computation of $\text{ρ}$ and
 > $\text{ψ}$ for an OrchardZSA note, $\mathsf{leadByte}$ MUST be set to
 > $\mathtt{0x03}$.
@@ -958,7 +957,7 @@ such that the following conditions hold:
 $\begin{array}{l}
 \{\;\, \mathsf{use\_qsk} \Rightarrow \big(\;\, \mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}}) \\
 \hspace{6.7em} \wedge\; \mathsf{SoK^{qsk}.Validate}\big((\mathsf{qk}), \mathsf{SigHash}, \sigma_{\mathsf{qsk}}\big) \\
-\hspace{6.7em} \wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_qk}(\mathsf{ak}, \mathsf{nk})\,\big) \\
+\hspace{6.7em} \wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})\,\big) \\
 \wedge\; \text{not } \mathsf{use\_qsk} \Rightarrow \mathsf{SoK^{sk}.Validate}\big((\mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}), \mathsf{SigHash}, \sigma_{\mathsf{sk}}\big) \\
 \wedge\; \mathsf{rivk} = \begin{cases}
 \mathsf{rivk\_ext}&\text{if } \mathsf{is\_rivk\_internal} = 0 \\
@@ -1239,7 +1238,7 @@ choose to attack either):
   than to search for values of $\mathsf{sk}$ (possibly using a Grover search)
   to find one that reproduces a given $\mathsf{ivk}$. Since $\mathsf{ivk}$
   must be an $x$-coordinate of a Pallas curve point (see the note at the end of
-  [§ 4.2.3 Orchard Key Components](https://zips.z.cash/protocol/protocol.pdf#orchardkeycomponents)),
+  [§ 4.2.3 Orchard Key Components](https://zips.z.cash/protocol/protocol.pdf#orchardkeycomponents)),
   it can take on $(r_{\mathbb{P}}-1)/2$ values. So if there are $T$ targets
   the success probability for each attempt in a classical search is
   $2T/(r_{\mathbb{P}}-1)$, which is negligible provided that
@@ -1367,7 +1366,7 @@ As far as I'm aware, all existing Zcash wallets already derive
 $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ from a spending key
 $\mathsf{sk}$ in the way specified for the
 $\mathsf{use\_qsk} = \mathsf{false}$ case in
-[§ 4.2.3 Orchard Key Components](https://zips.z.cash/protocol/protocol.pdf#orchardkeycomponents).
+§ 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents].
 
 FROST distributed key generation requires the $\mathsf{use\_qsk} = \mathsf{true}$ case.
 There is no significant existing deployment of FROST, so we can
@@ -1376,7 +1375,7 @@ from the start.
 
 The part of the protocol that is new is the different input for
 $\mathsf{pre\_rcm}$. It would have been possible to use a separate
-pq-binding commitment, but $\mathsf{H^rcm}$ is already pq-binding and so
+pq-binding commitment, but $\mathsf{H^{rcm}}$ is already pq-binding and so
 doing it this way involves fewer components. This also allows us to avoid
 any security compromise and use 256-bit cryptovalues for both integrity
 and randomization, which would otherwise have been difficult.


### PR DESCRIPTION
## Summary

A series of fixes and clarifications to ZIP 2005 (Orchard Quantum Recoverability), starting with renaming the ZIP from "Quantum Recoverability" to "Orchard Quantum Recoverability".

Notable substantive items:

- **Cost-section recount** — the Recovery circuit's BLAKE2b-512 compression count was 9 in the previous draft; recounting against the actual $\mathsf{H^*}$ definitions gives 7. Adds the $\ell_{\mathsf{qk}} \leq 504$ bits constraint that keeps the $\mathsf{H}^{\textsf{rivk-ext}}$ input within a single 128-byte BLAKE2b block. (Discussion in [#1135](https://github.com/zcash/zips/issues/1135#issuecomment-4319689606).)
- **Byte-tag list tightening for $\mathsf{PRF^{expand}}$** — consolidates $\{\mathtt{0x0C}, \mathtt{0x0D}, \mathtt{0x82}\}$ into a single set in the protocol-spec edit block; drops the now-stale "(also specified in ZIP-32)" parenthetical for $\mathtt{0x82}$; adds protocol-section footnote references.
- **Boolean phrasing in the Informal Security Argument** — replaces "Case $\textsf{use-qsk} = 0$" / "Case $\textsf{use-qsk} = 1$" with "Case $\text{not } \textsf{use-qsk}$" / "Case $\textsf{use-qsk}$" to match the boolean type defined in § 4.2.3. Also fixes the prior $\textsf{use-qsk} = 0$ / $\textsf{use-qsk} = 0$ typo where both cases were labelled with the same value (flagged in #1135).
- **ZIP 312 reference** — points at #895 (the current home of the $\textsf{use-qsk}$-supporting key generation changes) instead of the superseded #883.

Plus ZSA-activation phrasing in § 4.2.3 changes and a few smaller cosmetic items.

## Relationship to other PRs

- **Decoupled from #1156** (extensible tx format) — this PR no longer depends on or includes any ZIP 248 commits.
- **Companion to the $(\mathsf{dk}, \mathsf{ovk})$ refactor PR #1262** — the refactor PR touches `protocol/protocol.tex` + `zips/zip-0032.rst`; this PR touches `README.rst` + `zips/zip-2005.md`. Disjoint file sets — landing order doesn't matter.

## Discussion

[#1135 — \[ZIP 2005\] Quantum Recoverability](https://github.com/zcash/zips/issues/1135).

🤖 Filed with [Claude Code](https://claude.com/claude-code) (description; the substantive ZIP work is by @daira).
