### PR TITLE
[ZIP 231] Update abstract and motivation to clarify memo bundle data savings.

### DIFF
--- a/zips/zip-0231.md
+++ b/zips/zip-0231.md
@@ -34,8 +34,8 @@ The terms "Mainnet" and "Testnet" are to be interpreted as described in
 Currently, the memo associated with a shielded output is fixed to 512 bytes of data.
 
 This ZIP proposes to decouple memo data from outputs. This will:
-* reduce the default memo data of a transaction from a minimum of 1024 bytes to
-  approximately 576 bytes;
+* reduce the memo data of a transaction with two shielded outputs from a minimum
+  of 1024 bytes to approximately 576 bytes;
 * allow larger memos, with a proportionate increase in fees;
 * enable memo data to be shared between multiple recipients of a transaction;
 * enable memo data to be pruned from a stored transaction without impairing the


### PR DESCRIPTION
In the aftermath of the recent coin-weighted vote, it became clear that the data-saving motivations for separating memos from transaction outputs had not been clearly represented in the draft ZIP. This alters the abstract and motivation sections to clarify this point.