### PR TITLE
[ZIP TBD] Orchard Proof-of-Balance

### DIFF
--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -171,7 +171,7 @@ specification is out of scope for this document.
 
 **Hardware wallet device exposure.** When the PCZT-based hardware wallet
 signing flow (see [Hardware Wallet Signing]) is used, the device observes
-the governance PCZT but learns no information about the holder's real
+the PCZT but learns no information about the holder's real
 Orchard balance or delegation context. The PCZT contains a 1-zatoshi
 dummy note with no on-chain counterpart; the holder's actual note
 commitments, values, and nullifiers are never transmitted to the device.
@@ -686,7 +686,7 @@ The delegation signing flow proceeds in five steps:
 1. The wallet generates a governance hotkey on the local device.
 2. The wallet constructs a dummy signed note whose nullifier commits
    to the delegation context.
-3. The wallet builds a governance PCZT containing the dummy signed note.
+3. The wallet builds a PCZT containing the dummy signed note.
 4. The hardware wallet device signs the PCZT and returns the signature.
 5. The wallet extracts the signature and assembles the delegation
    submission.
@@ -748,10 +748,9 @@ scope) from the holder's full viewing key. These padding notes enter
 the $\text{ρ}$ commitment via their $\mathsf{cmx}$ values but do not
 correspond to real on-chain notes.
 
-### Governance PCZT Construction
+### PCZT Construction
 
-The wallet constructs a governance PCZT as a single-action Orchard
-transaction:
+The wallet constructs a PCZT as a single-action Orchard transaction:
 
 #### Spend Side
 
@@ -791,8 +790,8 @@ IoFinalizer computes the ZIP 244 [^zip-244] transaction identifier
 
 ### Device Display
 
-During signing, the hardware wallet device displays the governance PCZT
-as a standard Orchard transaction. The user sees fields such as:
+During signing, the hardware wallet device displays the PCZT as a
+standard Orchard transaction. The user sees fields such as:
 
     Amount: 0.00000001 ZEC
     Fee: 0 ZEC
@@ -815,8 +814,7 @@ governance hotkey address displayed in the wallet application. The memo
 provides human-readable context for what the user is authorizing.
 
 The hardware wallet device has no awareness of governance semantics. It
-interprets the governance PCZT identically to any other Orchard
-transaction.
+interprets the PCZT identically to any other Orchard transaction.
 
 ### Signature Extraction and Submission
 
@@ -830,7 +828,7 @@ wallet:
    rather than by byte-diffing against the unsigned version.
 
 2. Extracts the sighash that the device signed. This is the ZIP 244
-   transaction identifier computed over the governance PCZT.
+   transaction identifier computed over the PCZT.
 
 3. Assembles the delegation submission by combining the hardware wallet
    signature and sighash with the Delegation Proof and other public
@@ -888,7 +886,7 @@ smaller ones, so the width bound is maintained permanently.
 ## Why 1 Zatoshi Instead of 0
 
 The dummy signed note uses a value of 1 zatoshi (0.00000001 ZEC) in the
-governance PCZT rather than 0. When an Orchard Action has a 0-value
+PCZT rather than 0. When an Orchard Action has a 0-value
 note, Keystone's suppress the display of transaction fields
 (amount, fee, addresses, memo), presenting the user with insufficient
 information to make an informed signing decision. Setting the value to
@@ -906,7 +904,7 @@ delegation. The dummy signed note is constructed specifically for
 governance and never appears in any on-chain note commitment tree. This
 design has three advantages:
 
-- **No fund risk.** Because the governance PCZT is never broadcast to
+- **No fund risk.** Because the PCZT is never broadcast to
   the Zcash mainchain and the signed note has no on-chain existence,
   there is no scenario in which the delegation signing could result in
   loss of funds.
@@ -918,7 +916,7 @@ design has three advantages:
   can participate in concurrent voting rounds or other balance-proof
   use cases without conflict.
 - **PCZT compatibility.** The dummy note reuses the standard Orchard
-  Action structure, allowing the governance PCZT to pass through the
+  Action structure, allowing the PCZT to pass through the
   hardware wallet's existing PCZT parser and signer without
   modification.
 
@@ -943,7 +941,7 @@ compatible without firmware changes.
 
 ## Why ZIP 244 Sighash
 
-The governance PCZT uses the standard ZIP 244 [^zip-244] transaction
+The PCZT uses the standard ZIP 244 [^zip-244] transaction
 identifier as the sighash. This is the only sighash format that
 existing hardware wallet Orchard signing implementations can produce.
 Using a governance-specific sighash would require firmware changes,

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -67,10 +67,6 @@ Dummy signed note
   solely for obtaining a spend authorization signature from the holder's
   key. See [Wallet Signing].
 
-The terms "Vote Authority Note (VAN)", "governance nullifier", "voting
-round", "governance hotkey", and "ballot" are defined in the Shielded
-Voting Protocol ZIP [^voting-protocol].
-
 
 # Abstract
 
@@ -135,7 +131,7 @@ keys on hardware wallets such as Keystone. Without a delegation mechanism,
 hardware wallet users must either export their spending keys to software
 (negating the security benefit of hardware custody) or forgo participation entirely.
 This ZIP therefore specifies a PCZT-based signing flow (see
-[Hardware Wallet Signing]) that works with any hardware wallet supporting
+[Wallet Signing]) that works with any hardware wallet supporting
 Orchard PCZT signing today, requiring no firmware changes.
 
 
@@ -175,13 +171,14 @@ the PCZT but learns no information about the holder's real
 Orchard balance or delegation context. The PCZT contains a 1-zatoshi
 dummy note with no on-chain counterpart; the holder's actual note
 commitments, values, and nullifiers are never transmitted to the device.
-The VAN commitment, governance nullifiers, and voting round identifier are
+The application commitment, alternate nullifiers, and usage identifier are
 committed via the dummy note's nullifier inside the ZKP circuit and
-do not appear as plaintext fields in the PCZT. The output address (governance hotkey) is
-visible on the device but is freshly generated per voting round and is not
-linked to the holder's on-chain Orchard addresses. An attacker with
-physical access to the device during signing learns only that the holder
-is participating in a governance round and the declared voting weight.
+do not appear as plaintext fields in the PCZT. The output address
+(application hotkey) is visible on the device but is freshly generated
+per usage instance and is not linked to the holder's on-chain Orchard
+addresses. An attacker with physical access to the device during signing
+learns only that the holder is participating in a proof-of-balance
+instance and the declared balance.
 
 
 # Requirements
@@ -206,8 +203,8 @@ is participating in a governance round and the declared voting weight.
   air-drop distribution, or delegation) are out of scope.
 - Privacy-preserving retrieval of non-membership Merkle paths (e.g., via
   PIR) is out of scope.
-- Value denomination conversions (e.g., converting zatoshi to ballot
-  counts) are application-specific and out of scope.
+- Value denomination conversions (e.g., converting zatoshi to
+  application-specific units) are out of scope.
 - Transaction-level encoding of claims is out of scope; this ZIP specifies
   only the proof statement and its verification.
 
@@ -681,9 +678,9 @@ distinguishes real notes from padded notes:
 
 ## Wallet Signing
 
-The delegation signing flow proceeds in five steps:
+The signing flow proceeds in five steps:
 
-1. The wallet generates a governance hotkey on the local device.
+1. The wallet generates an application hotkey on the local device.
 2. The wallet constructs a dummy signed note whose nullifier commits
    to the delegation context.
 3. The wallet builds a PCZT containing the dummy signed note.
@@ -691,12 +688,12 @@ The delegation signing flow proceeds in five steps:
 5. The wallet extracts the signature and assembles the delegation
    submission.
 
-Each interaction with the hardware wallet device delegates up to 5
-Orchard notes (the per-delegation batch size defined in
-[^voting-protocol]). A holder with more than 5 notes repeats the flow
-for each batch of up to 5, producing a separate VAN per batch. The
-holder MAY choose to delegate fewer batches than their full note set,
-voting with only the balance covered by the delegated batches.
+Each interaction with the hardware wallet device delegates up to
+$N_{\max}$ Orchard notes (the default batch size is 5). A holder with
+more than $N_{\max}$ notes repeats the flow for each batch, producing a
+separate application commitment per batch. The holder MAY choose to
+delegate fewer batches than their full note set, claiming only the
+balance covered by the delegated batches.
 
 ### Dummy Signed Note Construction
 
@@ -718,17 +715,20 @@ The wallet constructs a dummy Orchard note as follows:
 
    Concretely, the signed note's $\text{ρ}$ is set to:
 
-$$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1}, \mathsf{cmx}\_\mathsf{2}, \mathsf{cmx}\_\mathsf{3}, \mathsf{cmx}\_\mathsf{4}, \mathsf{cmx}\_\mathsf{5}, \mathsf{van}, \mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}\bigr)$$
+$$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1}, \ldots, \mathsf{cmx}\_{N_{\max}}, \mathsf{app\_commitment}, \mathsf{instance\_id}\bigr)$$
 
-   where $\mathsf{cmx}\_\mathsf{1} \ldots \mathsf{cmx}\_\mathsf{5}$ are the
-   extracted note commitments of the 5 delegated note slots (real notes
-   plus zero-value padding notes), $\mathsf{van}$ is the VAN commitment
-   as defined in [^voting-protocol], and
-   $\mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}$ is the round identifier.
+   where $\mathsf{cmx}\_\mathsf{1} \ldots \mathsf{cmx}\_{N_{\max}}$ are the
+   extracted note commitments of the $N_{\max}$ delegated note slots
+   (real notes plus zero-value padding notes),
+   $\mathsf{app\_commitment}$ is an application-defined commitment
+   (e.g., a VAN commitment in the voting protocol [^voting-protocol]),
+   and $\mathsf{instance\_id}$ is the usage identifier that uniquely
+   identifies the proof-of-balance instance.
 
-   This is a 7-input Poseidon hash using the $\mathsf{P128Pow5T3}$
-   instantiation (width $t = 3$, rate 2) over $\mathbb{F}_{q_{\mathbb{P}}}$.
-   The seven inputs are absorbed in four permutations.
+   With $N_{\max} = 5$ this is a 7-input Poseidon hash using the
+   $\mathsf{P128Pow5T3}$ instantiation (width $t = 3$, rate 2) over
+   $\mathbb{F}_{q_{\mathbb{P}}}$. The seven inputs are absorbed in four
+   permutations.
 
 3. **Value.** The note value MUST be set to 1 zatoshi (0.00000001 ZEC)
    in the PCZT so that the hardware wallet device renders all transaction
@@ -742,11 +742,11 @@ $$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1},
    note construction using the address, value (1 zatoshi), rho, and
    rseed above.
 
-For fewer than 5 real notes, the wallet pads the remaining slots with
-zero-value dummy notes at diversifier indices $1000 + i$ (external
-scope) from the holder's full viewing key. These padding notes enter
-the $\text{ρ}$ commitment via their $\mathsf{cmx}$ values but do not
-correspond to real on-chain notes.
+For fewer than $N_{\max}$ real notes, the wallet pads the remaining
+slots with zero-value dummy notes at diversifier indices $1000 + i$
+(external scope) from the holder's full viewing key. These padding notes
+enter the $\text{ρ}$ commitment via their $\mathsf{cmx}$ values but do
+not correspond to real on-chain notes.
 
 ### PCZT Construction
 
@@ -764,13 +764,14 @@ The wallet constructs a PCZT as a single-action Orchard transaction:
 
 #### Output Side
 
-- A single output of 1 zatoshi is addressed to the governance hotkey.
-- The output memo SHOULD contain a human-readable delegation description:
+- A single output of 1 zatoshi is addressed to the application hotkey.
+- The output memo SHOULD contain a human-readable delegation description.
+  For example, a voting application might use:
 
-  `"I am authorizing this hotkey managed by my wallet to vote on`
-  `{round_name} with {amount}.{frac} ZEC."`
+  `"I am authorizing this hotkey managed by my wallet to participate`
+  `in {instance_name} with {amount}.{frac} ZEC."`
 
-  where `{round_name}` is the voting round title and
+  where `{instance_name}` identifies the proof-of-balance instance and
   `{amount}.{frac}` is the holder's eligible ZEC balance.
 
 #### ZIP-32 Derivation
@@ -803,17 +804,17 @@ standard Orchard transaction. The user sees fields such as:
 
     To
     #1 0.00000001 ZEC
-    {governance hotkey address}
+    {application hotkey address}
     Memo: I am authorizing this hotkey managed by my
-          wallet to vote on {round_name} with
+          wallet to participate in {instance_name} with
           {amount}.{frac} ZEC
 
 The 0.00000001 ZEC amount (1 zatoshi) and 0 ZEC fee confirm that no
 real funds are being transferred. The "To" address matches the
-governance hotkey address displayed in the wallet application. The memo
+application hotkey address displayed in the wallet application. The memo
 provides human-readable context for what the user is authorizing.
 
-The hardware wallet device has no awareness of governance semantics. It
+The hardware wallet device has no awareness of application semantics. It
 interprets the PCZT identically to any other Orchard transaction.
 
 ### Signature Extraction and Submission
@@ -831,14 +832,13 @@ wallet:
    transaction identifier computed over the PCZT.
 
 3. Assembles the delegation submission by combining the hardware wallet
-   signature and sighash with the Delegation Proof and other public
-   inputs. The full delegation message structure is defined in the
-   Delegation Message section of [^voting-protocol].
+   signature and sighash with the Claim proof and other public inputs.
+   The submission format is application-defined.
 
-The delegation submission is sent to the vote chain. The wallet does
-not need the hardware wallet device again for the remainder of the
-voting round; all subsequent operations (voting, share submission) use
-the governance hotkey.
+The delegation submission is sent to the application verifier. The
+wallet does not need the hardware wallet device again for the remainder
+of the usage instance; all subsequent operations use the application
+hotkey.
 
 # Rationale
 
@@ -890,7 +890,7 @@ PCZT rather than 0. When an Orchard Action has a 0-value
 note, Keystone's suppress the display of transaction fields
 (amount, fee, addresses, memo), presenting the user with insufficient
 information to make an informed signing decision. Setting the value to
-1 zatoshi causes the device to render allfields normally.
+1 zatoshi causes the device to render all fields normally.
 
 The Claim circuit enforces that the signed note value is 0 regardless of
 the PCZT value. The 1-zatoshi value exists solely in the serialized PCZT
@@ -900,21 +900,20 @@ protocol security or fund safety.
 ## Why a Dummy Note Instead of a Real Note
 
 A holder's real Orchard notes are not spent or consumed during
-delegation. The dummy signed note is constructed specifically for
-governance and never appears in any on-chain note commitment tree. This
-design has three advantages:
+delegation. The dummy signed note is constructed specifically for the
+proof-of-balance flow and never appears in any on-chain note commitment
+tree. This design has three advantages:
 
-- **No fund risk.** Because the PCZT is never broadcast to
-  the Zcash mainchain and the signed note has no on-chain existence,
+- **No fund risk.** Because the PCZT is never broadcast
+  to the Zcash mainchain and the signed note has no on-chain existence,
   there is no scenario in which the delegation signing could result in
   loss of funds.
 - **Note reusability.** Because real notes are never consumed on
   mainchain, they remain fully spendable and available for other
-  applications that use the proof-of-balance mechanism. Governance
-  nullifiers are domain-separated by
-  $\mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}$, so the same notes
-  can participate in concurrent voting rounds or other balance-proof
-  use cases without conflict.
+  applications that use the proof-of-balance mechanism. Alternate
+  nullifiers are domain-separated by $\mathsf{instance\_id}$, so the
+  same notes can participate in concurrent proof-of-balance instances
+  without conflict.
 - **PCZT compatibility.** The dummy note reuses the standard Orchard
   Action structure, allowing the PCZT to pass through the
   hardware wallet's existing PCZT parser and signer without
@@ -925,16 +924,17 @@ design has three advantages:
 Because the dummy signed note does not correspond to any on-chain note,
 its inputs can be freely chosen. The design sets
 $\text{ρ}^{\mathsf{signed}}$ to a Poseidon hash of the delegated note
-commitments, the VAN, and the voting round identifier. Because
-$\text{ρ}$ enters the note commitment (and therefore the sighash), the
-hardware wallet's signature is cryptographically bound to the exact
-delegation context. An attacker cannot replay the signature for a
-different set of notes, a different VAN, or a different voting round.
+commitments, the application commitment, and the usage identifier.
+Because $\text{ρ}$ enters the note commitment (and therefore the
+sighash), the hardware wallet's signature is cryptographically bound to
+the exact delegation context. An attacker cannot replay the signature
+for a different set of notes, a different application commitment, or a
+different usage instance.
 
-This binding is enforced by the Claim circuit, which the vote chain
-verifies. The hardware wallet device does not need to understand the
-binding; it is sufficient that the device signs the sighash derived from
-the PCZT containing the committed $\text{ρ}$. No custom signing
+This binding is enforced by the Claim circuit, which the application
+verifier checks. The hardware wallet device does not need to understand
+the binding; it is sufficient that the device signs the sighash derived
+from the PCZT containing the committed $\text{ρ}$. No custom signing
 protocol is required — the standard Orchard PCZT flow is reused, and
 all existing hardware wallets that support Orchard signing are
 compatible without firmware changes.
@@ -944,7 +944,7 @@ compatible without firmware changes.
 The PCZT uses the standard ZIP 244 [^zip-244] transaction
 identifier as the sighash. This is the only sighash format that
 existing hardware wallet Orchard signing implementations can produce.
-Using a governance-specific sighash would require firmware changes,
+Using an application-specific sighash would require firmware changes,
 which this specification explicitly avoids.
 
 The ZIP 244 sighash commits to the full Orchard bundle structure
@@ -982,26 +982,27 @@ this ZIP.
 
 # Open issues
 
-- **v2 hardware wallet signing with a new transaction format.** The
-  hardware wallet signing flow specified in this ZIP (v1) reuses the
-  existing Orchard PCZT format and requires no firmware changes from any
-  custodian. A v2 of the protocol could introduce a new transaction
-  format purpose-built for token holder voting, enabling:
+- **v2 signing with a new transaction format.** The signing flow
+  specified in this ZIP (v1) reuses the existing Orchard PCZT format and
+  requires no firmware changes from any hardware wallet vendor. A v2 of
+  the protocol could introduce a new transaction format purpose-built for
+  proof-of-balance, enabling:
 
   - Finer-grained delegation from a hardware wallet to a hotkey, without
     requiring the ZK circuit to verify blake2b.
-  - Combination of the first and second ZKPs in the voting design into a
-    single proof.
-  - Better UX for what the user is signing over, with governance-aware
+  - Reduction in the number of ZKPs required by downstream application
+    protocols.
+  - Better UX for what the user is signing over, with application-aware
     context display on the device screen.
 
-  However, v2 would require a firmware update, and then every one of those users
-  would need to update their device before they could vote.
+  However, v2 would require a firmware update, and every user of a
+  hardware wallet would need to update their device before they could
+  participate.
 
   If both v1 (compatible with the base Zcash transaction format) and v2
-  (governance-specific format) are supported simultaneously, the system
+  (application-specific format) are supported simultaneously, the system
   SHOULD NOT publicly leak which custody method or protocol version a
-  voter is using. This will come with proving and format overheads whose
+  holder is using. This will come with proving and format overheads whose
   design can be determined closer to the time of v2 deployment.
 
 - **Memo content standardization.** The delegation memo format is

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -346,20 +346,24 @@ Given a nullifier domain $\mathsf{dom}$ and an Orchard note with standard
 nullifier $\mathsf{nf^{old}}$, the alternate nullifier $\mathsf{nf_ {dom}}$
 is computed as:
 
-$$\mathsf{nf_ {dom}} = \mathsf{DeriveAlternateNullifier_ {nk}}(\mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$$
+$$\mathsf{nf_ {dom}} = \mathsf{DeriveAlternateNullifier_ {nk}}(\mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$$
 
 where:
 
 - $\mathsf{nk} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier deriving
   key from the holder's full viewing key.
+- $\mathsf{tag} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is an application-defined
+  domain separator constant that identifies the protocol type (e.g.,
+  governance, air-drop). This value is fixed per application and known to
+  both prover and verifier.
 - $\mathsf{dom} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier domain.
 - $\mathsf{nf^{old}} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the note's
   standard Orchard nullifier, computed as
   $\mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
-This is a 3-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
+This is a 4-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
 instantiation (width $t = 3$, rate 2), this requires two permutations
-to absorb three input elements.
+to absorb four input elements.
 
 ### Properties
 
@@ -383,23 +387,23 @@ The security of the alternate nullifier derivation relies on Poseidon
 being a pseudorandom function (PRF) when keyed with a uniformly random
 element of $\mathbb{F}_ {q_ {\mathbb{P}}}$.
 
-**Unlinkability.** Model $\mathsf{Poseidon}(\mathsf{nk}, \cdot, \cdot)$
+**Unlinkability.** Model $\mathsf{Poseidon}(\mathsf{nk}, \cdot, \cdot, \cdot)$
 as a PRF keyed by $\mathsf{nk}$. An adversary who does not know
 $\mathsf{nk}$ sees outputs that are indistinguishable from random. Given
-$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$
 and $\mathsf{nf^{old}}$, the adversary cannot verify the relationship
 without $\mathsf{nk}$. The nullifier deriving key $\mathsf{nk}$ is a
 255-bit value derived from the spending key and is never revealed on-chain.
 
 **Cross-domain unlinkability.** For two domains $\mathsf{dom_ 1} \neq \mathsf{dom_ 2}$,
-the pairs $(\mathsf{dom_ 1}, \mathsf{nf^{old}})$ and
-$(\mathsf{dom_ 2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
+the tuples $(\mathsf{tag}, \mathsf{dom_ 1}, \mathsf{nf^{old}})$ and
+$(\mathsf{tag}, \mathsf{dom_ 2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
 Under the PRF assumption, their outputs are jointly indistinguishable from
 independent random values.
 
 **Collision resistance.** If $\mathsf{nf^{old}_ 1} \neq \mathsf{nf^{old}_ 2}$,
-then $(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_ 1})$ and
-$(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_ 2})$ are distinct Poseidon
+then $(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}_ 1})$ and
+$(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}_ 2})$ are distinct Poseidon
 inputs, so their outputs collide with negligible probability under
 Poseidon's collision resistance.
 
@@ -463,6 +467,7 @@ the prover knows an auxiliary input:
 - $\mathsf{ak}^{\mathbb{P}} ⦂ \mathbb{P}^*$
 - $\mathsf{nk} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{rivk} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
+- $\mathsf{rivk\_ {internal}} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
 - $\alpha ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
 - $\mathsf{low} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{width} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
@@ -496,9 +501,12 @@ check and the alternate nullifier derivation. It is never revealed.
 $\mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}})$.
 
 **Diversified address integrity.** $\hspace{0.5em}$
-$\mathsf{ivk} = \bot$ or $\mathsf{pk_ d^{old}} = [\mathsf{ivk}]\, \mathsf{g_ d^{old}}$
-where
-$\mathsf{ivk} = \mathsf{Commit^{ivk}_ {rivk}}(\mathsf{Extract}_ {\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}), \mathsf{nk})$.
+Let
+$\mathsf{ivk} = \mathsf{Commit^{ivk}_ {rivk}}(\mathsf{Extract}_ {\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}), \mathsf{nk})$
+and
+$\mathsf{ivk\_ {internal}} = \mathsf{Commit^{ivk}_ {rivk\_ {internal}}}(\mathsf{Extract}_ {\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}), \mathsf{nk})$.
+Then $\mathsf{pk_ d^{old}} = [\mathsf{ivk}]\, \mathsf{g_ d^{old}}$ or
+$\mathsf{pk_ d^{old}} = [\mathsf{ivk\_ {internal}}]\, \mathsf{g_ d^{old}}$.
 
 **Nullifier non-membership.** $\hspace{0.5em}$
 Let $\mathsf{leaf} = \mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$.
@@ -535,7 +543,7 @@ To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}
 </details>
 
 **Alternate nullifier integrity.** $\hspace{0.5em}$
-$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$.
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$.
 
 ### Circuit Implementation Notes
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -233,10 +233,10 @@ in-circuit proofs that a given nullifier is absent from the revealed set.
 
 ### Construction
 
-Let $S = \{s_ 0, s_ 1, \ldots, s_ {m-1}\}$ be the set of all Orchard
+Let $S = \{s_ 0, s_ 1, \ldots, s_ {m-1}\} \subset \mathbb{F}_ {q_ {\mathbb{P}}}$ be the set of all Orchard
 nullifiers revealed on the consensus chain as of block height $h$, together
-with a set of sentinel values (see [Sentinel Initialization]). Sort $S$ in
-ascending order as elements of $\mathbb{F}_ {q_ {\mathbb{P}}}$.
+with the sentinel values defined in [Sentinel Initialization]. Sort $S$ in
+ascending order.
 Because sentinel initialization is mandatory, $S$ is non-empty.
 
 For each pair of consecutive elements $(s_ i, s_ {i+1})$ where $s_ i < s_ {i+1}$
@@ -332,7 +332,7 @@ initialized with sentinel values that partition $\mathbb{F}_ {q_ {\mathbb{P}}}$
 into intervals each of width strictly less than $2^{250}$.
 
 For the Pallas base field ($q_ {\mathbb{P}} \approx 2^{254}$),
-implementations MUST insert 17 sentinels at:
+implementations MUST insert 17 sentinels $s_k \in \mathbb{F}_ {q_ {\mathbb{P}}}$ at:
 
 $$s_k = k \cdot 2^{250}, \quad k \in \{0,1,\ldots,16\}.$$
 
@@ -347,8 +347,7 @@ The width bound is critical for the soundness of the in-circuit range
 checks. If any interval had width $\geq 2^{250}$, the range check could
 overflow, allowing a prover to falsely claim non-membership.
 
-Sentinel values are fixed per deployment and MUST be published alongside the
-tree specification so that any party can reconstruct the tree independently.
+These sentinel values are constants defined by this specification.
 
 
 ## Nullifier Domains

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -268,6 +268,10 @@ efficient inside Halo 2 arithmetic circuits. Sinsemilla is optimized for
 bitstring inputs and incurs overhead when hashing field elements. Since
 the non-membership tree is a new data structure not constrained by backwards
 compatibility, the more circuit-efficient choice is appropriate.
+
+Poseidon2 was considered but not adopted because no audited implementation was
+available at the time of design. Poseidon already has an audited implementation
+used by Orchard for nullifier derivation.
 </details>
 
 ### Tree Depth

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -4,8 +4,8 @@
             Adam Tucker <adamleetucker@outlook.com>
             Roman Akhtariev <ackhtariev@gmail.com>
             Greg Nagy <greg@dhamma.works>
-    Credits: Daira-Emma Hopwood <daira@jacaranda.org>
-             Jack Grigg <thestr4d@gmail.com>
+    Credits: Daira-Emma Hopwood
+             Jack Grigg
     Status: Draft
     Category: Informational
     Created: 2026-03-03
@@ -147,23 +147,23 @@ viewing key cannot make claims on behalf of the holder.
 non-membership tree requires querying a data source that holds the full
 tree. A naive query reveals which path is being requested, potentially
 linking the querier to a nullifier range. Private information retrieval
-(PIR) techniques can mitigate this leakage [^pir-governance]; their
+(PIR) techniques can mitigate this leakage [^pir-nullifier-exclusion]; their
 specification is out of scope for this document.
 
 
 # Requirements
 
-- A holder MUST be able to prove ownership of an unspent Orchard note at a
-  pool snapshot without revealing the note's standard nullifier.
-- Double-claiming the same note within the same nullifier domain MUST be
+- A holder can prove ownership of an unspent Orchard note at a pool
+  snapshot without revealing the note's standard nullifier.
+- Double-claiming the same note within the same nullifier domain is
   detectable: the alternate nullifier is deterministic, so a duplicate
   claim produces an identical value that the verifier can reject.
-- Claims MUST be unlinkable to the holder's past or future on-chain
-  spends, and to their claims in other nullifier domains.
-- The holder MUST prove spend authority (not merely viewing access).
-- The construction SHOULD allow a holder to participate in multiple
-  independent applications using the same notes, provided each application
-  uses a distinct nullifier domain. This is a natural consequence of the
+- Claims are unlinkable to the holder's past or future on-chain spends,
+  and to their claims in other nullifier domains.
+- The holder proves spend authority (not merely viewing access).
+- The construction allows a holder to participate in multiple independent
+  applications using the same notes, provided each application uses a
+  distinct nullifier domain. This is a natural consequence of the
   domain-separated alternate nullifier derivation.
 
 
@@ -232,7 +232,10 @@ This ensures that all unrevealed values above the largest element of $S$ are
 represented in the tree.
 
 <details>
-<summary>Rationale for (low, width) encoding</summary>
+<summary>
+
+### Rationale for (low, width) encoding
+</summary>
 
 An alternative encoding stores $(\mathsf{start}, \mathsf{end})$ pairs
 directly, as proposed in [^draft-str4d-orchard-balance-proof]. The
@@ -259,7 +262,10 @@ with the standard parameter generation procedure from [^poseidon], targeting
 128-bit security.
 
 <details>
-<summary>Rationale for Poseidon over Sinsemilla</summary>
+<summary>
+
+### Rationale for Poseidon over Sinsemilla
+</summary>
 
 The Orchard note commitment tree uses Sinsemilla [^protocol-sinsemilla]
 for Merkle hashing. The non-membership tree uses Poseidon instead because
@@ -408,7 +414,10 @@ inputs, so their outputs collide with negligible probability under
 Poseidon's collision resistance.
 
 <details>
-<summary>Rationale for divergence from the Orchard-native construction</summary>
+<summary>
+
+### Rationale for divergence from the Orchard-native construction
+</summary>
 
 The earlier draft [^draft-str4d-orchard-balance-proof] proposed an
 alternate nullifier derivation structurally parallel to the standard
@@ -525,7 +534,10 @@ over $\mathbb{F}_ {q_ {\mathbb{P}}}$, proving that the standard nullifier
 falls within an interval of unrevealed values.
 
 <details>
-<summary>Derivation of the interval check</summary>
+<summary>
+
+### Derivation of the interval check
+</summary>
 
 To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}$:
 
@@ -696,14 +708,14 @@ batching for $N_ {\max} = 5$) exists in the coinholder voting codebase used
 for this design.
 
 At the time of writing, some implementation repositories are not publicly
-accessible. Public, stable links SHOULD be added before finalization of
+accessible. Public, stable links will be added before finalization of
 this ZIP.
 
 
 # Open issues
 
 - The Poseidon instantiation ($\mathsf{P128Pow5T3}$) and its round
-  constants should be explicitly referenced or pinned once a canonical
+  constants remain to be explicitly referenced or pinned once a canonical
   parameter set for Zcash usage is published.
 - The interaction between multi-note batching and the sighash scheme
   (what exactly is signed, and how it binds to all $N$ notes) requires
@@ -726,6 +738,6 @@ this ZIP.
 
 [^poseidon]: [Poseidon: A New Hash Function for Zero-Knowledge Proof Systems](https://eprint.iacr.org/2019/458)
 
-[^pir-governance]: [Draft ZIP: Private Information Retrieval for Governance](https://github.com/zcash/zips/pull/1198)
+[^pir-nullifier-exclusion]: [Draft ZIP: Private Information Retrieval for Nullifier Exclusion Proofs](https://github.com/zcash/zips/pull/1198)
 
 [^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -848,7 +848,7 @@ wallet:
    so the wallet MUST extract the signature by parsing the PCZT structure
    rather than by byte-diffing against the unsigned version.
 
-2. Extracts the sighash that the device signed. This is the ZIP 244
+2. Recomputes the sighash that the device signed. This is the ZIP 244
    transaction identifier computed over the PCZT.
 
 3. Assembles the delegation submission by combining the hardware wallet

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -483,6 +483,7 @@ Given a primary input:
 - $\mathsf{rt^{cm}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 - $\mathsf{rt^{excl}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 - $\mathsf{rk} ⦂ \mathsf{SpendAuthSig^{Orchard}.Public}$
+- $\mathsf{cv} ⦂ \mathsf{ValueCommit^{Orchard}.Output}$
 - $\mathsf{nf_ {dom}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 - $\mathsf{dom} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 
@@ -505,6 +506,7 @@ the prover knows an auxiliary input:
 - $\mathsf{rivk} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
 - $\mathsf{rivk\_ {internal}} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
 - $\alpha ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
+- $\mathsf{rcv} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
 - $\mathsf{low} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{width} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{path^{excl}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{excl}}]}$
@@ -525,6 +527,9 @@ $(\mathsf{path^{cm}}, \mathsf{pos^{cm}})$ is a valid Merkle path of depth
 $\mathsf{MerkleDepth^{Orchard}}$, as defined in
 § 4.9 'Merkle Path Validity' [^protocol-merklepath], from
 $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{cm}}$.
+
+**Value commitment integrity.** $\hspace{0.5em}$
+$\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_ {rcv}}(\mathsf{v^{old}})$.
 
 **Nullifier derivation.** $\hspace{0.5em}$
 $\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
@@ -587,7 +592,7 @@ in the circuit definition.
 
 ### Circuit Implementation Notes
 
-The first five conditions (note commitment integrity through diversified
+The first six conditions (note commitment integrity through diversified
 address integrity) are adapted from the corresponding Orchard Action
 statement checks. In particular, note-commitment Merkle membership uses
 $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ as in the Orchard
@@ -609,7 +614,7 @@ A verifier that receives a Claim proof $\pi$ together with a spend
 authorization signature $\sigma$ MUST perform the following checks:
 
 1. Verify $\pi$ against the public inputs
-   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{nf_ {dom}}, \mathsf{dom})$.
+   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{cv}, \mathsf{nf_ {dom}}, \mathsf{dom})$.
 
 2. Verify $\sigma$ as a valid $\mathsf{SpendAuthSig^{Orchard}}$ signature
    on the application-defined sighash, under the randomized key
@@ -641,14 +646,15 @@ as follows:
 
 - The public inputs $\mathsf{rt^{cm}}$, $\mathsf{rt^{excl}}$,
   $\mathsf{rk}$, and $\mathsf{dom}$ are shared across all $N$ notes.
-- Each note $i$ contributes its own alternate nullifier
-  $\mathsf{nf_ {dom,i}}$ as a public input.
+- Each note $i$ contributes its own value commitment
+  $\mathsf{cv_ i}$ and alternate nullifier
+  $\mathsf{nf_ {dom,i}}$ as public inputs.
 - A single $\mathsf{ivk}$ (derived from the shared $\mathsf{ak}$ and
   $\mathsf{nk}$) is constrained to own all $N$ notes, ensuring they
   belong to the same holder.
-- All $N$ note commitment integrity, Merkle path, nullifier derivation,
-  non-membership, and alternate nullifier checks are performed
-  independently per note.
+- All $N$ note commitment integrity, value commitment integrity,
+  Merkle path, nullifier derivation, non-membership, and alternate
+  nullifier checks are performed independently per note.
 
 ### Note Padding
 
@@ -665,6 +671,9 @@ A padded note MUST satisfy the following:
 
 - **Value.** The value MUST be 0, enforced by the constraint
   $(1 - \mathsf{is\_real}) \cdot \mathsf{v^{old}} = 0$.
+- **Value commitment.** The value commitment is computed for every slot
+  (not gated). Padded notes commit to value 0 with a fresh
+  $\mathsf{rcv}$.
 - **Ownership.** The note is derived from the same full viewing key as
   real notes (using a distinct diversifier index per padded slot), so it
   passes the diversified address integrity check with the shared
@@ -691,6 +700,20 @@ A padded note MUST satisfy the following:
 - **Alternate nullifier.** The alternate nullifier is derived and
   published for every slot (not gated). The application verifier MAY
   ignore alternate nullifiers corresponding to zero-value slots.
+
+
+## Sub-Circuit Instantiation
+
+When the Claim circuit is used as a sub-circuit of an application-specific
+circuit, the application circuit has direct access to the private witnesses
+including the note value $\mathsf{v^{old}}$. In this case, the value
+commitment $\mathsf{cv}$ MAY be omitted from the public inputs if the
+application circuit binds to the note values through its own mechanism.
+For example, an application circuit that converts note values to
+application-specific units (such as vote weight) may bind to
+$\mathsf{v^{old}}$ directly within the circuit and expose the converted
+result through its own public outputs. All other conditions of the Claim
+circuit MUST still be enforced.
 
 
 ## Wallet Signing

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -351,7 +351,7 @@ where:
 - $\mathsf{dom} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier domain.
 - $\mathsf{nf^{old}} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the note's
   standard Orchard nullifier, computed as
-  $\mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
+  $\mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
 This is a 3-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
 instantiation (width $t = 3$, rate 2), this requires two permutations
@@ -406,14 +406,14 @@ The earlier draft [^draft-str4d-orchard-balance-proof] proposed an
 alternate nullifier derivation structurally parallel to the standard
 Orchard nullifier:
 
-$$\mathsf{Extract}_ {\mathbb{P}}\!\left(\!\left[(\mathsf{PRF^{nfAlternate}_ {nk}}(\text{ρ}^{\mathsf{old}}, \mathsf{dom}) + \text{φ}^{\mathsf{old}}) \bmod q_ {\mathbb{P}}\right] \mathcal{K}^\mathsf{Orchard} + \mathsf{cm^{old}}\right)$$
+$$\mathsf{Extract}_ {\mathbb{P}}\!\left(\!\left[(\mathsf{PRF^{nfAlternate}_ {nk}}(\text{ρ}^{\mathsf{old}}, \mathsf{dom}) + \text{ψ}^{\mathsf{old}}) \bmod q_ {\mathbb{P}}\right] \mathcal{K}^\mathsf{Orchard} + \mathsf{cm^{old}}\right)$$
 
 That construction has the advantage of sharing more circuit infrastructure
 with the standard nullifier check.
 
 The Poseidon-based construction adopted here was chosen for simplicity:
 it requires only a single Poseidon hash rather than an additional
-variable-base scalar multiplication, and it reuses the standard nullifier
+fixed-base scalar multiplication, and it reuses the standard nullifier
 $\mathsf{nf^{old}}$ that the circuit already computes for the
 non-membership check. The security assumption is comparable — both
 constructions rely on the hardness of distinguishing $\mathsf{nk}$-keyed
@@ -451,7 +451,7 @@ the prover knows an auxiliary input:
 - $\mathsf{pk_ d^{old}} ⦂ \mathbb{P}^*$
 - $\mathsf{v^{old}} ⦂ \{ 0 .. 2^{\ell_ {\mathsf{value}}}-1 \}$
 - $\text{ρ}^{\mathsf{old}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
-- $\text{φ}^{\mathsf{old}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\text{ψ}^{\mathsf{old}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{rcm^{old}} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
 - $\mathsf{cm^{old}} ⦂ \mathbb{P}$
 - $\mathsf{nf^{old}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
@@ -472,7 +472,7 @@ such that the following conditions hold:
 ### Conditions
 
 **Note commitment integrity.** $\hspace{0.5em}$
-$\mathsf{NoteCommit^{Orchard}_ {rcm^{old}}}(\mathsf{repr}_ {\mathbb{P}}(\mathsf{g_ d^{old}}), \mathsf{repr}_ {\mathbb{P}}(\mathsf{pk_ d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}) \in \{ \mathsf{cm^{old}}, \bot \}$.
+$\mathsf{NoteCommit^{Orchard}_ {rcm^{old}}}(\mathsf{repr}_ {\mathbb{P}}(\mathsf{g_ d^{old}}), \mathsf{repr}_ {\mathbb{P}}(\mathsf{pk_ d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}) \in \{ \mathsf{cm^{old}}, \bot \}$.
 
 This is identical to the corresponding check in an Orchard Action
 statement. [^protocol-actionstatement]
@@ -487,7 +487,7 @@ $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{c
 $\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_ {rcv}}(\mathsf{v^{old}})$.
 
 **Nullifier derivation.** $\hspace{0.5em}$
-$\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
+$\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
 The standard nullifier is computed inside the circuit but is NOT a public
 input — it is used only as an intermediate value for the non-membership

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -869,15 +869,6 @@ the same notes in a concurrent application. Alternate nullifiers avoid
 this by operating entirely off the main chain: the standard nullifiers are
 never revealed, and the notes remain spendable.
 
-## Why (low, width) Leaf Encoding
-
-Storing $\mathsf{width} = \mathsf{end} - \mathsf{low}$ in the leaf
-instead of $\mathsf{end}$ eliminates one field subtraction from the
-in-circuit interval check. The tree builder performs this subtraction once
-during construction; the circuit evaluates the check once per claim per
-note. Since the number of claims vastly exceeds the number of tree
-rebuilds, the net constraint savings is significant.
-
 ## Why Poseidon for the Non-Membership Tree
 
 The Orchard note commitment tree uses Sinsemilla for Merkle hashing.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -1038,7 +1038,3 @@ this ZIP.
 [^zip-244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244)
 
 [^zip-32]: [ZIP 32: Shielded Hierarchical Deterministic Wallets](zip-0032)
-
-[^protocol-concretespendauthsig]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 5.4.7.1: Spend Authorization Signature (Orchard)](protocol/protocol.pdf#concretespendauthsig)
-
-[^ur]: [BCR-2020-005: Uniform Resources (UR)](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-005-ur.md)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -221,6 +221,15 @@ The leaf represents the closed interval
 $[\mathsf{low},\; \mathsf{low} + \mathsf{width}]$, which contains exactly
 the field elements between $s_i$ and $s_{i+1}$ exclusive.
 
+After processing all consecutive pairs, if $s_{m-1} < q_{\mathbb{P}} - 1$,
+a terminal leaf MUST be added with:
+
+- $\mathsf{low} = s_{m-1} + 1$
+- $\mathsf{width} = (q_{\mathbb{P}} - 1) - \mathsf{low}$
+
+This ensures that all unrevealed values above the largest element of $S$ are
+represented in the tree.
+
 <details>
 <summary>Rationale for (low, width) encoding</summary>
 
@@ -266,8 +275,9 @@ This specification uses a tree depth of
 $\mathsf{MerkleDepth^{excl}} = 29$, supporting up to $2^{29} \approx 537$
 million leaves. Each nullifier insertion splits one interval leaf into two
 (adding one leaf), so the tree supports approximately 537 million distinct
-nullifiers. As of this writing, the Zcash Orchard pool contains
-approximately 50 million nullifiers, providing over 10x headroom.
+nullifiers. As of early 2026, the Zcash Orchard pool contains roughly
+51 million nullifiers, so depth 29 provides about one order of magnitude
+of headroom.
 Implementations MAY choose a different depth to suit their capacity
 requirements; the circuit must be parameterized accordingly.
 
@@ -280,11 +290,17 @@ Before inserting any real nullifiers, the non-membership tree MUST be
 initialized with sentinel values that partition $\mathbb{F}_{q_{\mathbb{P}}}$
 into intervals each of width strictly less than $2^{250}$.
 
-This is achieved by inserting sentinel nullifiers at evenly spaced points
-across the field. For the Pallas base field ($q_{\mathbb{P}} \approx
-2^{254.9}$), inserting 17 sentinels at multiples of
-$\lfloor q_{\mathbb{P}} / 17 \rfloor$ suffices, as each resulting interval
-has width at most $\lceil q_{\mathbb{P}} / 17 \rceil < 2^{250}$.
+For the Pallas base field ($q_{\mathbb{P}} \approx 2^{254}$),
+implementations MUST insert 17 sentinels at:
+
+$$s_k = k \cdot 2^{250}, \quad k \in \{0,1,\ldots,16\}.$$
+
+This guarantees the width bound required by the in-circuit range checks:
+
+- For $k = 0,\ldots,15$, the interval between consecutive sentinels has
+  width exactly $2^{250} - 2$.
+- The final tail interval has width
+  $q_{\mathbb{P}} - 16 \cdot 2^{250} - 2 < 2^{250}$.
 
 The width bound is critical for the soundness of the in-circuit range
 checks. If any interval had width $\geq 2^{250}$, the range check could
@@ -464,7 +480,7 @@ statement. [^protocol-actionstatement]
 $(\mathsf{path^{cm}}, \mathsf{pos^{cm}})$ is a valid Merkle path of depth
 $\mathsf{MerkleDepth^{Orchard}}$, as defined in
 § 4.9 'Merkle Path Validity' [^protocol-merklepath], from
-$\mathsf{cm^{old}}$ to the anchor $\mathsf{rt^{cm}}$.
+$\mathsf{Extract}_{\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{cm}}$.
 
 **Value commitment integrity.** $\hspace{0.5em}$
 $\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_{rcv}}(\mathsf{v^{old}})$.
@@ -524,7 +540,9 @@ $\mathsf{nf_{dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{ol
 ### Circuit Implementation Notes
 
 The first six conditions (note commitment integrity through diversified
-address integrity) are identical to the corresponding parts of an Orchard
+address integrity) are adapted from the corresponding Orchard Action
+statement checks. In particular, note-commitment Merkle membership uses
+$\mathsf{Extract}_{\mathbb{P}}(\mathsf{cm^{old}})$ as in the Orchard
 Action statement. [^protocol-actionstatement] Implementations SHOULD share
 circuit gadgets with an Orchard implementation to minimize new code
 requiring review.
@@ -680,11 +698,12 @@ signature scheme.
 
 A reference implementation of the Claim circuit (including the
 non-membership tree, alternate nullifier derivation, and multi-note
-batching for $N_{\max} = 5$) is provided in the voting-circuits
-repository. [^voting-circuits]
+batching for $N_{\max} = 5$) exists in the coinholder voting codebase used
+for this design.
 
-The out-of-circuit IMT construction and Merkle path utilities are
-implemented in the orchard fork used by the voting system. [^imt-impl]
+At the time of writing, some implementation repositories are not publicly
+accessible. Public, stable links SHOULD be added before finalization of
+this ZIP.
 
 
 # Open issues

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -94,9 +94,9 @@ demonstrate that they controlled a certain balance at a point in time,
 without revealing which specific notes they held or linking the
 demonstration to their on-chain transaction history. Examples include:
 
-- **Air drops** — distributing tokens proportional to shielded holdings.
-- **Stake-weighted polling** — weighting votes by ZEC balance.
-- **Proof-of-balance** — demonstrating solvency or collateral without
+- **Air drops**: distributing tokens proportional to shielded holdings.
+- **Stake-weighted polling**: weighting votes by ZEC balance.
+- **Proof-of-balance**: demonstrating solvency or collateral without
   revealing addresses.
 
 The naive approach of revealing standard nullifiers would link the
@@ -214,8 +214,8 @@ Because sentinel initialization is mandatory, $S$ is non-empty.
 For each pair of consecutive elements $(s_ i, s_ {i+1})$ where $s_ i < s_ {i+1}$
 and $s_ {i+1} - s_ i > 1$, create a leaf with:
 
-- $\mathsf{low} = s_ i + 1$ — the first value in the gap
-- $\mathsf{width} = s_ {i+1} - s_ i - 2$ — the number of additional values
+- $\mathsf{low} = s_ i + 1$: the first value in the gap
+- $\mathsf{width} = s_ {i+1} - s_ i - 2$: the number of additional values
   in the gap beyond $\mathsf{low}$
 
 The leaf represents the closed interval
@@ -433,13 +433,13 @@ The Poseidon-based construction adopted here was chosen for simplicity:
 it requires only a single Poseidon hash rather than an additional
 fixed-base scalar multiplication, and it reuses the standard nullifier
 $\mathsf{nf^{old}}$ that the circuit already computes for the
-non-membership check. The security assumption is comparable — both
+non-membership check. The security assumption is comparable, as both
 constructions rely on the hardness of distinguishing $\mathsf{nk}$-keyed
 evaluations from random.
 
 The current Zcash coinholder voting system was designed and implemented
 around this construction. A future revision of this ZIP may revisit the
-choice as part of a broader protocol revision — for example, if hardware
+choice as part of a broader protocol revision. For example, if hardware
 wallet firmware support (e.g., a Keystone testnet byte for governance
 signing) restructures the spend authority flow in a way that favors
 tighter integration with the standard Orchard nullifier derivation.
@@ -504,7 +504,7 @@ $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{c
 $\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
 The standard nullifier is computed inside the circuit but is NOT a public
-input — it is used only as an intermediate value for the non-membership
+input. It is used only as an intermediate value for the non-membership
 check and the alternate nullifier derivation. It is never revealed.
 
 **Spend authority.** $\hspace{0.5em}$
@@ -556,7 +556,10 @@ To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}
 </details>
 
 **Alternate nullifier integrity.** $\hspace{0.5em}$
-$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$.
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$,
+where $\mathsf{tag}$ is the application-defined domain separator constant
+(see [Alternate Nullifier Derivation]), fixed per application and embedded
+in the circuit definition.
 
 ### Circuit Implementation Notes
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -738,7 +738,7 @@ $\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx_ 1}, \ldots, \
 
 where $\mathsf{cmx_ i} = \mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}_ i})$
 is the extracted note commitment of the $i$-th claimed note slot
-(real or padded). This binds the hardware wallet's signature to the
+(real or dummy). This binds the hardware wallet's signature to the
 exact set of notes being claimed and the application context.
 
 **Spend authority.** $\hspace{0.5em}$
@@ -757,46 +757,25 @@ conditions.
 
 To avoid leaking the number of notes a holder is claiming, the circuit
 SHOULD accept a fixed number of note slots $N_ {\max}$ (for example,
-$N_ {\max} = 5$). Unused slots are filled with *padded notes*.
+$N_ {\max} = 5$). Unused slots are filled with dummy notes (Orchard
+notes with $\mathsf{v^{old}} = 0$).
 
-Each note slot carries a private boolean witness
-$\mathsf{is\_real} \in \{0, 1\}$, constrained by
-$\mathsf{is\_real} \cdot (1 - \mathsf{is\_real}) = 0$.
-A padded note is a slot with $\mathsf{is\_real} = 0$.
+Dummy notes use the same Merkle path validity check as the standard
+Orchard Action circuit [^protocol-actionstatement]: if
+$\mathsf{v^{old}} = 0$, the Merkle path check is skipped.
 
-A padded note MUST satisfy the following:
+All other conditions are enforced unconditionally:
 
-- **Value.** The value MUST be 0, enforced by the constraint
-  $(1 - \mathsf{is\_real}) \cdot \mathsf{v^{old}} = 0$.
-- **Value commitment.** The value commitment is computed for every slot
-  (not gated). Padded notes commit to value 0 with a fresh
-  $\mathsf{rcv}$.
-- **Ownership.** The note is derived from the same full viewing key as
-  real notes (using a distinct diversifier index per padded slot), so it
-  passes the diversified address integrity check with the shared
-  $\mathsf{ivk}$.
-- **Note commitment integrity.** The commitment is recomputed from the
-  padded note's plaintext (value 0, random nullifier, random
-  $\text{ψ}$, fresh $\mathsf{rcm}$) and constrained to equal the
-  witnessed $\mathsf{cm}$. This check is not gated by
-  $\mathsf{is\_real}$.
-- **Merkle membership.** The Merkle path is computed for the padded
-  note, but the root equality check is gated:
-  $\mathsf{is\_real} \cdot (\mathsf{root} - \mathsf{rt^{cm}}) = 0$.
-  For padded notes ($\mathsf{is\_real} = 0$) the constraint is
-  trivially satisfied regardless of the computed root, effectively
-  skipping the membership check.
-- **Nullifier non-membership.** The IMT non-membership check is NOT
-  gated by $\mathsf{is\_real}$. Padded notes MUST provide a valid
-  non-membership proof against $\mathsf{rt^{excl}}$. Because padded
-  nullifiers are random field elements, they fall within an unrevealed
-  interval with overwhelming probability.
-- **Nullifier derivation.** The standard nullifier is derived in-circuit
-  (not gated). It is used for the non-membership check and the alternate
-  nullifier derivation but is never revealed.
-- **Alternate nullifier.** The alternate nullifier is derived and
-  published for every slot (not gated). The application verifier MAY
-  ignore alternate nullifiers corresponding to zero-value slots.
+- Dummy notes commit to value 0 with a fresh $\mathsf{rcv}$.
+- Dummy notes are derived from the same full viewing key as real notes
+  (using a distinct diversifier index per slot).
+- Dummy notes MUST provide a valid non-membership proof against
+  $\mathsf{rt^{excl}}$. Because dummy nullifiers are random field
+  elements, they fall within an unrevealed interval with overwhelming
+  probability.
+- The alternate nullifier is derived and published for every slot. The
+  application verifier MAY ignore alternate nullifiers corresponding
+  to zero-value slots.
 
 
 ## Sub-Circuit Instantiation

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -76,8 +76,8 @@ prevent double-claiming within an application domain while remaining
 unlinkable across domains and to on-chain activity.
 
 A Claim circuit combines these primitives with standard Orchard note
-commitment integrity, Merkle membership, value commitment, spend authority,
-and diversified address integrity checks to produce a single proof per
+commitment integrity, Merkle membership, spend authority, and diversified
+address integrity checks to produce a single proof per
 note. An optional multi-note batching extension allows proving aggregate
 balance across several notes in one proof.
 
@@ -445,7 +445,6 @@ Given a primary input:
 - $\mathsf{rk} ⦂ \mathsf{SpendAuthSig^{Orchard}.Public}$
 - $\mathsf{nf_ {dom}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 - $\mathsf{dom} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
-- $\mathsf{cv} ⦂ \mathsf{ValueCommit^{Orchard}.Output}$
 
 ### Auxiliary Inputs
 
@@ -465,7 +464,6 @@ the prover knows an auxiliary input:
 - $\mathsf{nk} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{rivk} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
 - $\alpha ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
-- $\mathsf{rcv} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
 - $\mathsf{low} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{width} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{path^{excl}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{excl}}]}$
@@ -486,9 +484,6 @@ $(\mathsf{path^{cm}}, \mathsf{pos^{cm}})$ is a valid Merkle path of depth
 $\mathsf{MerkleDepth^{Orchard}}$, as defined in
 § 4.9 'Merkle Path Validity' [^protocol-merklepath], from
 $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{cm}}$.
-
-**Value commitment integrity.** $\hspace{0.5em}$
-$\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_ {rcv}}(\mathsf{v^{old}})$.
 
 **Nullifier derivation.** $\hspace{0.5em}$
 $\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
@@ -544,7 +539,7 @@ $\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{o
 
 ### Circuit Implementation Notes
 
-The first six conditions (note commitment integrity through diversified
+The first five conditions (note commitment integrity through diversified
 address integrity) are adapted from the corresponding Orchard Action
 statement checks. In particular, note-commitment Merkle membership uses
 $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ as in the Orchard
@@ -566,7 +561,7 @@ A verifier that receives a Claim proof $\pi$ together with a spend
 authorization signature $\sigma$ MUST perform the following checks:
 
 1. Verify $\pi$ against the public inputs
-   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{nf_ {dom}}, \mathsf{dom}, \mathsf{cv})$.
+   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{nf_ {dom}}, \mathsf{dom})$.
 
 2. Verify $\sigma$ as a valid $\mathsf{SpendAuthSig^{Orchard}}$ signature
    on the application-defined sighash, under the randomized key
@@ -599,8 +594,7 @@ as follows:
 - The public inputs $\mathsf{rt^{cm}}$, $\mathsf{rt^{excl}}$,
   $\mathsf{rk}$, and $\mathsf{dom}$ are shared across all $N$ notes.
 - Each note $i$ contributes its own alternate nullifier
-  $\mathsf{nf_ {dom,i}}$ and value commitment $\mathsf{cv_ i}$ as public
-  inputs.
+  $\mathsf{nf_ {dom,i}}$ as a public input.
 - A single $\mathsf{ivk}$ (derived from the shared $\mathsf{ak}$ and
   $\mathsf{nk}$) is constrained to own all $N$ notes, ensuring they
   belong to the same holder.
@@ -615,8 +609,8 @@ SHOULD accept a fixed number of note slots $N_ {\max}$ (for example,
 $N_ {\max} = 5$). Unused slots are filled with *padded notes*: randomly
 generated note data with value 0. Padded notes satisfy all circuit
 checks (the commitment is valid, the Merkle path can use any valid leaf,
-the non-membership check passes for random nullifiers with overwhelming
-probability, and the value commitment commits to zero).
+and the non-membership check passes for random nullifiers with overwhelming
+probability).
 
 An $\mathsf{is\_real}$ flag (private witness, constrained to be boolean)
 distinguishes real notes from padded notes:
@@ -625,19 +619,6 @@ distinguishes real notes from padded notes:
 - Merkle membership and non-membership checks MAY be skipped for padded
   notes (conditioned on $\mathsf{is\_real} = 0$) as an optimization, but
   performing them is also sound since padded notes use valid dummy data.
-
-### Aggregate Value
-
-The verifier computes the aggregate value commitment as:
-
-$$\mathsf{cv_ {total}} = \sum_ {i=0}^{N_ {\max}-1} \mathsf{cv_ i}$$
-
-Since padded notes commit to value 0, they contribute the identity to the
-sum (up to their blinding factor). The aggregate commitment
-$\mathsf{cv_ {total}}$ commits to the holder's total claimed balance.
-Applications that need to open this commitment (e.g., to verify a minimum
-balance threshold) can do so by requiring the prover to reveal the
-aggregate randomness $\mathsf{rcv_ {total}} = \sum_ i \mathsf{rcv_ i}$.
 
 
 # Rationale

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -813,6 +813,34 @@ result through its own public outputs. All other conditions of the Claim
 circuit MUST still be enforced.
 
 
+## Application Requirements
+
+An application instantiating this ZIP MUST define the following:
+
+- An **application hotkey**: a key pair generated locally by the wallet,
+  freshly generated per proof-of-balance instance, and not linked to the
+  holder's on-chain Orchard addresses. When the PCZT-based signing flow
+  is used, the output is addressed to this key (see [Wallet Signing]).
+  All subsequent application-level operations use the hotkey in place of
+  the holder's spending key.
+- An **application verifier**: the component that accepts or rejects
+  claims by performing the checks in [Out-of-Circuit Verification]. It
+  MUST maintain a persistent set of accepted alternate nullifiers per
+  domain for double-claim detection.
+- A **nullifier domain** derivation, as specified in [Nullifier Domains].
+- An **application commitment** ($\mathsf{app\_commitment}$): a value
+  that commits to application-specific context, included in the rho
+  binding (see [Dummy Signed Note]). For example, a voting protocol
+  might commit to the delegated vote weight and recipient address.
+- An **instance identifier** ($\mathsf{instance\_id}$): a unique
+  identifier for the proof-of-balance instance, included in the rho
+  binding (see [Dummy Signed Note]).
+- A **sighash derivation**: the method for computing the sighash for the
+  spend authorization signature (see [Spend Authorization Signature]).
+  Applications using the PCZT-based signing flow use the ZIP 244
+  [^zip-244] sighash.
+
+
 ## Wallet Signing
 
 The signing flow proceeds in five steps:

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -689,11 +689,11 @@ The signing flow proceeds in five steps:
    submission.
 
 Each interaction with the hardware wallet device delegates up to
-$N_{\max}$ Orchard notes (the default batch size is 5). A holder with
-more than $N_{\max}$ notes repeats the flow for each batch, producing a
-separate application commitment per batch. The holder MAY choose to
-delegate fewer batches than their full note set, claiming only the
-balance covered by the delegated batches.
+$N_{\max}$ Orchard notes. A holder with more than $N_{\max}$ notes
+repeats the flow for each batch, producing a separate application
+commitment per batch. The holder MAY choose to delegate fewer batches
+than their full note set, claiming only the balance covered by the
+delegated batches.
 
 ### Dummy Signed Note Construction
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -62,9 +62,10 @@ Claim
 
 Dummy signed note
 
-: A synthetic Orchard note with value 0 (in the Claim circuit) whose
-  $\text{ρ}$ is deterministically bound to the delegation context. The
-  note does not exist in any on-chain note commitment tree.
+: A synthetic Orchard note with value 0 (in the Claim circuit) that
+  does not exist in any on-chain note commitment tree. It is constructed
+  solely for obtaining a spend authorization signature from the holder's
+  key. See [Wallet Signing].
 
 The terms "Vote Authority Note (VAN)", "governance nullifier", "voting
 round", "governance hotkey", and "ballot" are defined in the Shielded
@@ -175,8 +176,8 @@ Orchard balance or delegation context. The PCZT contains a 1-zatoshi
 dummy note with no on-chain counterpart; the holder's actual note
 commitments, values, and nullifiers are never transmitted to the device.
 The VAN commitment, governance nullifiers, and voting round identifier are
-embedded in the rho binding inside the ZKP circuit and do not appear as
-plaintext fields in the PCZT. The output address (governance hotkey) is
+committed via the dummy note's nullifier inside the ZKP circuit and
+do not appear as plaintext fields in the PCZT. The output address (governance hotkey) is
 visible on the device but is freshly generated per voting round and is not
 linked to the holder's on-chain Orchard addresses. An attacker with
 physical access to the device during signing learns only that the holder
@@ -678,13 +679,13 @@ distinguishes real notes from padded notes:
   performing them is also sound since padded notes use valid dummy data.
 
 
-## Hardware Wallet Signing
+## Wallet Signing
 
 The delegation signing flow proceeds in five steps:
 
 1. The wallet generates a governance hotkey on the local device.
-2. The wallet constructs a dummy signed note with rho bound to the
-   delegation context.
+2. The wallet constructs a dummy signed note whose nullifier commits
+   to the delegation context.
 3. The wallet builds a governance PCZT containing the dummy signed note.
 4. The hardware wallet device signs the PCZT and returns the signature.
 5. The wallet extracts the signature and assembles the delegation
@@ -705,7 +706,17 @@ The wallet constructs a dummy Orchard note as follows:
    full viewing key at diversifier index 0 with external scope:
    $\mathsf{addr}^{\mathsf{signed}} = \mathsf{fvk.address\_at}(0, \mathsf{External})$.
 
-2. **Rho binding.** The signed note's $\text{ρ}$ is set to:
+2. **Nullifier commitment.** Because the dummy note
+   has no on-chain existence, its fields (including $\text{ρ}$) can be
+   freely chosen. This design utilizes that freedom: $\text{ρ}$ is set to
+   a hash of the delegation context so that the note commitment, and
+   therefore the sighash, cryptographically binds the hardware wallet's
+   signature to the exact set of notes being delegated. This avoids
+   requiring a custom signing protocol; the hardware wallet signs a
+   standard Orchard PCZT, and the binding is enforced by the ZKP circuit
+   rather than by device firmware.
+
+   Concretely, the signed note's $\text{ρ}$ is set to:
 
 $$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1}, \mathsf{cmx}\_\mathsf{2}, \mathsf{cmx}\_\mathsf{3}, \mathsf{cmx}\_\mathsf{4}, \mathsf{cmx}\_\mathsf{5}, \mathsf{van}, \mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}\bigr)$$
 
@@ -734,8 +745,8 @@ $$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1},
 For fewer than 5 real notes, the wallet pads the remaining slots with
 zero-value dummy notes at diversifier indices $1000 + i$ (external
 scope) from the holder's full viewing key. These padding notes enter
-the rho binding via their $\mathsf{cmx}$ values but do not correspond
-to real on-chain notes.
+the $\text{ρ}$ commitment via their $\mathsf{cmx}$ values but do not
+correspond to real on-chain notes.
 
 ### Governance PCZT Construction
 
@@ -911,20 +922,24 @@ design has three advantages:
   hardware wallet's existing PCZT parser and signer without
   modification.
 
-## Why Rho Binding Provides Non-Replayability
+## Why the Dummy Note's ρ Provides Non-Replayability
 
-The dummy signed note's $\text{ρ}^{\mathsf{signed}}$ is set to a
-Poseidon hash of the delegated note commitments, the VAN, and the
-voting round identifier. Because $\text{ρ}$ enters the note commitment
-(and therefore the sighash), the hardware wallet's signature is
-cryptographically bound to the exact delegation context. An attacker
-cannot replay the signature for a different set of notes, a different
-VAN, or a different voting round.
+Because the dummy signed note does not correspond to any on-chain note,
+its inputs can be freely chosen. The design sets
+$\text{ρ}^{\mathsf{signed}}$ to a Poseidon hash of the delegated note
+commitments, the VAN, and the voting round identifier. Because
+$\text{ρ}$ enters the note commitment (and therefore the sighash), the
+hardware wallet's signature is cryptographically bound to the exact
+delegation context. An attacker cannot replay the signature for a
+different set of notes, a different VAN, or a different voting round.
 
-This binding is enforced by the Claim circuit's rho binding condition,
-which the vote chain verifies. The hardware wallet device does not need
-to understand the binding; it is sufficient that the device signs the
-sighash derived from the PCZT containing the bound $\text{ρ}$.
+This binding is enforced by the Claim circuit, which the vote chain
+verifies. The hardware wallet device does not need to understand the
+binding; it is sufficient that the device signs the sighash derived from
+the PCZT containing the committed $\text{ρ}$. No custom signing
+protocol is required — the standard Orchard PCZT flow is reused, and
+all existing hardware wallets that support Orchard signing are
+compatible without firmware changes.
 
 ## Why ZIP 244 Sighash
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -628,6 +628,25 @@ The alternate nullifier integrity check is a single Poseidon hash
 (two permutations at width 3).
 
 
+## Spend Authorization Signature
+
+Each Claim proof MUST be accompanied by a spend authorization signature
+$\sigma$, which is a $\mathsf{SpendAuthSig^{Orchard}}$ signature under
+the randomized key $\mathsf{rk}$ that is a public input to the circuit.
+
+The signature MUST be computed over a sighash that binds the signature
+to the specific claim, ensuring that it cannot be replayed for a
+different set of public inputs. Applications MAY achieve this binding
+directly (by including the public inputs in the sighash) or indirectly
+(through values that the Claim circuit constrains to be consistent with
+the public inputs).
+
+The concrete sighash derivation is application-defined. The [Wallet Signing]
+section specifies a PCZT-based signing flow that reuses the standard
+ZIP 244 [^zip-244] sighash, enabling compatibility with existing hardware
+wallets.
+
+
 ## Out-of-Circuit Verification
 
 A verifier that receives a Claim proof $\pi$ together with a spend
@@ -637,8 +656,8 @@ authorization signature $\sigma$ MUST perform the following checks:
    $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{cv}, \mathsf{nf_ {dom}}, \mathsf{dom})$.
 
 2. Verify $\sigma$ as a valid $\mathsf{SpendAuthSig^{Orchard}}$ signature
-   on the application-defined sighash, under the randomized key
-   $\mathsf{rk}$.
+   on the sighash (see [Spend Authorization Signature]), under the
+   randomized key $\mathsf{rk}$.
 
 3. Verify that $\mathsf{rt^{cm}}$ corresponds to the Orchard note
    commitment tree root at the declared snapshot height.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -199,8 +199,6 @@ instance and the declared balance.
 
 # Non-requirements
 
-- Application-specific protocols that consume claims (such as voting,
-  air-drop distribution, or delegation) are out of scope.
 - Privacy-preserving retrieval of non-membership Merkle paths (e.g., via
   PIR) is out of scope.
 - Value denomination conversions (e.g., converting zatoshi to

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -343,8 +343,11 @@ supports up to $2^{29} \approx 537$ million leaves. As of early 2026,
 the Zcash Orchard pool contains roughly 51 million nullifiers, so
 depth 29 provides about one order of magnitude of headroom.
 
-Unused leaf positions MUST be filled with a canonical empty leaf value
-$\mathsf{GapCommit}(0, 0)$.
+Unused leaf positions MUST be filled with the canonical empty leaf value
+$\mathsf{GapCommit}(0, 0)$. This is non-overlapping with every valid
+gap encoding because the sentinel set always includes $0$ (see
+[Sentinel Initialization]), so $\mathsf{low} = 0$ can never appear in
+a valid gap.
 
 ### Sentinel Initialization
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -60,24 +60,11 @@ Claim
   committed value at a given pool snapshot, and revealing the note's
   alternate nullifier in a specified domain.
 
-Governance PCZT
-
-: A Partially Created Zcash Transaction [^pczt] constructed solely for
-  governance delegation. The PCZT contains a single Orchard Action that
-  spends a dummy signed note and produces an output to the governance
-  hotkey address.
-
 Dummy signed note
 
 : A synthetic Orchard note with value 0 (in the Claim circuit) whose
   $\text{ρ}$ is deterministically bound to the delegation context. The
   note does not exist in any on-chain note commitment tree.
-
-Rho binding
-
-: The constraint that the dummy signed note's
-  $\text{ρ}^{\mathsf{signed}}$ equals a Poseidon hash of the delegated
-  note commitments, the VAN commitment, and the voting round identifier.
 
 The terms "Vote Authority Note (VAN)", "governance nullifier", "voting
 round", "governance hotkey", and "ballot" are defined in the Shielded
@@ -1032,8 +1019,6 @@ this ZIP.
 [^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)
 
 [^voting-protocol]: [Shielded Voting Protocol](draft-valargroup-shielded-voting)
-
-[^pczt]: [zcash/zips issue #693: Standardize a protocol for creating shielded transactions offline (PCZT)](https://github.com/zcash/zips/issues/693)
 
 [^zip-244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244)
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -248,8 +248,8 @@ per claim, this trade-off favors prover efficiency.
 
 ### Hash Function
 
-The non-membership tree uses Poseidon [^poseidon] over
-$\mathbb{F}_ {q_ {\mathbb{P}}}$ (the Pallas base field) for all hashing:
+The non-membership tree uses Poseidon [^poseidon], instantiated over
+the Pallas base field $\mathbb{F}_ {q_ {\mathbb{P}}}$, for all hashing:
 
 - **Leaf hash:** $\mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$,
   a 2-input Poseidon hash with width $t = 3$.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -347,7 +347,8 @@ $\mathsf{GapCommit}(0, 0)$.
 
 Before inserting any real nullifiers, the non-membership tree MUST be
 initialized with sentinel values that partition $\mathbb{F}_ {q_ {\mathbb{P}}}$
-into intervals each of width strictly less than $2^{250}$.
+into intervals each of width strictly less than $2^{250}$. The sentinel
+set MUST include the value $0$.
 
 For the Pallas base field ($q_ {\mathbb{P}} \approx 2^{254}$),
 implementations MUST insert 17 sentinels $s_k \in \mathbb{F}_ {q_ {\mathbb{P}}}$ at:

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -227,9 +227,26 @@ be able to independently verify both roots.
 
 ## Nullifier Non-Membership Tree
 
-The nullifier non-membership tree is a Merkle tree whose leaves encode
-the gaps between consecutive revealed nullifiers, enabling efficient
-in-circuit proofs that a given nullifier is absent from the revealed set.
+The nullifier non-membership tree is a Merkle tree whose leaves are
+commitments to the gaps between consecutive revealed nullifiers, enabling
+efficient in-circuit proofs that a given nullifier is absent from the
+revealed set.
+
+The relationship between the sorted nullifier set and the tree is
+illustrated below:
+
+```
+            /  \                          ..
+           /    \                        /
+       gcm_0    gcm_1               gcm_2      <-- Gap commitments (tree leaves)
+      /\            /\              /\
+  |(l_0, w_0)| |(l_1, w_1)|   |(l_2, w_2) ..  <-- Gap encodings (low, width)
+s_0|          |s_1|         |s_2|          ..   <-- Sorted nullifier set + sentinels
+```
+
+Each gap between consecutive nullifiers is encoded as a
+$(\mathsf{low}, \mathsf{width})$ pair, then committed via
+$\mathsf{GapCommit}$ (see [Hash Function]) to produce a tree leaf.
 
 ### Construction
 
@@ -240,18 +257,19 @@ ascending order.
 Because sentinel initialization is mandatory, $S$ is non-empty.
 
 For each pair of consecutive elements $(s_ i, s_ {i+1})$ where $s_ i < s_ {i+1}$
-and $s_ {i+1} - s_ i > 1$, create a leaf with:
+and $s_ {i+1} - s_ i > 1$, compute a gap encoding:
 
 - $\mathsf{low} = s_ i + 1$: the first value in the gap
 - $\mathsf{width} = s_ {i+1} - s_ i - 2$: the number of additional values
   in the gap beyond $\mathsf{low}$
 
-The leaf represents the closed interval
+The gap encoding represents the closed interval
 $[\mathsf{low},\; \mathsf{low} + \mathsf{width}]$, which contains exactly
-the field elements between $s_ i$ and $s_ {i+1}$ exclusive.
+the field elements between $s_ i$ and $s_ {i+1}$ exclusive. The
+corresponding tree leaf is $\mathsf{GapCommit}(\mathsf{low}, \mathsf{width})$.
 
 After processing all consecutive pairs, if $s_ {m-1} < q_ {\mathbb{P}} - 1$,
-a terminal leaf MUST be added with:
+a terminal gap MUST be added with:
 
 - $\mathsf{low} = s_ {m-1} + 1$
 - $\mathsf{width} = (q_ {\mathbb{P}} - 1) - \mathsf{low}$
@@ -280,7 +298,7 @@ The non-membership tree uses Poseidon [^protocol-poseidon] with the
 $\mathsf{P128Pow5T3}$ instantiation (width $t = 3$, rate 2) over the
 Pallas base field $\mathbb{F}_ {q_ {\mathbb{P}}}$ for all hashing:
 
-- **Leaf hash:** $\mathsf{PoseidonLeafHash}(\mathsf{low}, \mathsf{width})$,
+- **Gap commitment:** $\mathsf{GapCommit}(\mathsf{low}, \mathsf{width})$,
   a 2-input Poseidon hash (one permutation).
 - **Internal node hash:** $\mathsf{PoseidonNodeHash}(\mathsf{left}, \mathsf{right})$,
   a 2-input Poseidon hash (one permutation), where $\mathsf{left}$ and
@@ -313,8 +331,8 @@ used by Orchard for nullifier derivation.
 
 This specification uses a tree depth of
 $\mathsf{MerkleDepth^{excl}} = 29$, supporting up to $2^{29} \approx 537$
-million leaves. Each nullifier insertion splits one interval leaf into two
-(adding one leaf), so the tree supports approximately 537 million distinct
+million leaves. Each nullifier insertion splits one gap into two, replacing one leaf
+with two (adding one leaf), so the tree supports approximately 537 million distinct
 nullifiers. As of early 2026, the Zcash Orchard pool contains roughly
 51 million nullifiers, so depth 29 provides about one order of magnitude
 of headroom.
@@ -323,7 +341,7 @@ requirements, but the circuit MUST be parameterized accordingly based on
 the chosen depth.
 
 Unused leaf positions MUST be filled with a canonical empty leaf value
-(the hash of the zero interval).
+$\mathsf{GapCommit}(0, 0)$.
 
 ### Sentinel Initialization
 
@@ -543,7 +561,7 @@ Then $\mathsf{pk_ d^{old}} = [\mathsf{ivk}]\, \mathsf{g_ d^{old}}$ or
 $\mathsf{pk_ d^{old}} = [\mathsf{ivk\_ {internal}}]\, \mathsf{g_ d^{old}}$.
 
 **Nullifier non-membership.** $\hspace{0.5em}$
-Let $\mathsf{leaf} = \mathsf{PoseidonLeafHash}(\mathsf{low}, \mathsf{width})$
+Let $\mathsf{leaf} = \mathsf{GapCommit}(\mathsf{low}, \mathsf{width})$
 (see [Hash Function]).
 $(\mathsf{path^{excl}}, \mathsf{pos^{excl}})$ is a valid Merkle path of
 depth $\mathsf{MerkleDepth^{excl}}$ from $\mathsf{leaf}$ to the anchor

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -679,7 +679,10 @@ authorization signature $\sigma$ MUST perform the following checks:
 
 The Claim circuit defined in [Claim Circuit] proves a statement about a
 single note. Applications that require proving aggregate balance across
-multiple notes MAY use the following batching extension.
+multiple notes MAY use the following batching extension. Applications
+that use the PCZT-based signing flow (see [Wallet Signing]) MUST use
+the batched circuit, as the dummy signed note (see [Dummy Signed Note])
+requires binding to the claimed note slots.
 
 ### Batched Claim Circuit
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -156,9 +156,11 @@ $\mathsf{nf_ {dom_ 1}}$ and $\mathsf{nf_ {dom_ 2}}$ are unlinkable. This
 follows from the PRF property: distinct inputs produce outputs that are
 computationally indistinguishable from independent random values.
 
-**Spend authority prevents viewing-key delegation.** The circuit requires
-a valid spend authorization signature, ensuring that a party with only a
-viewing key cannot make claims on behalf of the holder.
+**Spend authority prevents viewing-key delegation.** The circuit
+constrains correct derivation of $\mathsf{rk}$, and the protocol
+requires a valid spend authorization signature under $\mathsf{rk}$
+(see [Spend Authorization Signature]), ensuring that a party with only
+a viewing key cannot make claims on behalf of the holder.
 
 **Non-membership tree queries.** Obtaining a Merkle path in the nullifier
 non-membership tree requires querying a data source that holds the full

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -129,8 +129,10 @@ experience of the Zcash coinholder voting system.
 A key practical consideration is that many holders custody their spending
 keys on hardware wallets such as Keystone. Without a delegation mechanism,
 hardware wallet users must either export their spending keys to software
-(negating the security benefit of hardware custody) or forgo participation entirely.
-This ZIP therefore specifies a PCZT-based signing flow (see
+(negating the security benefit of hardware custody) or perform many more
+hardware wallet signing interactions (one per protocol action rather than
+a single delegation) each with limited ability to verify the signing
+context on screen. This ZIP therefore specifies a PCZT-based signing flow (see
 [Wallet Signing]) that works with any hardware wallet supporting
 Orchard PCZT signing today, requiring no firmware changes.
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -751,10 +751,8 @@ $$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1},
    permutations.
 
 3. **Value.** The note value MUST be set to 1 zatoshi (0.00000001 ZEC)
-   in the PCZT so that the hardware wallet device renders all transaction
-   fields. A value of 0 causes a Keystone device to suppress
-   field display, degrading the user experience. The Claim circuit treats
-   the signed note value as 0 regardless of the PCZT value.
+   in the PCZT. The Claim circuit treats the signed note value as 0
+   regardless of the PCZT value.
 
 4. **Rseed.** A fresh random $\mathsf{rseed}$ is sampled for the note.
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -869,16 +869,6 @@ the same notes in a concurrent application. Alternate nullifiers avoid
 this by operating entirely off the main chain: the standard nullifiers are
 never revealed, and the notes remain spendable.
 
-## Why Poseidon for the Non-Membership Tree
-
-The Orchard note commitment tree uses Sinsemilla for Merkle hashing.
-Sinsemilla operates on bitstrings and requires decomposition of field
-elements into bits before hashing, incurring overhead in an arithmetic
-circuit. Poseidon operates natively on field elements, avoiding this
-decomposition. Since the non-membership tree is new infrastructure with
-no backwards-compatibility constraint, the more circuit-efficient
-primitive is used.
-
 ## Why Sentinel Initialization
 
 Without sentinels, the initial non-membership tree would contain a single

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -364,10 +364,10 @@ the mechanism for double-claim prevention.
 
 Applications SHOULD derive the domain deterministically from public
 parameters that bind it to a specific context. For example, an
-application-specific domain tag can be constructed by encoding a
-UTF-8 string as a little-endian Pallas base field element (zero-padded
-to 32 bytes), then combining it with a round or event identifier that
-is unique per claim context.
+application identifier (such as a UTF-8 protocol name encoded as a
+little-endian Pallas base field element, zero-padded to 32 bytes) can
+be combined with a round or event identifier via a hash, producing a
+single field element that is unique per claim context.
 
 Applications MAY define their own domain derivation scheme provided it
 satisfies the uniqueness requirement above.
@@ -379,24 +379,20 @@ Given a nullifier domain $\mathsf{dom}$ and an Orchard note with standard
 nullifier $\mathsf{nf^{old}}$, the alternate nullifier $\mathsf{nf_ {dom}}$
 is computed as:
 
-$$\mathsf{nf_ {dom}} = \mathsf{DeriveAlternateNullifier_ {nk}}(\mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$$
+$$\mathsf{nf_ {dom}} = \mathsf{DeriveAlternateNullifier_ {nk}}(\mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$$
 
 where:
 
 - $\mathsf{nk} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier deriving
   key from the holder's full viewing key.
-- $\mathsf{tag} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is an application-defined
-  domain separator constant that identifies the protocol type (e.g.,
-  governance, air-drop). This value is fixed per application and known to
-  both prover and verifier.
-- $\mathsf{dom} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier domain.
+- $\mathsf{dom} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier domain
+  (see [Nullifier Domains]).
 - $\mathsf{nf^{old}} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the note's
   standard Orchard nullifier, computed as
   $\mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
-This is a 4-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
-instantiation (width $t = 3$, rate 2), this requires two permutations
-to absorb four input elements.
+This is a 3-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
+instantiation (width $t = 3$, rate 2), this requires two permutations.
 
 ### Properties
 
@@ -420,23 +416,23 @@ The security of the alternate nullifier derivation relies on Poseidon
 being a pseudorandom function (PRF) when keyed with a uniformly random
 element of $\mathbb{F}_ {q_ {\mathbb{P}}}$.
 
-**Unlinkability.** Model $\mathsf{Poseidon}(\mathsf{nk}, \cdot, \cdot, \cdot)$
+**Unlinkability.** Model $\mathsf{Poseidon}(\mathsf{nk}, \cdot, \cdot)$
 as a PRF keyed by $\mathsf{nk}$. An adversary who does not know
 $\mathsf{nk}$ sees outputs that are indistinguishable from random. Given
-$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$
 and $\mathsf{nf^{old}}$, the adversary cannot verify the relationship
 without $\mathsf{nk}$. The nullifier deriving key $\mathsf{nk}$ is a
 255-bit value derived from the spending key and is never revealed on-chain.
 
 **Cross-domain unlinkability.** For two domains $\mathsf{dom_ 1} \neq \mathsf{dom_ 2}$,
-the tuples $(\mathsf{tag}, \mathsf{dom_ 1}, \mathsf{nf^{old}})$ and
-$(\mathsf{tag}, \mathsf{dom_ 2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
+the tuples $(\mathsf{dom_ 1}, \mathsf{nf^{old}})$ and
+$(\mathsf{dom_ 2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
 Under the PRF assumption, their outputs are jointly indistinguishable from
 independent random values.
 
 **Collision resistance.** If $\mathsf{nf^{old}_ 1} \neq \mathsf{nf^{old}_ 2}$,
-then $(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}_ 1})$ and
-$(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}_ 2})$ are distinct Poseidon
+then $(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_ 1})$ and
+$(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_ 2})$ are distinct Poseidon
 inputs, so their outputs collide with negligible probability under
 Poseidon's collision resistance.
 
@@ -585,10 +581,8 @@ To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}
 </details>
 
 **Alternate nullifier integrity.** $\hspace{0.5em}$
-$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{tag}, \mathsf{dom}, \mathsf{nf^{old}})$,
-where $\mathsf{tag}$ is the application-defined domain separator constant
-(see [Alternate Nullifier Derivation]), fixed per application and embedded
-in the circuit definition.
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$
+(see [Alternate Nullifier Derivation]).
 
 ### Circuit Implementation Notes
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -530,10 +530,6 @@ $\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{c
 **Nullifier derivation.** $\hspace{0.5em}$
 $\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{ψ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
-The standard nullifier is computed inside the circuit but is NOT a public
-input. It is used only as an intermediate value for the non-membership
-check and the alternate nullifier derivation. It is never revealed.
-
 **Spend authority.** $\hspace{0.5em}$
 $\mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}})$.
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -728,6 +728,8 @@ The wallet constructs a dummy Orchard note as follows:
 1. **Address.** The signed note's address is derived from the holder's
    full viewing key at diversifier index 0 with external scope:
    $\mathsf{addr}^{\mathsf{signed}} = \mathsf{fvk.address\_at}(0, \mathsf{External})$.
+   A fixed index is used because the address is a private witness inside
+   the ZKP circuit and is never publicly transmitted.
 
 2. **Nullifier commitment.** Because the dummy note
    has no on-chain existence, its fields (including $\text{ρ}$) can be

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -709,9 +709,6 @@ this ZIP.
 
 # Open issues
 
-- The security argument for the alternate nullifier derivation is
-  informal. A formal reduction from the unlinkability property to the
-  Poseidon PRF assumption would strengthen confidence.
 - The Poseidon instantiation ($\mathsf{P128Pow5T3}$) and its round
   constants should be explicitly referenced or pinned once a canonical
   parameter set for Zcash usage is published.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -250,9 +250,9 @@ $\mathsf{GapCommit}$ (see [Hash Function]) to produce a tree leaf.
 
 ### Construction
 
-Let $S = \{s_ 0, s_ 1, \ldots, s_ {m-1}\} \subset \mathbb{F}_ {q_ {\mathbb{P}}}$ be the set of all Orchard
-nullifiers revealed on the consensus chain as of block height $h$, together
-with the sentinel values defined in [Sentinel Initialization]. Sort $S$ in
+Let $S = \{s_ 0, s_ 1, \ldots, s_ {m-1}\} \subset \mathbb{F}_ {q_ {\mathbb{P}}}$ be the union of the set of all Orchard
+nullifiers revealed on the consensus chain as of block height $h$ and
+the sentinel values defined in [Sentinel Initialization]. Sort $S$ in
 ascending order.
 Because sentinel initialization is mandatory, $S$ is non-empty.
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -248,18 +248,19 @@ per claim, this trade-off favors prover efficiency.
 
 ### Hash Function
 
-The non-membership tree uses Poseidon [^poseidon], instantiated over
-the Pallas base field $\mathbb{F}_ {q_ {\mathbb{P}}}$, for all hashing:
+The non-membership tree uses Poseidon [^protocol-poseidon] with the
+$\mathsf{P128Pow5T3}$ instantiation (width $t = 3$, rate 2) over the
+Pallas base field $\mathbb{F}_ {q_ {\mathbb{P}}}$ for all hashing:
 
-- **Leaf hash:** $\mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$,
-  a 2-input Poseidon hash with width $t = 3$.
-- **Internal node hash:** $\mathsf{Poseidon}(\mathsf{left}, \mathsf{right})$,
-  a 2-input Poseidon hash with width $t = 3$, where $\mathsf{left}$ and
+- **Leaf hash:** $\mathsf{PoseidonLeafHash}(\mathsf{low}, \mathsf{width})$,
+  a 2-input Poseidon hash (one permutation).
+- **Internal node hash:** $\mathsf{PoseidonNodeHash}(\mathsf{left}, \mathsf{right})$,
+  a 2-input Poseidon hash (one permutation), where $\mathsf{left}$ and
   $\mathsf{right}$ are determined by the node's position bit at each level.
 
-Implementations MUST use the Poseidon instantiation over $\mathbb{F}_ {q_ {\mathbb{P}}}$
-with the standard parameter generation procedure from [^poseidon], targeting
-128-bit security.
+Both functions use $\mathsf{P128Pow5T3}$ with $\mathsf{ConstantLength}\langle 2 \rangle$.
+This is the same Poseidon instantiation used by Orchard for nullifier
+derivation [^protocol-poseidon].
 
 <details>
 <summary>
@@ -335,13 +336,11 @@ same underlying note will produce the same alternate nullifier, which is
 the mechanism for double-claim prevention.
 
 Applications SHOULD derive the domain deterministically from public
-parameters that bind it to a specific context. For example:
-
-$$\mathsf{dom} = \mathsf{Poseidon}(\text{"BalanceProofDomain"}, \mathsf{snapshot\_height}, \mathsf{purpose\_hash})$$
-
-where $\mathsf{purpose\_hash}$ is a hash of an application-specific
-identifier string. This derivation prevents accidental domain collisions
-across independent applications using the same snapshot.
+parameters that bind it to a specific context. For example, an
+application-specific domain tag can be constructed by encoding a
+UTF-8 string as a little-endian Pallas base field element (zero-padded
+to 32 bytes), then combining it with a round or event identifier that
+is unique per claim context.
 
 Applications MAY define their own domain derivation scheme provided it
 satisfies the uniqueness requirement above.
@@ -519,10 +518,12 @@ Then $\mathsf{pk_ d^{old}} = [\mathsf{ivk}]\, \mathsf{g_ d^{old}}$ or
 $\mathsf{pk_ d^{old}} = [\mathsf{ivk\_ {internal}}]\, \mathsf{g_ d^{old}}$.
 
 **Nullifier non-membership.** $\hspace{0.5em}$
-Let $\mathsf{leaf} = \mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$.
+Let $\mathsf{leaf} = \mathsf{PoseidonLeafHash}(\mathsf{low}, \mathsf{width})$
+(see [Hash Function]).
 $(\mathsf{path^{excl}}, \mathsf{pos^{excl}})$ is a valid Merkle path of
 depth $\mathsf{MerkleDepth^{excl}}$ from $\mathsf{leaf}$ to the anchor
-$\mathsf{rt^{excl}}$, using Poseidon for internal node hashing.
+$\mathsf{rt^{excl}}$, using $\mathsf{PoseidonNodeHash}$ (see [Hash Function])
+at each level.
 
 Additionally, let $x = \mathsf{nf^{old}} - \mathsf{low} \bmod q_ {\mathbb{P}}$.
 Both of the following range checks MUST hold:
@@ -718,13 +719,6 @@ this ZIP.
 
 # Open issues
 
-- The Poseidon instantiation ($\mathsf{P128Pow5T3}$) and its round
-  constants remain to be explicitly referenced or pinned once a canonical
-  parameter set for Zcash usage is published.
-- The interaction between multi-note batching and the sighash scheme
-  (what exactly is signed, and how it binds to all $N$ notes) requires
-  further specification per application.
-
 
 # References
 
@@ -739,6 +733,8 @@ this ZIP.
 [^protocol-merklepath]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 4.9: Merkle Path Validity](protocol/protocol.pdf#merklepath)
 
 [^protocol-sinsemilla]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 5.4.1.9: Sinsemilla Hash Function](protocol/protocol.pdf#concretesinsemillahash)
+
+[^protocol-poseidon]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 5.4.2: Pseudo Random Functions](protocol/protocol.pdf#concreteprfs)
 
 [^poseidon]: [Poseidon: A New Hash Function for Zero-Knowledge Proof Systems](https://eprint.iacr.org/2019/458)
 

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -1000,12 +1000,8 @@ sign the application-defined sighash directly.
 
 A reference implementation of the Claim circuit (including the
 non-membership tree, alternate nullifier derivation, and multi-note
-batching for $N_ {\max} = 5$) exists in the coinholder voting codebase used
-for this design.
-
-At the time of writing, some implementation repositories are not publicly
-accessible. Public, stable links will be added before finalization of
-this ZIP.
+batching for $N_ {\max} = 5$) is available at
+[valargroup/voting-circuits](https://github.com/valargroup/voting-circuits).
 
 
 # Open issues

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -62,10 +62,11 @@ Claim
 
 Dummy signed note
 
-: A synthetic Orchard note with value 0 (in the Claim circuit) that
-  does not exist in any on-chain note commitment tree. It is constructed
-  solely for obtaining a spend authorization signature from the holder's
-  key. See [Wallet Signing].
+: A synthetic Orchard note with value 1 zatoshi that does not exist in
+  any on-chain note commitment tree. It is constructed solely for
+  obtaining a spend authorization signature from the holder's key. Its
+  value does not contribute to the claimed balance. See [Wallet Signing]
+  and [Dummy Signed Note].
 
 
 # Abstract
@@ -697,6 +698,58 @@ as follows:
   Merkle path, nullifier derivation, non-membership, and alternate
   nullifier checks are performed independently per note.
 
+### Dummy Signed Note
+
+When the PCZT-based signing flow (see [Wallet Signing]) is used, the
+batched circuit MUST include an additional slot for the dummy signed
+note alongside the $N_{\max}$ claimed note slots. This slot has the
+following additional public input:
+
+- $\mathsf{nf^{signed}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
+
+and the following additional auxiliary inputs:
+
+- $\mathsf{g_ d^{signed}} ⦂ \mathbb{P}^*$
+- $\mathsf{pk_ d^{signed}} ⦂ \mathbb{P}^*$
+- $\text{ρ}^{\mathsf{signed}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\text{ψ}^{\mathsf{signed}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\mathsf{rcm^{signed}} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
+- $\mathsf{cm^{signed}} ⦂ \mathbb{P}$
+- $\mathsf{app\_commitment} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\mathsf{instance\_id} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+
+The following conditions MUST hold for the dummy signed note:
+
+**Signed note commitment integrity.** $\hspace{0.5em}$
+$\mathsf{NoteCommit^{Orchard}_ {rcm^{signed}}}(\mathsf{repr}_ {\mathbb{P}}(\mathsf{g_ d^{signed}}), \mathsf{repr}_ {\mathbb{P}}(\mathsf{pk_ d^{signed}}), 1, \text{ρ}^{\mathsf{signed}}, \text{ψ}^{\mathsf{signed}}) \in \{ \mathsf{cm^{signed}}, \bot \}$.
+
+The value is fixed to 1 (zatoshi) to match the PCZT value used for
+hardware wallet display (see [Wallet Signing]). The dummy signed note's
+value does not contribute to the claimed balance.
+
+**Signed note nullifier derivation.** $\hspace{0.5em}$
+$\mathsf{nf^{signed}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{signed}}, \text{ψ}^{\mathsf{signed}}, \mathsf{cm^{signed}})$.
+
+**Rho binding.** $\hspace{0.5em}$
+$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx_ 1}, \ldots, \mathsf{cmx_ {N_ {\max}}}, \mathsf{app\_commitment}, \mathsf{instance\_id}\bigr)$
+
+where $\mathsf{cmx_ i} = \mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}_ i})$
+is the extracted note commitment of the $i$-th claimed note slot
+(real or padded). This binds the hardware wallet's signature to the
+exact set of notes being claimed and the application context.
+
+**Spend authority.** $\hspace{0.5em}$
+$\mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}})$.
+
+This is the same $\mathsf{rk}$ shared across the $N_{\max}$ claimed
+note slots.
+
+**Diversified address integrity.** $\hspace{0.5em}$
+$\mathsf{pk_ d^{signed}} = [\mathsf{ivk}]\, \mathsf{g_ d^{signed}}$
+where $\mathsf{ivk}$ is derived from the shared
+$\mathsf{ak}^{\mathbb{P}}$ and $\mathsf{nk}$ as in the claimed note
+conditions.
+
 ### Note Padding
 
 To avoid leaking the number of notes a holder is claiming, the circuit
@@ -786,36 +839,16 @@ The wallet constructs a dummy Orchard note as follows:
    A fixed index is used because the address is a private witness inside
    the ZKP circuit and is never publicly transmitted.
 
-2. **Nullifier commitment.** Because the dummy note
-   has no on-chain existence, its fields (including $\text{ρ}$) can be
-   freely chosen. This design utilizes that freedom: $\text{ρ}$ is set to
-   a hash of the delegation context so that the note commitment, and
-   therefore the sighash, cryptographically binds the hardware wallet's
-   signature to the exact set of notes being delegated. This avoids
-   requiring a custom signing protocol; the hardware wallet signs a
-   standard Orchard PCZT, and the binding is enforced by the ZKP circuit
-   rather than by device firmware.
-
-   Concretely, the signed note's $\text{ρ}$ is set to:
-
-$$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1}, \ldots, \mathsf{cmx}\_{N_{\max}}, \mathsf{app\_commitment}, \mathsf{instance\_id}\bigr)$$
-
-   where $\mathsf{cmx}\_\mathsf{1} \ldots \mathsf{cmx}\_{N_{\max}}$ are the
-   extracted note commitments of the $N_{\max}$ delegated note slots
-   (real notes plus zero-value padding notes),
-   $\mathsf{app\_commitment}$ is an application-defined commitment
-   (e.g., a VAN commitment in the voting protocol [^voting-protocol]),
-   and $\mathsf{instance\_id}$ is the usage identifier that uniquely
-   identifies the proof-of-balance instance.
-
-   With $N_{\max} = 5$ this is a 7-input Poseidon hash using the
-   $\mathsf{P128Pow5T3}$ instantiation (width $t = 3$, rate 2) over
-   $\mathbb{F}_{q_{\mathbb{P}}}$. The seven inputs are absorbed in four
-   permutations.
+2. **Nullifier commitment.** The signed note's $\text{ρ}$ is set to
+   the value specified by the rho binding condition in [Dummy Signed Note].
+   Because the dummy note has no on-chain existence, $\text{ρ}$ can be
+   freely chosen; this design binds the hardware wallet's signature to
+   the exact set of notes being claimed and the application context via
+   the ZKP circuit, avoiding the need for a custom signing protocol.
 
 3. **Value.** The note value MUST be set to 1 zatoshi (0.00000001 ZEC)
-   in the PCZT. The Claim circuit treats the signed note value as 0
-   regardless of the PCZT value.
+   in the PCZT, matching the value used in the signed note commitment
+   integrity condition (see [Dummy Signed Note]).
 
 4. **Rseed.** A fresh random $\mathsf{rseed}$ is sampled for the note.
 
@@ -951,10 +984,10 @@ note, Keystone's suppress the display of transaction fields
 information to make an informed signing decision. Setting the value to
 1 zatoshi causes the device to render all fields normally.
 
-The Claim circuit enforces that the signed note value is 0 regardless of
-the PCZT value. The 1-zatoshi value exists solely in the serialized PCZT
-for the benefit of the device's display logic and has no effect on
-protocol security or fund safety.
+The Batched Claim circuit uses the 1-zatoshi value in the signed note
+commitment integrity check (see [Dummy Signed Note]), matching the
+PCZT value. The dummy signed note's value does not contribute to the
+claimed balance.
 
 ## Why a Dummy Note Instead of a Real Note
 
@@ -990,8 +1023,9 @@ the exact delegation context. An attacker cannot replay the signature
 for a different set of notes, a different application commitment, or a
 different usage instance.
 
-This binding is enforced by the Claim circuit, which the application
-verifier checks. The hardware wallet device does not need to understand
+This binding is enforced by the Batched Claim circuit's rho binding
+condition (see [Dummy Signed Note]), which the application verifier
+checks. The hardware wallet device does not need to understand
 the binding; it is sufficient that the device signs the sighash derived
 from the PCZT containing the committed $\text{ρ}$. No custom signing
 protocol is required — the standard Orchard PCZT flow is reused, and

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -60,6 +60,29 @@ Claim
   committed value at a given pool snapshot, and revealing the note's
   alternate nullifier in a specified domain.
 
+Governance PCZT
+
+: A Partially Created Zcash Transaction [^pczt] constructed solely for
+  governance delegation. The PCZT contains a single Orchard Action that
+  spends a dummy signed note and produces an output to the governance
+  hotkey address.
+
+Dummy signed note
+
+: A synthetic Orchard note with value 0 (in the Claim circuit) whose
+  $\text{ρ}$ is deterministically bound to the delegation context. The
+  note does not exist in any on-chain note commitment tree.
+
+Rho binding
+
+: The constraint that the dummy signed note's
+  $\text{ρ}^{\mathsf{signed}}$ equals a Poseidon hash of the delegated
+  note commitments, the VAN commitment, and the voting round identifier.
+
+The terms "Vote Authority Note (VAN)", "governance nullifier", "voting
+round", "governance hotkey", and "ballot" are defined in the Shielded
+Voting Protocol ZIP [^voting-protocol].
+
 
 # Abstract
 
@@ -119,6 +142,14 @@ in a 2023 draft. [^draft-str4d-orchard-balance-proof] This ZIP builds on
 that work with a concrete instantiation informed by the implementation
 experience of the Zcash coinholder voting system.
 
+A key practical consideration is that many holders custody their spending
+keys on hardware wallets such as Keystone. Without a delegation mechanism,
+hardware wallet users must either export their spending keys to software
+(negating the security benefit of hardware custody) or forgo participation entirely.
+This ZIP therefore specifies a PCZT-based signing flow (see
+[Hardware Wallet Signing]) that works with any hardware wallet supporting
+Orchard PCZT signing today, requiring no firmware changes.
+
 
 # Privacy Implications
 
@@ -149,6 +180,20 @@ tree. A naive query reveals which path is being requested, potentially
 linking the querier to a nullifier range. Private information retrieval
 (PIR) techniques can mitigate this leakage [^pir-nullifier-exclusion]; their
 specification is out of scope for this document.
+
+**Hardware wallet device exposure.** When the PCZT-based hardware wallet
+signing flow (see [Hardware Wallet Signing]) is used, the device observes
+the governance PCZT but learns no information about the holder's real
+Orchard balance or delegation context. The PCZT contains a 1-zatoshi
+dummy note with no on-chain counterpart; the holder's actual note
+commitments, values, and nullifiers are never transmitted to the device.
+The VAN commitment, governance nullifiers, and voting round identifier are
+embedded in the rho binding inside the ZKP circuit and do not appear as
+plaintext fields in the PCZT. The output address (governance hotkey) is
+visible on the device but is freshly generated per voting round and is not
+linked to the holder's on-chain Orchard addresses. An attacker with
+physical access to the device during signing learns only that the holder
+is participating in a governance round and the declared voting weight.
 
 
 # Requirements
@@ -646,6 +691,159 @@ distinguishes real notes from padded notes:
   performing them is also sound since padded notes use valid dummy data.
 
 
+## Hardware Wallet Signing
+
+The delegation signing flow proceeds in five steps:
+
+1. The wallet generates a governance hotkey on the local device.
+2. The wallet constructs a dummy signed note with rho bound to the
+   delegation context.
+3. The wallet builds a governance PCZT containing the dummy signed note.
+4. The hardware wallet device signs the PCZT and returns the signature.
+5. The wallet extracts the signature and assembles the delegation
+   submission.
+
+Each interaction with the hardware wallet device delegates up to 5
+Orchard notes (the per-delegation batch size defined in
+[^voting-protocol]). A holder with more than 5 notes repeats the flow
+for each batch of up to 5, producing a separate VAN per batch. The
+holder MAY choose to delegate fewer batches than their full note set,
+voting with only the balance covered by the delegated batches.
+
+### Dummy Signed Note Construction
+
+The wallet constructs a dummy Orchard note as follows:
+
+1. **Address.** The signed note's address is derived from the holder's
+   full viewing key at diversifier index 0 with external scope:
+   $\mathsf{addr}^{\mathsf{signed}} = \mathsf{fvk.address\_at}(0, \mathsf{External})$.
+
+2. **Rho binding.** The signed note's $\text{ρ}$ is set to:
+
+$$\text{ρ}^{\mathsf{signed}} = \mathsf{Poseidon}\bigl(\mathsf{cmx}\_\mathsf{1}, \mathsf{cmx}\_\mathsf{2}, \mathsf{cmx}\_\mathsf{3}, \mathsf{cmx}\_\mathsf{4}, \mathsf{cmx}\_\mathsf{5}, \mathsf{van}, \mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}\bigr)$$
+
+   where $\mathsf{cmx}\_\mathsf{1} \ldots \mathsf{cmx}\_\mathsf{5}$ are the
+   extracted note commitments of the 5 delegated note slots (real notes
+   plus zero-value padding notes), $\mathsf{van}$ is the VAN commitment
+   as defined in [^voting-protocol], and
+   $\mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}$ is the round identifier.
+
+   This is a 7-input Poseidon hash using the $\mathsf{P128Pow5T3}$
+   instantiation (width $t = 3$, rate 2) over $\mathbb{F}_{q_{\mathbb{P}}}$.
+   The seven inputs are absorbed in four permutations.
+
+3. **Value.** The note value MUST be set to 1 zatoshi (0.00000001 ZEC)
+   in the PCZT so that the hardware wallet device renders all transaction
+   fields. A value of 0 causes a Keystone device to suppress
+   field display, degrading the user experience. The Claim circuit treats
+   the signed note value as 0 regardless of the PCZT value.
+
+4. **Rseed.** A fresh random $\mathsf{rseed}$ is sampled for the note.
+
+5. **Note construction.** The note is constructed via standard Orchard
+   note construction using the address, value (1 zatoshi), rho, and
+   rseed above.
+
+For fewer than 5 real notes, the wallet pads the remaining slots with
+zero-value dummy notes at diversifier indices $1000 + i$ (external
+scope) from the holder's full viewing key. These padding notes enter
+the rho binding via their $\mathsf{cmx}$ values but do not correspond
+to real on-chain notes.
+
+### Governance PCZT Construction
+
+The wallet constructs a governance PCZT as a single-action Orchard
+transaction:
+
+#### Spend Side
+
+- The single spend consumes the dummy signed note constructed above.
+- A dummy Merkle authentication path (all-zero siblings, position 0)
+  is used. The path is not verified on-chain; spend authorization is
+  established by the ZKP circuit.
+- The Orchard bundle builder generates the spend authorization
+  randomizer $\alpha$ and the randomized verification key
+  $\mathsf{rk} = \mathsf{ak} + [\alpha]\, G$ internally.
+
+#### Output Side
+
+- A single output of 1 zatoshi is addressed to the governance hotkey.
+- The output memo SHOULD contain a human-readable delegation description:
+
+  `"I am authorizing this hotkey managed by my wallet to vote on`
+  `{round_name} with {amount}.{frac} ZEC."`
+
+  where `{round_name}` is the voting round title and
+  `{amount}.{frac}` is the holder's eligible ZEC balance.
+
+#### ZIP-32 Derivation
+
+The spend MUST include a ZIP 32 [^zip-32] derivation path so that the
+hardware wallet device can derive the correct spending key:
+
+$$\mathsf{path} = [32', \mathsf{coin\_type}', \mathsf{account}']$$
+
+where $\mathsf{coin\_type}$ is 133 for Zcash mainnet.
+
+#### Finalization
+
+The wallet applies the PCZT Creator and IoFinalizer roles. The
+IoFinalizer computes the ZIP 244 [^zip-244] transaction identifier
+(sighash) that the hardware wallet device will sign.
+
+### Device Display
+
+During signing, the hardware wallet device displays the governance PCZT
+as a standard Orchard transaction. The user sees fields such as:
+
+    Amount: 0.00000001 ZEC
+    Fee: 0 ZEC
+
+    Orchard
+    From
+    #1 0.00000001 ZEC Mine
+    <shielded>
+
+    To
+    #1 0.00000001 ZEC
+    {governance hotkey address}
+    Memo: I am authorizing this hotkey managed by my
+          wallet to vote on {round_name} with
+          {amount}.{frac} ZEC
+
+The 0.00000001 ZEC amount (1 zatoshi) and 0 ZEC fee confirm that no
+real funds are being transferred. The "To" address matches the
+governance hotkey address displayed in the wallet application. The memo
+provides human-readable context for what the user is authorizing.
+
+The hardware wallet device has no awareness of governance semantics. It
+interprets the governance PCZT identically to any other Orchard
+transaction.
+
+### Signature Extraction and Submission
+
+After receiving the signed PCZT from the hardware wallet device, the
+wallet:
+
+1. Parses the signed PCZT structurally and reads the `spend_auth_sig`
+   field from the relevant action. Some devices (e.g., Keystone) redact
+   sensitive fields ($\alpha$, rseed, ZIP-32 derivation) after signing,
+   so the wallet MUST extract the signature by parsing the PCZT structure
+   rather than by byte-diffing against the unsigned version.
+
+2. Extracts the sighash that the device signed. This is the ZIP 244
+   transaction identifier computed over the governance PCZT.
+
+3. Assembles the delegation submission by combining the hardware wallet
+   signature and sighash with the Delegation Proof and other public
+   inputs. The full delegation message structure is defined in the
+   Delegation Message section of [^voting-protocol].
+
+The delegation submission is sent to the vote chain. The wallet does
+not need the hardware wallet device again for the remainder of the
+voting round; all subsequent operations (voting, share submission) use
+the governance hotkey.
+
 # Rationale
 
 ## Why Alternate Nullifiers Instead of Actual Spends
@@ -689,20 +887,85 @@ Sentinels partition the field into intervals each narrower than $2^{250}$
 at initialization. Real nullifier insertions only split intervals into
 smaller ones, so the width bound is maintained permanently.
 
+## Why 1 Zatoshi Instead of 0
+
+The dummy signed note uses a value of 1 zatoshi (0.00000001 ZEC) in the
+governance PCZT rather than 0. When an Orchard Action has a 0-value
+note, Keystone's suppress the display of transaction fields
+(amount, fee, addresses, memo), presenting the user with insufficient
+information to make an informed signing decision. Setting the value to
+1 zatoshi causes the device to render allfields normally.
+
+The Claim circuit enforces that the signed note value is 0 regardless of
+the PCZT value. The 1-zatoshi value exists solely in the serialized PCZT
+for the benefit of the device's display logic and has no effect on
+protocol security or fund safety.
+
+## Why a Dummy Note Instead of a Real Note
+
+A holder's real Orchard notes are not spent or consumed during
+delegation. The dummy signed note is constructed specifically for
+governance and never appears in any on-chain note commitment tree. This
+design has three advantages:
+
+- **No fund risk.** Because the governance PCZT is never broadcast to
+  the Zcash mainchain and the signed note has no on-chain existence,
+  there is no scenario in which the delegation signing could result in
+  loss of funds.
+- **Note reusability.** Because real notes are never consumed on
+  mainchain, they remain fully spendable and available for other
+  applications that use the proof-of-balance mechanism. Governance
+  nullifiers are domain-separated by
+  $\mathsf{voting}\_{\mathsf{round}\_\mathsf{id}}$, so the same notes
+  can participate in concurrent voting rounds or other balance-proof
+  use cases without conflict.
+- **PCZT compatibility.** The dummy note reuses the standard Orchard
+  Action structure, allowing the governance PCZT to pass through the
+  hardware wallet's existing PCZT parser and signer without
+  modification.
+
+## Why Rho Binding Provides Non-Replayability
+
+The dummy signed note's $\text{ρ}^{\mathsf{signed}}$ is set to a
+Poseidon hash of the delegated note commitments, the VAN, and the
+voting round identifier. Because $\text{ρ}$ enters the note commitment
+(and therefore the sighash), the hardware wallet's signature is
+cryptographically bound to the exact delegation context. An attacker
+cannot replay the signature for a different set of notes, a different
+VAN, or a different voting round.
+
+This binding is enforced by the Claim circuit's rho binding condition,
+which the vote chain verifies. The hardware wallet device does not need
+to understand the binding; it is sufficient that the device signs the
+sighash derived from the PCZT containing the bound $\text{ρ}$.
+
+## Why ZIP 244 Sighash
+
+The governance PCZT uses the standard ZIP 244 [^zip-244] transaction
+identifier as the sighash. This is the only sighash format that
+existing hardware wallet Orchard signing implementations can produce.
+Using a governance-specific sighash would require firmware changes,
+which this specification explicitly avoids.
+
+The ZIP 244 sighash commits to the full Orchard bundle structure
+(including the dummy note's commitment, which embeds the bound
+$\text{ρ}$), providing the necessary cryptographic binding without
+a custom signature scheme.
+
 
 # Deployment
 
 This ZIP does not specify a consensus change. Deployment considerations
 are application-specific.
 
-For applications using hardware wallets (e.g., Keystone), the spend
-authorization signature is obtained through a PCZT-based signing flow
-where the hardware wallet signs a transaction that encodes the claim
-context. The hardware wallet need not understand the claim semantics; it
-signs a standard Orchard spend authorization. Applications that support
-Keystone firmware with voting-aware context display can provide richer
-user assurance, but both modes use the same underlying circuit and
-signature scheme.
+The hardware wallet signing flow specified in [Hardware Wallet Signing]
+requires no firmware changes and no changes to Zcash mainchain consensus
+rules. Any hardware wallet that supports Orchard PCZT signing can
+participate immediately.
+
+Software wallets that hold the spending key directly do not need the
+PCZT construction; they follow the same Claim proof specification but
+sign the application-defined sighash directly.
 
 
 # Reference implementation
@@ -718,6 +981,32 @@ this ZIP.
 
 
 # Open issues
+
+- **v2 hardware wallet signing with a new transaction format.** The
+  hardware wallet signing flow specified in this ZIP (v1) reuses the
+  existing Orchard PCZT format and requires no firmware changes from any
+  custodian. A v2 of the protocol could introduce a new transaction
+  format purpose-built for token holder voting, enabling:
+
+  - Finer-grained delegation from a hardware wallet to a hotkey, without
+    requiring the ZK circuit to verify blake2b.
+  - Combination of the first and second ZKPs in the voting design into a
+    single proof.
+  - Better UX for what the user is signing over, with governance-aware
+    context display on the device screen.
+
+  However, v2 would require a firmware update, and then every one of those users
+  would need to update their device before they could vote.
+
+  If both v1 (compatible with the base Zcash transaction format) and v2
+  (governance-specific format) are supported simultaneously, the system
+  SHOULD NOT publicly leak which custody method or protocol version a
+  voter is using. This will come with proving and format overheads whose
+  design can be determined closer to the time of v2 deployment.
+
+- **Memo content standardization.** The delegation memo format is
+  currently informational. A future revision could specify a structured
+  memo format to support programmatic verification of delegation intent.
 
 
 # References
@@ -741,3 +1030,15 @@ this ZIP.
 [^pir-nullifier-exclusion]: [Draft ZIP: Private Information Retrieval for Nullifier Exclusion Proofs](https://github.com/zcash/zips/pull/1198)
 
 [^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)
+
+[^voting-protocol]: [Shielded Voting Protocol](draft-valargroup-shielded-voting)
+
+[^pczt]: [zcash/zips issue #693: Standardize a protocol for creating shielded transactions offline (PCZT)](https://github.com/zcash/zips/issues/693)
+
+[^zip-244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244)
+
+[^zip-32]: [ZIP 32: Shielded Hierarchical Deterministic Wallets](zip-0032)
+
+[^protocol-concretespendauthsig]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 5.4.7.1: Spend Authorization Signature (Orchard)](protocol/protocol.pdf#concretespendauthsig)
+
+[^ur]: [BCR-2020-005: Uniform Resources (UR)](https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-005-ur.md)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -362,12 +362,13 @@ independent claim contexts. Two claims that share the same domain and the
 same underlying note will produce the same alternate nullifier, which is
 the mechanism for double-claim prevention.
 
-Applications SHOULD derive the domain deterministically from public
-parameters that bind it to a specific context. For example, an
-application identifier (such as a UTF-8 protocol name encoded as a
-little-endian Pallas base field element, zero-padded to 32 bytes) can
-be combined with a round or event identifier via a hash, producing a
-single field element that is unique per claim context.
+Applications SHOULD derive the domain deterministically by hashing a
+protocol identifier with an application-specific instance value. The
+protocol identifier SHOULD be the application's ZIP number, encoded as
+a little-endian Pallas base field element, which guarantees
+cross-application uniqueness. The instance value (such as a round or
+event identifier) ensures uniqueness across instances of the same
+application.
 
 Applications MAY define their own domain derivation scheme provided it
 satisfies the uniqueness requirement above.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -188,8 +188,7 @@ instance and the declared balance.
 - A holder can prove ownership of an unspent Orchard note at a pool
   snapshot without revealing the note's standard nullifier.
 - Double-claiming the same note within the same nullifier domain is
-  detectable: the alternate nullifier is deterministic, so a duplicate
-  claim produces an identical value that the verifier can reject.
+  detectable.
 - Claims are unlinkable to the holder's past or future on-chain spends,
   and to their claims in other nullifier domains.
 - The holder proves spend authority (not merely viewing access).

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -290,7 +290,8 @@ nullifiers. As of early 2026, the Zcash Orchard pool contains roughly
 51 million nullifiers, so depth 29 provides about one order of magnitude
 of headroom.
 Implementations MAY choose a different depth to suit their capacity
-requirements; the circuit must be parameterized accordingly.
+requirements, but the circuit MUST be parameterized accordingly based on
+the chosen depth.
 
 Unused leaf positions MUST be filled with a canonical empty leaf value
 (the hash of the zero interval).

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -48,7 +48,7 @@ Alternate nullifier
 
 Nullifier domain
 
-: A unique identifier, encoded as an element of $\mathbb{F}_{q_{\mathbb{P}}}$,
+: A unique identifier, encoded as an element of $\mathbb{F}_ {q_ {\mathbb{P}}}$,
   that scopes alternate nullifiers to a particular application instance. Two
   claims in the same domain for the same note produce the same alternate
   nullifier; claims in different domains are unlinkable.
@@ -123,9 +123,9 @@ experience of the Zcash coinholder voting system.
 # Privacy Implications
 
 **Unlinkability to standard nullifiers.** The alternate nullifier
-$\mathsf{nf_{dom}}$ for a note is computed as a Poseidon hash keyed by the
+$\mathsf{nf_ {dom}}$ for a note is computed as a Poseidon hash keyed by the
 nullifier deriving key $\mathsf{nk}$, which is secret. An observer who
-sees both $\mathsf{nf_{dom}}$ (published during a claim) and the standard
+sees both $\mathsf{nf_ {dom}}$ (published during a claim) and the standard
 nullifier $\mathsf{nf^{old}}$ (published when the note is later spent on
 the Zcash chain) cannot link them without knowledge of $\mathsf{nk}$.
 This property holds under the assumption that Poseidon is a pseudorandom
@@ -133,9 +133,9 @@ function when keyed with a uniformly random field element (see
 [Security Argument]).
 
 **Cross-domain unlinkability.** If the same note participates in two
-independent applications with different nullifier domains $\mathsf{dom_1}$
-and $\mathsf{dom_2}$, the resulting alternate nullifiers
-$\mathsf{nf_{dom_1}}$ and $\mathsf{nf_{dom_2}}$ are unlinkable. This
+independent applications with different nullifier domains $\mathsf{dom_ 1}$
+and $\mathsf{dom_ 2}$, the resulting alternate nullifiers
+$\mathsf{nf_ {dom_ 1}}$ and $\mathsf{nf_ {dom_ 2}}$ are unlinkable. This
 follows from the PRF property: distinct inputs produce outputs that are
 computationally indistinguishable from independent random values.
 
@@ -205,28 +205,28 @@ in-circuit proofs that a given nullifier is absent from the revealed set.
 
 ### Construction
 
-Let $S = \{s_0, s_1, \ldots, s_{m-1}\}$ be the set of all Orchard
+Let $S = \{s_ 0, s_ 1, \ldots, s_ {m-1}\}$ be the set of all Orchard
 nullifiers revealed on the consensus chain as of block height $h$, together
 with a set of sentinel values (see [Sentinel Initialization]). Sort $S$ in
-ascending order as elements of $\mathbb{F}_{q_{\mathbb{P}}}$.
+ascending order as elements of $\mathbb{F}_ {q_ {\mathbb{P}}}$.
 Because sentinel initialization is mandatory, $S$ is non-empty.
 
-For each pair of consecutive elements $(s_i, s_{i+1})$ where $s_i < s_{i+1}$
-and $s_{i+1} - s_i > 1$, create a leaf with:
+For each pair of consecutive elements $(s_ i, s_ {i+1})$ where $s_ i < s_ {i+1}$
+and $s_ {i+1} - s_ i > 1$, create a leaf with:
 
-- $\mathsf{low} = s_i + 1$ — the first value in the gap
-- $\mathsf{width} = s_{i+1} - s_i - 2$ — the number of additional values
+- $\mathsf{low} = s_ i + 1$ — the first value in the gap
+- $\mathsf{width} = s_ {i+1} - s_ i - 2$ — the number of additional values
   in the gap beyond $\mathsf{low}$
 
 The leaf represents the closed interval
 $[\mathsf{low},\; \mathsf{low} + \mathsf{width}]$, which contains exactly
-the field elements between $s_i$ and $s_{i+1}$ exclusive.
+the field elements between $s_ i$ and $s_ {i+1}$ exclusive.
 
-After processing all consecutive pairs, if $s_{m-1} < q_{\mathbb{P}} - 1$,
+After processing all consecutive pairs, if $s_ {m-1} < q_ {\mathbb{P}} - 1$,
 a terminal leaf MUST be added with:
 
-- $\mathsf{low} = s_{m-1} + 1$
-- $\mathsf{width} = (q_{\mathbb{P}} - 1) - \mathsf{low}$
+- $\mathsf{low} = s_ {m-1} + 1$
+- $\mathsf{width} = (q_ {\mathbb{P}} - 1) - \mathsf{low}$
 
 This ensures that all unrevealed values above the largest element of $S$ are
 represented in the tree.
@@ -246,7 +246,7 @@ per claim, this trade-off favors prover efficiency.
 ### Hash Function
 
 The non-membership tree uses Poseidon [^poseidon] over
-$\mathbb{F}_{q_{\mathbb{P}}}$ (the Pallas base field) for all hashing:
+$\mathbb{F}_ {q_ {\mathbb{P}}}$ (the Pallas base field) for all hashing:
 
 - **Leaf hash:** $\mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$,
   a 2-input Poseidon hash with width $t = 3$.
@@ -254,7 +254,7 @@ $\mathbb{F}_{q_{\mathbb{P}}}$ (the Pallas base field) for all hashing:
   a 2-input Poseidon hash with width $t = 3$, where $\mathsf{left}$ and
   $\mathsf{right}$ are determined by the node's position bit at each level.
 
-Implementations MUST use the Poseidon instantiation over $\mathbb{F}_{q_{\mathbb{P}}}$
+Implementations MUST use the Poseidon instantiation over $\mathbb{F}_ {q_ {\mathbb{P}}}$
 with the standard parameter generation procedure from [^poseidon], targeting
 128-bit security.
 
@@ -288,10 +288,10 @@ Unused leaf positions MUST be filled with a canonical empty leaf value
 ### Sentinel Initialization
 
 Before inserting any real nullifiers, the non-membership tree MUST be
-initialized with sentinel values that partition $\mathbb{F}_{q_{\mathbb{P}}}$
+initialized with sentinel values that partition $\mathbb{F}_ {q_ {\mathbb{P}}}$
 into intervals each of width strictly less than $2^{250}$.
 
-For the Pallas base field ($q_{\mathbb{P}} \approx 2^{254}$),
+For the Pallas base field ($q_ {\mathbb{P}} \approx 2^{254}$),
 implementations MUST insert 17 sentinels at:
 
 $$s_k = k \cdot 2^{250}, \quad k \in \{0,1,\ldots,16\}.$$
@@ -301,7 +301,7 @@ This guarantees the width bound required by the in-circuit range checks:
 - For $k = 0,\ldots,15$, the interval between consecutive sentinels has
   width exactly $2^{250} - 2$.
 - The final tail interval has width
-  $q_{\mathbb{P}} - 16 \cdot 2^{250} - 2 < 2^{250}$.
+  $q_ {\mathbb{P}} - 16 \cdot 2^{250} - 2 < 2^{250}$.
 
 The width bound is critical for the soundness of the in-circuit range
 checks. If any interval had width $\geq 2^{250}$, the range check could
@@ -314,7 +314,7 @@ tree specification so that any party can reconstruct the tree independently.
 ## Nullifier Domains
 
 A nullifier domain $\mathsf{dom}$ is an element of
-$\mathbb{F}_{q_{\mathbb{P}}}$ that defines a double-claim detection scope.
+$\mathbb{F}_ {q_ {\mathbb{P}}}$ that defines a double-claim detection scope.
 Each independent claim context (such as a specific air-drop event, a single
 poll, or an individual voting round) MUST use its own domain.
 
@@ -339,19 +339,19 @@ satisfies the uniqueness requirement above.
 ## Alternate Nullifier Derivation
 
 Given a nullifier domain $\mathsf{dom}$ and an Orchard note with standard
-nullifier $\mathsf{nf^{old}}$, the alternate nullifier $\mathsf{nf_{dom}}$
+nullifier $\mathsf{nf^{old}}$, the alternate nullifier $\mathsf{nf_ {dom}}$
 is computed as:
 
-$$\mathsf{nf_{dom}} = \mathsf{DeriveAlternateNullifier_{nk}}(\mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$$
+$$\mathsf{nf_ {dom}} = \mathsf{DeriveAlternateNullifier_ {nk}}(\mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$$
 
 where:
 
-- $\mathsf{nk} \in \mathbb{F}_{q_{\mathbb{P}}}$ is the nullifier deriving
+- $\mathsf{nk} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier deriving
   key from the holder's full viewing key.
-- $\mathsf{dom} \in \mathbb{F}_{q_{\mathbb{P}}}$ is the nullifier domain.
-- $\mathsf{nf^{old}} \in \mathbb{F}_{q_{\mathbb{P}}}$ is the note's
+- $\mathsf{dom} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the nullifier domain.
+- $\mathsf{nf^{old}} \in \mathbb{F}_ {q_ {\mathbb{P}}}$ is the note's
   standard Orchard nullifier, computed as
-  $\mathsf{DeriveNullifier_{nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
+  $\mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
 This is a 3-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
 instantiation (width $t = 3$, rate 2), this requires two permutations
@@ -363,7 +363,7 @@ to absorb three input elements.
 same alternate nullifier, enabling double-claim detection.
 
 **Unlinkable to standard nullifier.** An adversary who observes
-$\mathsf{nf_{dom}}$ and later observes $\mathsf{nf^{old}}$ (when the note
+$\mathsf{nf_ {dom}}$ and later observes $\mathsf{nf^{old}}$ (when the note
 is spent on-chain) cannot link them without knowledge of $\mathsf{nk}$.
 
 **Cross-domain unlinkable.** Alternate nullifiers for the same note in
@@ -377,25 +377,25 @@ distinct alternate nullifiers, under the collision resistance of Poseidon.
 
 The security of the alternate nullifier derivation relies on Poseidon
 being a pseudorandom function (PRF) when keyed with a uniformly random
-element of $\mathbb{F}_{q_{\mathbb{P}}}$.
+element of $\mathbb{F}_ {q_ {\mathbb{P}}}$.
 
 **Unlinkability.** Model $\mathsf{Poseidon}(\mathsf{nk}, \cdot, \cdot)$
 as a PRF keyed by $\mathsf{nk}$. An adversary who does not know
 $\mathsf{nk}$ sees outputs that are indistinguishable from random. Given
-$\mathsf{nf_{dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$
 and $\mathsf{nf^{old}}$, the adversary cannot verify the relationship
 without $\mathsf{nk}$. The nullifier deriving key $\mathsf{nk}$ is a
 255-bit value derived from the spending key and is never revealed on-chain.
 
-**Cross-domain unlinkability.** For two domains $\mathsf{dom_1} \neq \mathsf{dom_2}$,
-the pairs $(\mathsf{dom_1}, \mathsf{nf^{old}})$ and
-$(\mathsf{dom_2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
+**Cross-domain unlinkability.** For two domains $\mathsf{dom_ 1} \neq \mathsf{dom_ 2}$,
+the pairs $(\mathsf{dom_ 1}, \mathsf{nf^{old}})$ and
+$(\mathsf{dom_ 2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
 Under the PRF assumption, their outputs are jointly indistinguishable from
 independent random values.
 
-**Collision resistance.** If $\mathsf{nf^{old}_1} \neq \mathsf{nf^{old}_2}$,
-then $(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_1})$ and
-$(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_2})$ are distinct Poseidon
+**Collision resistance.** If $\mathsf{nf^{old}_ 1} \neq \mathsf{nf^{old}_ 2}$,
+then $(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_ 1})$ and
+$(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_ 2})$ are distinct Poseidon
 inputs, so their outputs collide with negligible probability under
 Poseidon's collision resistance.
 
@@ -406,7 +406,7 @@ The earlier draft [^draft-str4d-orchard-balance-proof] proposed an
 alternate nullifier derivation structurally parallel to the standard
 Orchard nullifier:
 
-$$\mathsf{Extract}_{\mathbb{P}}\!\left(\!\left[(\mathsf{PRF^{nfAlternate}_{nk}}(\text{ρ}^{\mathsf{old}}, \mathsf{dom}) + \text{φ}^{\mathsf{old}}) \bmod q_{\mathbb{P}}\right] \mathcal{K}^\mathsf{Orchard} + \mathsf{cm^{old}}\right)$$
+$$\mathsf{Extract}_ {\mathbb{P}}\!\left(\!\left[(\mathsf{PRF^{nfAlternate}_ {nk}}(\text{ρ}^{\mathsf{old}}, \mathsf{dom}) + \text{φ}^{\mathsf{old}}) \bmod q_ {\mathbb{P}}\right] \mathcal{K}^\mathsf{Orchard} + \mathsf{cm^{old}}\right)$$
 
 That construction has the advantage of sharing more circuit infrastructure
 with the standard nullifier check.
@@ -436,35 +436,35 @@ A valid instance of a Claim proof $\pi$ assures the following statement.
 
 Given a primary input:
 
-- $\mathsf{rt^{cm}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
-- $\mathsf{rt^{excl}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{rt^{cm}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
+- $\mathsf{rt^{excl}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 - $\mathsf{rk} ⦂ \mathsf{SpendAuthSig^{Orchard}.Public}$
-- $\mathsf{nf_{dom}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
-- $\mathsf{dom} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{nf_ {dom}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
+- $\mathsf{dom} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
 - $\mathsf{cv} ⦂ \mathsf{ValueCommit^{Orchard}.Output}$
 
 ### Auxiliary Inputs
 
 the prover knows an auxiliary input:
 
-- $\mathsf{g_d^{old}} ⦂ \mathbb{P}^*$
-- $\mathsf{pk_d^{old}} ⦂ \mathbb{P}^*$
-- $\mathsf{v^{old}} ⦂ \{ 0 .. 2^{\ell_{\mathsf{value}}}-1 \}$
-- $\text{ρ}^{\mathsf{old}} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
-- $\text{φ}^{\mathsf{old}} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
-- $\mathsf{rcm^{old}} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_{\mathsf{scalar}}}-1 \}$
+- $\mathsf{g_ d^{old}} ⦂ \mathbb{P}^*$
+- $\mathsf{pk_ d^{old}} ⦂ \mathbb{P}^*$
+- $\mathsf{v^{old}} ⦂ \{ 0 .. 2^{\ell_ {\mathsf{value}}}-1 \}$
+- $\text{ρ}^{\mathsf{old}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\text{φ}^{\mathsf{old}} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\mathsf{rcm^{old}} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
 - $\mathsf{cm^{old}} ⦂ \mathbb{P}$
-- $\mathsf{nf^{old}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
-- $\mathsf{path^{cm}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{Orchard}}]}$
+- $\mathsf{nf^{old}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}$
+- $\mathsf{path^{cm}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{Orchard}}]}$
 - $\mathsf{pos^{cm}} ⦂ \{ 0 .. 2^{\mathsf{MerkleDepth^{Orchard}}}\!-1 \}$
 - $\mathsf{ak}^{\mathbb{P}} ⦂ \mathbb{P}^*$
-- $\mathsf{nk} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
+- $\mathsf{nk} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
 - $\mathsf{rivk} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
-- $\alpha ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_{\mathsf{scalar}}}-1 \}$
-- $\mathsf{rcv} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_{\mathsf{scalar}}}-1 \}$
-- $\mathsf{low} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
-- $\mathsf{width} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
-- $\mathsf{path^{excl}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{excl}}]}$
+- $\alpha ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
+- $\mathsf{rcv} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_ {\mathsf{scalar}}}-1 \}$
+- $\mathsf{low} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\mathsf{width} ⦂ \mathbb{F}_ {q_ {\mathbb{P}}}$
+- $\mathsf{path^{excl}} ⦂ \{ 0 .. q_ {\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{excl}}]}$
 - $\mathsf{pos^{excl}} ⦂ \{ 0 .. 2^{\mathsf{MerkleDepth^{excl}}}\!-1 \}$
 
 such that the following conditions hold:
@@ -472,7 +472,7 @@ such that the following conditions hold:
 ### Conditions
 
 **Note commitment integrity.** $\hspace{0.5em}$
-$\mathsf{NoteCommit^{Orchard}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}) \in \{ \mathsf{cm^{old}}, \bot \}$.
+$\mathsf{NoteCommit^{Orchard}_ {rcm^{old}}}(\mathsf{repr}_ {\mathbb{P}}(\mathsf{g_ d^{old}}), \mathsf{repr}_ {\mathbb{P}}(\mathsf{pk_ d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}) \in \{ \mathsf{cm^{old}}, \bot \}$.
 
 This is identical to the corresponding check in an Orchard Action
 statement. [^protocol-actionstatement]
@@ -481,13 +481,13 @@ statement. [^protocol-actionstatement]
 $(\mathsf{path^{cm}}, \mathsf{pos^{cm}})$ is a valid Merkle path of depth
 $\mathsf{MerkleDepth^{Orchard}}$, as defined in
 § 4.9 'Merkle Path Validity' [^protocol-merklepath], from
-$\mathsf{Extract}_{\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{cm}}$.
+$\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ to the anchor $\mathsf{rt^{cm}}$.
 
 **Value commitment integrity.** $\hspace{0.5em}$
-$\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_{rcv}}(\mathsf{v^{old}})$.
+$\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_ {rcv}}(\mathsf{v^{old}})$.
 
 **Nullifier derivation.** $\hspace{0.5em}$
-$\mathsf{nf^{old}} = \mathsf{DeriveNullifier_{nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
+$\mathsf{nf^{old}} = \mathsf{DeriveNullifier_ {nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
 
 The standard nullifier is computed inside the circuit but is NOT a public
 input — it is used only as an intermediate value for the non-membership
@@ -497,9 +497,9 @@ check and the alternate nullifier derivation. It is never revealed.
 $\mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}})$.
 
 **Diversified address integrity.** $\hspace{0.5em}$
-$\mathsf{ivk} = \bot$ or $\mathsf{pk_d^{old}} = [\mathsf{ivk}]\, \mathsf{g_d^{old}}$
+$\mathsf{ivk} = \bot$ or $\mathsf{pk_ d^{old}} = [\mathsf{ivk}]\, \mathsf{g_ d^{old}}$
 where
-$\mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}), \mathsf{nk})$.
+$\mathsf{ivk} = \mathsf{Commit^{ivk}_ {rivk}}(\mathsf{Extract}_ {\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}), \mathsf{nk})$.
 
 **Nullifier non-membership.** $\hspace{0.5em}$
 Let $\mathsf{leaf} = \mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$.
@@ -507,14 +507,14 @@ $(\mathsf{path^{excl}}, \mathsf{pos^{excl}})$ is a valid Merkle path of
 depth $\mathsf{MerkleDepth^{excl}}$ from $\mathsf{leaf}$ to the anchor
 $\mathsf{rt^{excl}}$, using Poseidon for internal node hashing.
 
-Additionally, let $x = \mathsf{nf^{old}} - \mathsf{low} \bmod q_{\mathbb{P}}$.
+Additionally, let $x = \mathsf{nf^{old}} - \mathsf{low} \bmod q_ {\mathbb{P}}$.
 Both of the following range checks MUST hold:
 
 1. $x < 2^{250}$
 2. $2^{250} - 1 - \mathsf{width} + x < 2^{250}$
 
 These together enforce $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}$
-over $\mathbb{F}_{q_{\mathbb{P}}}$, proving that the standard nullifier
+over $\mathbb{F}_ {q_ {\mathbb{P}}}$, proving that the standard nullifier
 falls within an interval of unrevealed values.
 
 <details>
@@ -524,7 +524,7 @@ To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}
 
 - Check 1 proves $\mathsf{nf^{old}} \geq \mathsf{low}$: if
   $\mathsf{nf^{old}} < \mathsf{low}$, the field subtraction wraps to a
-  value $\geq q_{\mathbb{P}} - 2^{250} \gg 2^{250}$, failing the range
+  value $\geq q_ {\mathbb{P}} - 2^{250} \gg 2^{250}$, failing the range
   check. This relies on the sentinel initialization ensuring
   $\mathsf{width} < 2^{250}$ and therefore all legitimate offsets are
   small.
@@ -536,14 +536,14 @@ To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}
 </details>
 
 **Alternate nullifier integrity.** $\hspace{0.5em}$
-$\mathsf{nf_{dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$.
+$\mathsf{nf_ {dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$.
 
 ### Circuit Implementation Notes
 
 The first six conditions (note commitment integrity through diversified
 address integrity) are adapted from the corresponding Orchard Action
 statement checks. In particular, note-commitment Merkle membership uses
-$\mathsf{Extract}_{\mathbb{P}}(\mathsf{cm^{old}})$ as in the Orchard
+$\mathsf{Extract}_ {\mathbb{P}}(\mathsf{cm^{old}})$ as in the Orchard
 Action statement. [^protocol-actionstatement] Implementations SHOULD share
 circuit gadgets with an Orchard implementation to minimize new code
 requiring review.
@@ -562,7 +562,7 @@ A verifier that receives a Claim proof $\pi$ together with a spend
 authorization signature $\sigma$ MUST perform the following checks:
 
 1. Verify $\pi$ against the public inputs
-   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{nf_{dom}}, \mathsf{dom}, \mathsf{cv})$.
+   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{nf_ {dom}}, \mathsf{dom}, \mathsf{cv})$.
 
 2. Verify $\sigma$ as a valid $\mathsf{SpendAuthSig^{Orchard}}$ signature
    on the application-defined sighash, under the randomized key
@@ -577,7 +577,7 @@ authorization signature $\sigma$ MUST perform the following checks:
 5. Verify that $\mathsf{dom}$ is valid for the current application
    instance.
 
-6. Verify that $\mathsf{nf_{dom}}$ has not been previously accepted in the
+6. Verify that $\mathsf{nf_ {dom}}$ has not been previously accepted in the
    same nullifier domain. If it has, reject the claim as a double-claim.
 
 
@@ -595,7 +595,7 @@ as follows:
 - The public inputs $\mathsf{rt^{cm}}$, $\mathsf{rt^{excl}}$,
   $\mathsf{rk}$, and $\mathsf{dom}$ are shared across all $N$ notes.
 - Each note $i$ contributes its own alternate nullifier
-  $\mathsf{nf_{dom,i}}$ and value commitment $\mathsf{cv_i}$ as public
+  $\mathsf{nf_ {dom,i}}$ and value commitment $\mathsf{cv_ i}$ as public
   inputs.
 - A single $\mathsf{ivk}$ (derived from the shared $\mathsf{ak}$ and
   $\mathsf{nk}$) is constrained to own all $N$ notes, ensuring they
@@ -607,8 +607,8 @@ as follows:
 ### Note Padding
 
 To avoid leaking the number of notes a holder is claiming, the circuit
-SHOULD accept a fixed number of note slots $N_{\max}$ (for example,
-$N_{\max} = 5$). Unused slots are filled with *padded notes*: randomly
+SHOULD accept a fixed number of note slots $N_ {\max}$ (for example,
+$N_ {\max} = 5$). Unused slots are filled with *padded notes*: randomly
 generated note data with value 0. Padded notes satisfy all circuit
 checks (the commitment is valid, the Merkle path can use any valid leaf,
 the non-membership check passes for random nullifiers with overwhelming
@@ -626,14 +626,14 @@ distinguishes real notes from padded notes:
 
 The verifier computes the aggregate value commitment as:
 
-$$\mathsf{cv_{total}} = \sum_{i=0}^{N_{\max}-1} \mathsf{cv_i}$$
+$$\mathsf{cv_ {total}} = \sum_ {i=0}^{N_ {\max}-1} \mathsf{cv_ i}$$
 
 Since padded notes commit to value 0, they contribute the identity to the
 sum (up to their blinding factor). The aggregate commitment
-$\mathsf{cv_{total}}$ commits to the holder's total claimed balance.
+$\mathsf{cv_ {total}}$ commits to the holder's total claimed balance.
 Applications that need to open this commitment (e.g., to verify a minimum
 balance threshold) can do so by requiring the prover to reveal the
-aggregate randomness $\mathsf{rcv_{total}} = \sum_i \mathsf{rcv_i}$.
+aggregate randomness $\mathsf{rcv_ {total}} = \sum_ i \mathsf{rcv_ i}$.
 
 
 # Rationale
@@ -669,7 +669,7 @@ primitive is used.
 ## Why Sentinel Initialization
 
 Without sentinels, the initial non-membership tree would contain a single
-leaf spanning the entire field $[0, q_{\mathbb{P}}-1]$, with width
+leaf spanning the entire field $[0, q_ {\mathbb{P}}-1]$, with width
 $\approx 2^{254}$. The in-circuit range checks use 250-bit windows
 (25 limbs of the 10-bit lookup table). An interval wider than $2^{250}$
 would allow the upper-bound range check to wrap, enabling a prover to
@@ -699,7 +699,7 @@ signature scheme.
 
 A reference implementation of the Claim circuit (including the
 non-membership tree, alternate nullifier derivation, and multi-note
-batching for $N_{\max} = 5$) exists in the coinholder voting codebase used
+batching for $N_ {\max} = 5$) exists in the coinholder voting codebase used
 for this design.
 
 At the time of writing, some implementation repositories are not publicly

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -903,11 +903,8 @@ interprets the PCZT identically to any other Orchard transaction.
 After receiving the signed PCZT from the hardware wallet device, the
 wallet:
 
-1. Parses the signed PCZT structurally and reads the `spend_auth_sig`
-   field from the relevant action. Some devices (e.g., Keystone) redact
-   sensitive fields ($\alpha$, rseed, ZIP-32 derivation) after signing,
-   so the wallet MUST extract the signature by parsing the PCZT structure
-   rather than by byte-diffing against the unsigned version.
+1. Parses the signed PCZT and reads the `spend_auth_sig` field from
+   the relevant action.
 
 2. Recomputes the sighash that the device signed. This is the ZIP 244
    transaction identifier computed over the PCZT.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -147,8 +147,8 @@ viewing key cannot make claims on behalf of the holder.
 non-membership tree requires querying a data source that holds the full
 tree. A naive query reveals which path is being requested, potentially
 linking the querier to a nullifier range. Private information retrieval
-(PIR) techniques can mitigate this leakage; their specification is out of
-scope for this document.
+(PIR) techniques can mitigate this leakage [^pir-governance]; their
+specification is out of scope for this document.
 
 
 # Requirements
@@ -732,5 +732,7 @@ this ZIP.
 [^protocol-sinsemilla]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 5.4.1.9: Sinsemilla Hash Function](protocol/protocol.pdf#concretesinsemillahash)
 
 [^poseidon]: [Poseidon: A New Hash Function for Zero-Knowledge Proof Systems](https://eprint.iacr.org/2019/458)
+
+[^pir-governance]: [Draft ZIP: Private Information Retrieval for Governance](https://github.com/zcash/zips/pull/1198)
 
 [^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -329,16 +329,19 @@ used by Orchard for nullifier derivation.
 
 ### Tree Depth
 
-This specification uses a tree depth of
-$\mathsf{MerkleDepth^{excl}} = 29$, supporting up to $2^{29} \approx 537$
-million leaves. Each nullifier insertion splits one gap into two, replacing one leaf
-with two (adding one leaf), so the tree supports approximately 537 million distinct
-nullifiers. As of early 2026, the Zcash Orchard pool contains roughly
-51 million nullifiers, so depth 29 provides about one order of magnitude
-of headroom.
-Implementations MAY choose a different depth to suit their capacity
-requirements, but the circuit MUST be parameterized accordingly based on
-the chosen depth.
+$\mathsf{MerkleDepth^{excl}}$ MUST be large enough to accommodate the
+number of gap leaves. Each nullifier in the pool adds at most one leaf
+(by splitting an existing gap), so the tree requires capacity for at
+least $|N| + 17$ leaves, where $|N|$ is the size of the Orchard
+nullifier set and 17 is the number of sentinels for the Pallas base
+field. Concretely:
+
+$$\mathsf{MerkleDepth^{excl}} \geq \lceil \log_ 2(|N| + 17) \rceil$$
+
+A depth of $\mathsf{MerkleDepth^{excl}} = 29$ is RECOMMENDED. This
+supports up to $2^{29} \approx 537$ million leaves. As of early 2026,
+the Zcash Orchard pool contains roughly 51 million nullifiers, so
+depth 29 provides about one order of magnitude of headroom.
 
 Unused leaf positions MUST be filled with a canonical empty leaf value
 $\mathsf{GapCommit}(0, 0)$.

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -904,10 +904,10 @@ delegation. The dummy signed note is constructed specifically for the
 proof-of-balance flow and never appears in any on-chain note commitment
 tree. This design has three advantages:
 
-- **No fund risk.** Because the PCZT is never broadcast
-  to the Zcash mainchain and the signed note has no on-chain existence,
-  there is no scenario in which the delegation signing could result in
-  loss of funds.
+- **No fund risk.** Because the proof-of-balance transaction is never
+  broadcast to the Zcash mainchain and the signed note has no on-chain
+  existence, there is no scenario in which the delegation signing could
+  result in loss of funds.
 - **Note reusability.** Because real notes are never consumed on
   mainchain, they remain fully spendable and available for other
   applications that use the proof-of-balance mechanism. Alternate

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -1,0 +1,723 @@
+    ZIP: Unassigned
+    Title: Orchard Proof-of-Balance
+    Owners: Dev Ojha <dojha@berkeley.edu>
+            Adam Tucker <adamleetucker@outlook.com>
+            Roman Akhtariev <ackhtariev@gmail.com>
+            Greg Nagy <greg@dhamma.works>
+    Credits: Daira-Emma Hopwood <daira@jacaranda.org>
+             Jack Grigg <thestr4d@gmail.com>
+    Status: Draft
+    Category: Informational
+    Created: 2026-03-03
+    License: MIT
+    Pull-Request: <https://github.com/zcash/zips/pull/???>
+
+
+# Terminology
+
+The key words "MUST", "MUST NOT", "SHOULD", and "MAY" in this document
+are to be interpreted as described in BCP 14 [^BCP14] when, and only
+when, they appear in all capitals.
+
+The character § is used when referring to sections of the Zcash Protocol
+Specification. [^protocol]
+
+The terms below are to be interpreted as follows:
+
+Pool snapshot
+
+: A pair $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}})$ consisting of the
+  Orchard note commitment tree root and the nullifier non-membership tree
+  root, both computed as of the end of a specified block height. The pool
+  snapshot defines the set of notes eligible for claims.
+
+Nullifier non-membership tree
+
+: An Indexed Merkle Tree (IMT) whose leaves represent contiguous intervals
+  between consecutive revealed nullifiers. A Merkle path to a leaf, together
+  with a range check, proves that a given nullifier does not appear in the
+  set of revealed nullifiers at the snapshot height. See [Nullifier
+  Non-Membership Tree].
+
+Alternate nullifier
+
+: A value derived from an Orchard note and a nullifier domain, with similar
+  cryptographic properties to the note's standard nullifier but unlinkable
+  to it. A note has exactly one alternate nullifier for each nullifier
+  domain. See [Alternate Nullifier Derivation].
+
+Nullifier domain
+
+: A unique identifier, encoded as an element of $\mathbb{F}_{q_{\mathbb{P}}}$,
+  that scopes alternate nullifiers to a particular application instance. Two
+  claims in the same domain for the same note produce the same alternate
+  nullifier; claims in different domains are unlinkable.
+
+Claim
+
+: A zero-knowledge proof, together with a spend authorization signature,
+  demonstrating that the prover holds an unspent Orchard note with a
+  committed value at a given pool snapshot, and revealing the note's
+  alternate nullifier in a specified domain.
+
+
+# Abstract
+
+This ZIP specifies a mechanism for proving ownership of unspent Orchard
+notes at a snapshot of the shielded pool, without revealing the notes'
+standard nullifiers or linking claims to past or future on-chain spending.
+
+The mechanism introduces two primitives: a *nullifier non-membership tree*
+(an Indexed Merkle Tree of intervals between consecutive revealed
+nullifiers) that enables efficient in-circuit proofs that a note was
+unspent at the snapshot height, and *alternate nullifiers* (domain-separated
+values derived from a note's standard nullifier using Poseidon) that
+prevent double-claiming within an application domain while remaining
+unlinkable across domains and to on-chain activity.
+
+A Claim circuit combines these primitives with standard Orchard note
+commitment integrity, Merkle membership, value commitment, spend authority,
+and diversified address integrity checks to produce a single proof per
+note. An optional multi-note batching extension allows proving aggregate
+balance across several notes in one proof.
+
+Possible applications include private air drops, private proof-of-balance,
+and private stake-weighted polling. Application-specific protocols (such
+as coinholder voting) are specified in separate ZIPs that reference this
+one.
+
+
+# Motivation
+
+Several applications in the Zcash ecosystem require a holder to
+demonstrate that they controlled a certain balance at a point in time,
+without revealing which specific notes they held or linking the
+demonstration to their on-chain transaction history. Examples include:
+
+- **Air drops** — distributing tokens proportional to shielded holdings.
+- **Stake-weighted polling** — weighting votes by ZEC balance.
+- **Proof-of-balance** — demonstrating solvency or collateral without
+  revealing addresses.
+
+The naive approach of revealing standard nullifiers would link the
+claim to future spending, destroying the privacy that Zcash's shielded
+transactions are designed to provide. An alternative approach of actually
+spending the claimed notes (e.g., to oneself) with an anchor at the
+snapshot height has the disadvantage that the same notes cannot be used
+in concurrent applications, and it permanently commits the holder to the
+claim by recording it on the main chain.
+
+Domain-separated alternate nullifiers resolve both problems: they are
+unlinkable to the standard nullifiers (even after the note is later spent
+on-chain), and they are scoped to a specific application instance so that
+the same notes can participate in independent, concurrent applications
+without interference.
+
+The concept of alternate nullifiers and nullifier non-membership trees for
+proof-of-balance was first described by Daira-Emma Hopwood and Jack Grigg
+in a 2023 draft. [^draft-str4d-orchard-balance-proof] This ZIP builds on
+that work with a concrete instantiation informed by the implementation
+experience of the Zcash coinholder voting system.
+
+
+# Privacy Implications
+
+**Unlinkability to standard nullifiers.** The alternate nullifier
+$\mathsf{nf_{dom}}$ for a note is computed as a Poseidon hash keyed by the
+nullifier deriving key $\mathsf{nk}$, which is secret. An observer who
+sees both $\mathsf{nf_{dom}}$ (published during a claim) and the standard
+nullifier $\mathsf{nf^{old}}$ (published when the note is later spent on
+the Zcash chain) cannot link them without knowledge of $\mathsf{nk}$.
+This property holds under the assumption that Poseidon is a pseudorandom
+function when keyed with a uniformly random field element (see
+[Security Argument]).
+
+**Cross-domain unlinkability.** If the same note participates in two
+independent applications with different nullifier domains $\mathsf{dom_1}$
+and $\mathsf{dom_2}$, the resulting alternate nullifiers
+$\mathsf{nf_{dom_1}}$ and $\mathsf{nf_{dom_2}}$ are unlinkable. This
+follows from the PRF property: distinct inputs produce outputs that are
+computationally indistinguishable from independent random values.
+
+**Spend authority prevents viewing-key delegation.** The circuit requires
+a valid spend authorization signature, ensuring that a party with only a
+viewing key cannot make claims on behalf of the holder.
+
+**Non-membership tree queries.** Obtaining a Merkle path in the nullifier
+non-membership tree requires querying a data source that holds the full
+tree. A naive query reveals which path is being requested, potentially
+linking the querier to a nullifier range. Private information retrieval
+(PIR) techniques can mitigate this leakage; their specification is out of
+scope for this document.
+
+
+# Requirements
+
+- A holder MUST be able to prove ownership of an unspent Orchard note at a
+  pool snapshot without revealing the note's standard nullifier.
+- Double-claiming the same note within the same nullifier domain MUST be
+  detectable: the alternate nullifier is deterministic, so a duplicate
+  claim produces an identical value that the verifier can reject.
+- Claims MUST be unlinkable to the holder's past or future on-chain
+  spends, and to their claims in other nullifier domains.
+- The holder MUST prove spend authority (not merely viewing access).
+- The construction SHOULD allow a holder to participate in multiple
+  independent applications using the same notes, provided each application
+  uses a distinct nullifier domain. This is a natural consequence of the
+  domain-separated alternate nullifier derivation.
+
+
+# Non-requirements
+
+- Application-specific protocols that consume claims (such as voting,
+  air-drop distribution, or delegation) are out of scope.
+- Privacy-preserving retrieval of non-membership Merkle paths (e.g., via
+  PIR) is out of scope.
+- Value denomination conversions (e.g., converting zatoshi to ballot
+  counts) are application-specific and out of scope.
+- Transaction-level encoding of claims is out of scope; this ZIP specifies
+  only the proof statement and its verification.
+
+
+# Specification
+
+## Pool Snapshot
+
+A pool snapshot at block height $h$ is a pair
+$(\mathsf{rt^{cm}}, \mathsf{rt^{excl}})$ where:
+
+- $\mathsf{rt^{cm}}$ is the root of the Orchard note commitment tree
+  as of the end of block $h$. [^protocol-orchardcommitmenttree]
+- $\mathsf{rt^{excl}}$ is the root of the nullifier non-membership tree
+  constructed from the set of all Orchard nullifiers revealed on the
+  consensus chain as of the end of block $h$.
+
+The pool snapshot MUST be deterministically computable from the consensus
+chain state at height $h$. Any party with access to the chain state MUST
+be able to independently verify both roots.
+
+
+## Nullifier Non-Membership Tree
+
+The nullifier non-membership tree is a Merkle tree whose leaves encode
+the gaps between consecutive revealed nullifiers, enabling efficient
+in-circuit proofs that a given nullifier is absent from the revealed set.
+
+### Construction
+
+Let $S = \{s_0, s_1, \ldots, s_{m-1}\}$ be the set of all Orchard
+nullifiers revealed on the consensus chain as of block height $h$, together
+with a set of sentinel values (see [Sentinel Initialization]). Sort $S$ in
+ascending order as elements of $\mathbb{F}_{q_{\mathbb{P}}}$.
+
+For each pair of consecutive elements $(s_i, s_{i+1})$ where $s_i < s_{i+1}$
+and $s_{i+1} - s_i > 1$, create a leaf with:
+
+- $\mathsf{low} = s_i + 1$ — the first value in the gap
+- $\mathsf{width} = s_{i+1} - s_i - 2$ — the number of additional values
+  in the gap beyond $\mathsf{low}$
+
+The leaf represents the closed interval
+$[\mathsf{low},\; \mathsf{low} + \mathsf{width}]$, which contains exactly
+the field elements between $s_i$ and $s_{i+1}$ exclusive.
+
+<details>
+<summary>Rationale for (low, width) encoding</summary>
+
+An alternative encoding stores $(\mathsf{start}, \mathsf{end})$ pairs
+directly, as proposed in [^draft-str4d-orchard-balance-proof]. The
+$(\mathsf{low}, \mathsf{width})$ encoding precomputes
+$\mathsf{width} = \mathsf{end} - \mathsf{low}$ during tree construction,
+saving one field subtraction in the in-circuit interval check. Since tree
+construction is performed once per snapshot while the circuit is evaluated
+per claim, this trade-off favors prover efficiency.
+</details>
+
+### Hash Function
+
+The non-membership tree uses Poseidon [^poseidon] over
+$\mathbb{F}_{q_{\mathbb{P}}}$ (the Pallas base field) for all hashing:
+
+- **Leaf hash:** $\mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$,
+  a 2-input Poseidon hash with width $t = 3$.
+- **Internal node hash:** $\mathsf{Poseidon}(\mathsf{left}, \mathsf{right})$,
+  a 2-input Poseidon hash with width $t = 3$, where $\mathsf{left}$ and
+  $\mathsf{right}$ are determined by the node's position bit at each level.
+
+Implementations MUST use the Poseidon instantiation over $\mathbb{F}_{q_{\mathbb{P}}}$
+with the standard parameter generation procedure from [^poseidon], targeting
+128-bit security.
+
+<details>
+<summary>Rationale for Poseidon over Sinsemilla</summary>
+
+The Orchard note commitment tree uses Sinsemilla [^protocol-sinsemilla]
+for Merkle hashing. The non-membership tree uses Poseidon instead because
+Poseidon operates natively on field elements, making it significantly more
+efficient inside Halo 2 arithmetic circuits. Sinsemilla is optimized for
+bitstring inputs and incurs overhead when hashing field elements. Since
+the non-membership tree is a new data structure not constrained by backwards
+compatibility, the more circuit-efficient choice is appropriate.
+</details>
+
+### Tree Depth
+
+This specification uses a tree depth of
+$\mathsf{MerkleDepth^{excl}} = 29$, supporting up to $2^{29} \approx 537$
+million leaves. Each nullifier insertion splits one interval leaf into two
+(adding one leaf), so the tree supports approximately 537 million distinct
+nullifiers. As of this writing, the Zcash Orchard pool contains
+approximately 50 million nullifiers, providing over 10x headroom.
+Implementations MAY choose a different depth to suit their capacity
+requirements; the circuit must be parameterized accordingly.
+
+Unused leaf positions MUST be filled with a canonical empty leaf value
+(the hash of the zero interval).
+
+### Sentinel Initialization
+
+Before inserting any real nullifiers, the non-membership tree MUST be
+initialized with sentinel values that partition $\mathbb{F}_{q_{\mathbb{P}}}$
+into intervals each of width strictly less than $2^{250}$.
+
+This is achieved by inserting sentinel nullifiers at evenly spaced points
+across the field. For the Pallas base field ($q_{\mathbb{P}} \approx
+2^{254.9}$), inserting 17 sentinels at multiples of
+$\lfloor q_{\mathbb{P}} / 17 \rfloor$ suffices, as each resulting interval
+has width at most $\lceil q_{\mathbb{P}} / 17 \rceil < 2^{250}$.
+
+The width bound is critical for the soundness of the in-circuit range
+checks. If any interval had width $\geq 2^{250}$, the range check could
+overflow, allowing a prover to falsely claim non-membership.
+
+Sentinel values are fixed per deployment and MUST be published alongside the
+tree specification so that any party can reconstruct the tree independently.
+
+
+## Nullifier Domains
+
+A nullifier domain $\mathsf{dom}$ is an element of
+$\mathbb{F}_{q_{\mathbb{P}}}$ that defines a double-claim detection scope.
+Each independent claim context (such as a specific air-drop event, a single
+poll, or an individual voting round) MUST use its own domain.
+
+Applications MUST ensure that the domain value is unique across
+independent claim contexts. Two claims that share the same domain and the
+same underlying note will produce the same alternate nullifier, which is
+the mechanism for double-claim prevention.
+
+Applications SHOULD derive the domain deterministically from public
+parameters that bind it to a specific context. For example:
+
+$$\mathsf{dom} = \mathsf{Poseidon}(\text{"BalanceProofDomain"}, \mathsf{snapshot\_height}, \mathsf{purpose\_hash})$$
+
+where $\mathsf{purpose\_hash}$ is a hash of an application-specific
+identifier string. This derivation prevents accidental domain collisions
+across independent applications using the same snapshot.
+
+Applications MAY define their own domain derivation scheme provided it
+satisfies the uniqueness requirement above.
+
+
+## Alternate Nullifier Derivation
+
+Given a nullifier domain $\mathsf{dom}$ and an Orchard note with standard
+nullifier $\mathsf{nf^{old}}$, the alternate nullifier $\mathsf{nf_{dom}}$
+is computed as:
+
+$$\mathsf{nf_{dom}} = \mathsf{DeriveAlternateNullifier_{nk}}(\mathsf{dom}, \mathsf{nf^{old}}) = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$$
+
+where:
+
+- $\mathsf{nk} \in \mathbb{F}_{q_{\mathbb{P}}}$ is the nullifier deriving
+  key from the holder's full viewing key.
+- $\mathsf{dom} \in \mathbb{F}_{q_{\mathbb{P}}}$ is the nullifier domain.
+- $\mathsf{nf^{old}} \in \mathbb{F}_{q_{\mathbb{P}}}$ is the note's
+  standard Orchard nullifier, computed as
+  $\mathsf{DeriveNullifier_{nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
+
+This is a 3-input Poseidon hash. Using the standard $\mathsf{P128Pow5T3}$
+instantiation (width $t = 3$, rate 2), this requires two permutations
+to absorb three input elements.
+
+### Properties
+
+**Deterministic.** The same note in the same domain always produces the
+same alternate nullifier, enabling double-claim detection.
+
+**Unlinkable to standard nullifier.** An adversary who observes
+$\mathsf{nf_{dom}}$ and later observes $\mathsf{nf^{old}}$ (when the note
+is spent on-chain) cannot link them without knowledge of $\mathsf{nk}$.
+
+**Cross-domain unlinkable.** Alternate nullifiers for the same note in
+different domains are computationally indistinguishable from independent
+random values.
+
+**Collision resistant.** Distinct notes in the same domain produce
+distinct alternate nullifiers, under the collision resistance of Poseidon.
+
+### Security Argument
+
+The security of the alternate nullifier derivation relies on Poseidon
+being a pseudorandom function (PRF) when keyed with a uniformly random
+element of $\mathbb{F}_{q_{\mathbb{P}}}$.
+
+**Unlinkability.** Model $\mathsf{Poseidon}(\mathsf{nk}, \cdot, \cdot)$
+as a PRF keyed by $\mathsf{nk}$. An adversary who does not know
+$\mathsf{nk}$ sees outputs that are indistinguishable from random. Given
+$\mathsf{nf_{dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$
+and $\mathsf{nf^{old}}$, the adversary cannot verify the relationship
+without $\mathsf{nk}$. The nullifier deriving key $\mathsf{nk}$ is a
+255-bit value derived from the spending key and is never revealed on-chain.
+
+**Cross-domain unlinkability.** For two domains $\mathsf{dom_1} \neq \mathsf{dom_2}$,
+the pairs $(\mathsf{dom_1}, \mathsf{nf^{old}})$ and
+$(\mathsf{dom_2}, \mathsf{nf^{old}})$ are distinct inputs to the PRF.
+Under the PRF assumption, their outputs are jointly indistinguishable from
+independent random values.
+
+**Collision resistance.** If $\mathsf{nf^{old}_1} \neq \mathsf{nf^{old}_2}$,
+then $(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_1})$ and
+$(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}_2})$ are distinct Poseidon
+inputs, so their outputs collide with negligible probability under
+Poseidon's collision resistance.
+
+<details>
+<summary>Rationale for divergence from the Orchard-native construction</summary>
+
+The earlier draft [^draft-str4d-orchard-balance-proof] proposed an
+alternate nullifier derivation structurally parallel to the standard
+Orchard nullifier:
+
+$$\mathsf{Extract}_{\mathbb{P}}\!\left(\!\left[(\mathsf{PRF^{nfAlternate}_{nk}}(\text{ρ}^{\mathsf{old}}, \mathsf{dom}) + \text{φ}^{\mathsf{old}}) \bmod q_{\mathbb{P}}\right] \mathcal{K}^\mathsf{Orchard} + \mathsf{cm^{old}}\right)$$
+
+That construction has the advantage of sharing more circuit infrastructure
+with the standard nullifier check.
+
+The Poseidon-based construction adopted here was chosen for simplicity:
+it requires only a single Poseidon hash rather than an additional
+variable-base scalar multiplication, and it reuses the standard nullifier
+$\mathsf{nf^{old}}$ that the circuit already computes for the
+non-membership check. The security assumption is comparable — both
+constructions rely on the hardness of distinguishing $\mathsf{nk}$-keyed
+evaluations from random.
+
+The current Zcash coinholder voting system was designed and implemented
+around this construction. A future revision of this ZIP may revisit the
+choice as part of a broader protocol revision — for example, if hardware
+wallet firmware support (e.g., a Keystone testnet byte for governance
+signing) restructures the spend authority flow in a way that favors
+tighter integration with the standard Orchard nullifier derivation.
+</details>
+
+
+## Claim Circuit
+
+A valid instance of a Claim proof $\pi$ assures the following statement.
+
+### Public Inputs
+
+Given a primary input:
+
+- $\mathsf{rt^{cm}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{rt^{excl}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{rk} ⦂ \mathsf{SpendAuthSig^{Orchard}.Public}$
+- $\mathsf{nf_{dom}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{dom} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{cv} ⦂ \mathsf{ValueCommit^{Orchard}.Output}$
+
+### Auxiliary Inputs
+
+the prover knows an auxiliary input:
+
+- $\mathsf{g_d^{old}} ⦂ \mathbb{P}^*$
+- $\mathsf{pk_d^{old}} ⦂ \mathbb{P}^*$
+- $\mathsf{v^{old}} ⦂ \{ 0 .. 2^{\ell_{\mathsf{value}}}-1 \}$
+- $\text{ρ}^{\mathsf{old}} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
+- $\text{φ}^{\mathsf{old}} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
+- $\mathsf{rcm^{old}} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_{\mathsf{scalar}}}-1 \}$
+- $\mathsf{cm^{old}} ⦂ \mathbb{P}$
+- $\mathsf{nf^{old}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}$
+- $\mathsf{path^{cm}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{Orchard}}]}$
+- $\mathsf{pos^{cm}} ⦂ \{ 0 .. 2^{\mathsf{MerkleDepth^{Orchard}}}\!-1 \}$
+- $\mathsf{ak}^{\mathbb{P}} ⦂ \mathbb{P}^*$
+- $\mathsf{nk} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
+- $\mathsf{rivk} ⦂ \mathsf{Commit^{ivk}.Trapdoor}$
+- $\alpha ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_{\mathsf{scalar}}}-1 \}$
+- $\mathsf{rcv} ⦂ \{ 0 .. 2^{\ell^{\mathsf{Orchard}}_{\mathsf{scalar}}}-1 \}$
+- $\mathsf{low} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
+- $\mathsf{width} ⦂ \mathbb{F}_{q_{\mathbb{P}}}$
+- $\mathsf{path^{excl}} ⦂ \{ 0 .. q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{excl}}]}$
+- $\mathsf{pos^{excl}} ⦂ \{ 0 .. 2^{\mathsf{MerkleDepth^{excl}}}\!-1 \}$
+
+such that the following conditions hold:
+
+### Conditions
+
+**Note commitment integrity.** $\hspace{0.5em}$
+$\mathsf{NoteCommit^{Orchard}_{rcm^{old}}}(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d^{old}}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d^{old}}), \mathsf{v^{old}}, \text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}) \in \{ \mathsf{cm^{old}}, \bot \}$.
+
+This is identical to the corresponding check in an Orchard Action
+statement. [^protocol-actionstatement]
+
+**Merkle path validity for** $\mathsf{cm^{old}}$. $\hspace{0.5em}$
+$(\mathsf{path^{cm}}, \mathsf{pos^{cm}})$ is a valid Merkle path of depth
+$\mathsf{MerkleDepth^{Orchard}}$, as defined in
+§ 4.9 'Merkle Path Validity' [^protocol-merklepath], from
+$\mathsf{cm^{old}}$ to the anchor $\mathsf{rt^{cm}}$.
+
+**Value commitment integrity.** $\hspace{0.5em}$
+$\mathsf{cv} = \mathsf{ValueCommit^{Orchard}_{rcv}}(\mathsf{v^{old}})$.
+
+**Nullifier derivation.** $\hspace{0.5em}$
+$\mathsf{nf^{old}} = \mathsf{DeriveNullifier_{nk}}(\text{ρ}^{\mathsf{old}}, \text{φ}^{\mathsf{old}}, \mathsf{cm^{old}})$.
+
+The standard nullifier is computed inside the circuit but is NOT a public
+input — it is used only as an intermediate value for the non-membership
+check and the alternate nullifier derivation. It is never revealed.
+
+**Spend authority.** $\hspace{0.5em}$
+$\mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}})$.
+
+**Diversified address integrity.** $\hspace{0.5em}$
+$\mathsf{ivk} = \bot$ or $\mathsf{pk_d^{old}} = [\mathsf{ivk}]\, \mathsf{g_d^{old}}$
+where
+$\mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}), \mathsf{nk})$.
+
+**Nullifier non-membership.** $\hspace{0.5em}$
+Let $\mathsf{leaf} = \mathsf{Poseidon}(\mathsf{low}, \mathsf{width})$.
+$(\mathsf{path^{excl}}, \mathsf{pos^{excl}})$ is a valid Merkle path of
+depth $\mathsf{MerkleDepth^{excl}}$ from $\mathsf{leaf}$ to the anchor
+$\mathsf{rt^{excl}}$, using Poseidon for internal node hashing.
+
+Additionally, let $x = \mathsf{nf^{old}} - \mathsf{low} \bmod q_{\mathbb{P}}$.
+Both of the following range checks MUST hold:
+
+1. $x < 2^{250}$
+2. $2^{250} - 1 - \mathsf{width} + x < 2^{250}$
+
+These together enforce $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}$
+over $\mathbb{F}_{q_{\mathbb{P}}}$, proving that the standard nullifier
+falls within an interval of unrevealed values.
+
+<details>
+<summary>Derivation of the interval check</summary>
+
+To prove $\mathsf{low} \leq \mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}$:
+
+- Check 1 proves $\mathsf{nf^{old}} \geq \mathsf{low}$: if
+  $\mathsf{nf^{old}} < \mathsf{low}$, the field subtraction wraps to a
+  value $\geq q_{\mathbb{P}} - 2^{250} \gg 2^{250}$, failing the range
+  check. This relies on the sentinel initialization ensuring
+  $\mathsf{width} < 2^{250}$ and therefore all legitimate offsets are
+  small.
+
+- Check 2 proves $\mathsf{nf^{old}} \leq \mathsf{low} + \mathsf{width}$:
+  substituting, $2^{250} - 1 - \mathsf{width} + x = 2^{250} - 1 - (\mathsf{width} - x)$.
+  This is in $[0, 2^{250})$ if and only if $\mathsf{width} - x \geq 0$,
+  i.e., $x \leq \mathsf{width}$.
+</details>
+
+**Alternate nullifier integrity.** $\hspace{0.5em}$
+$\mathsf{nf_{dom}} = \mathsf{Poseidon}(\mathsf{nk}, \mathsf{dom}, \mathsf{nf^{old}})$.
+
+### Circuit Implementation Notes
+
+The first six conditions (note commitment integrity through diversified
+address integrity) are identical to the corresponding parts of an Orchard
+Action statement. [^protocol-actionstatement] Implementations SHOULD share
+circuit gadgets with an Orchard implementation to minimize new code
+requiring review.
+
+The nullifier non-membership check requires a Poseidon-based Merkle path
+verification (29 levels, 30 total Poseidon calls per note) and two 250-bit
+range checks.
+
+The alternate nullifier integrity check is a single Poseidon hash
+(two permutations at width 3).
+
+
+## Out-of-Circuit Verification
+
+A verifier that receives a Claim proof $\pi$ together with a spend
+authorization signature $\sigma$ MUST perform the following checks:
+
+1. Verify $\pi$ against the public inputs
+   $(\mathsf{rt^{cm}}, \mathsf{rt^{excl}}, \mathsf{rk}, \mathsf{nf_{dom}}, \mathsf{dom}, \mathsf{cv})$.
+
+2. Verify $\sigma$ as a valid $\mathsf{SpendAuthSig^{Orchard}}$ signature
+   on the application-defined sighash, under the randomized key
+   $\mathsf{rk}$.
+
+3. Verify that $\mathsf{rt^{cm}}$ corresponds to the Orchard note
+   commitment tree root at the declared snapshot height.
+
+4. Verify that $\mathsf{rt^{excl}}$ corresponds to the nullifier
+   non-membership tree root at the declared snapshot height.
+
+5. Verify that $\mathsf{dom}$ is valid for the current application
+   instance.
+
+6. Verify that $\mathsf{nf_{dom}}$ has not been previously accepted in the
+   same nullifier domain. If it has, reject the claim as a double-claim.
+
+
+## Multi-Note Batching
+
+The Claim circuit defined in [Claim Circuit] proves a statement about a
+single note. Applications that require proving aggregate balance across
+multiple notes MAY use the following batching extension.
+
+### Batched Claim Circuit
+
+A batched Claim circuit for $N$ notes modifies the single-note circuit
+as follows:
+
+- The public inputs $\mathsf{rt^{cm}}$, $\mathsf{rt^{excl}}$,
+  $\mathsf{rk}$, and $\mathsf{dom}$ are shared across all $N$ notes.
+- Each note $i$ contributes its own alternate nullifier
+  $\mathsf{nf_{dom,i}}$ and value commitment $\mathsf{cv_i}$ as public
+  inputs.
+- A single $\mathsf{ivk}$ (derived from the shared $\mathsf{ak}$ and
+  $\mathsf{nk}$) is constrained to own all $N$ notes, ensuring they
+  belong to the same holder.
+- All $N$ note commitment integrity, Merkle path, nullifier derivation,
+  non-membership, and alternate nullifier checks are performed
+  independently per note.
+
+### Note Padding
+
+To avoid leaking the number of notes a holder is claiming, the circuit
+SHOULD accept a fixed number of note slots $N_{\max}$ (for example,
+$N_{\max} = 5$). Unused slots are filled with *padded notes*: randomly
+generated note data with value 0. Padded notes satisfy all circuit
+checks (the commitment is valid, the Merkle path can use any valid leaf,
+the non-membership check passes for random nullifiers with overwhelming
+probability, and the value commitment commits to zero).
+
+An $\mathsf{is\_real}$ flag (private witness, constrained to be boolean)
+distinguishes real notes from padded notes:
+
+- Padded notes MUST have $\mathsf{v^{old}} = 0$.
+- Merkle membership and non-membership checks MAY be skipped for padded
+  notes (conditioned on $\mathsf{is\_real} = 0$) as an optimization, but
+  performing them is also sound since padded notes use valid dummy data.
+
+### Aggregate Value
+
+The verifier computes the aggregate value commitment as:
+
+$$\mathsf{cv_{total}} = \sum_{i=0}^{N_{\max}-1} \mathsf{cv_i}$$
+
+Since padded notes commit to value 0, they contribute the identity to the
+sum (up to their blinding factor). The aggregate commitment
+$\mathsf{cv_{total}}$ commits to the holder's total claimed balance.
+Applications that need to open this commitment (e.g., to verify a minimum
+balance threshold) can do so by requiring the prover to reveal the
+aggregate randomness $\mathsf{rcv_{total}} = \sum_i \mathsf{rcv_i}$.
+
+
+# Rationale
+
+## Why Alternate Nullifiers Instead of Actual Spends
+
+The most obvious approach to proof-of-balance (actually spending the
+notes to oneself at the snapshot anchor) fails because it consumes the
+notes on-chain. A holder who participates in one application cannot reuse
+the same notes in a concurrent application. Alternate nullifiers avoid
+this by operating entirely off the main chain: the standard nullifiers are
+never revealed, and the notes remain spendable.
+
+## Why (low, width) Leaf Encoding
+
+Storing $\mathsf{width} = \mathsf{end} - \mathsf{low}$ in the leaf
+instead of $\mathsf{end}$ eliminates one field subtraction from the
+in-circuit interval check. The tree builder performs this subtraction once
+during construction; the circuit evaluates the check once per claim per
+note. Since the number of claims vastly exceeds the number of tree
+rebuilds, the net constraint savings is significant.
+
+## Why Poseidon for the Non-Membership Tree
+
+The Orchard note commitment tree uses Sinsemilla for Merkle hashing.
+Sinsemilla operates on bitstrings and requires decomposition of field
+elements into bits before hashing, incurring overhead in an arithmetic
+circuit. Poseidon operates natively on field elements, avoiding this
+decomposition. Since the non-membership tree is new infrastructure with
+no backwards-compatibility constraint, the more circuit-efficient
+primitive is used.
+
+## Why Sentinel Initialization
+
+Without sentinels, the initial non-membership tree would contain a single
+leaf spanning the entire field $[0, q_{\mathbb{P}}-1]$, with width
+$\approx 2^{254}$. The in-circuit range checks use 250-bit windows
+(25 limbs of the 10-bit lookup table). An interval wider than $2^{250}$
+would allow the upper-bound range check to wrap, enabling a prover to
+falsely claim non-membership for a value outside the interval.
+
+Sentinels partition the field into intervals each narrower than $2^{250}$
+at initialization. Real nullifier insertions only split intervals into
+smaller ones, so the width bound is maintained permanently.
+
+
+# Deployment
+
+This ZIP does not specify a consensus change. Deployment considerations
+are application-specific.
+
+For applications using hardware wallets (e.g., Keystone), the spend
+authorization signature is obtained through a PCZT-based signing flow
+where the hardware wallet signs a transaction that encodes the claim
+context. The hardware wallet need not understand the claim semantics; it
+signs a standard Orchard spend authorization. Applications that support
+Keystone firmware with voting-aware context display can provide richer
+user assurance, but both modes use the same underlying circuit and
+signature scheme.
+
+
+# Reference implementation
+
+A reference implementation of the Claim circuit (including the
+non-membership tree, alternate nullifier derivation, and multi-note
+batching for $N_{\max} = 5$) is provided in the voting-circuits
+repository. [^voting-circuits]
+
+The out-of-circuit IMT construction and Merkle path utilities are
+implemented in the orchard fork used by the voting system. [^imt-impl]
+
+
+# Open issues
+
+- The security argument for the alternate nullifier derivation is
+  informal. A formal reduction from the unlinkability property to the
+  Poseidon PRF assumption would strengthen confidence.
+- The Poseidon instantiation ($\mathsf{P128Pow5T3}$) and its round
+  constants should be explicitly referenced or pinned once a canonical
+  parameter set for Zcash usage is published.
+- The interaction between multi-note batching and the sighash scheme
+  (what exactly is signed, and how it binds to all $N$ notes) requires
+  further specification per application.
+
+
+# References
+
+[^BCP14]: [Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
+
+[^protocol]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1] or later](protocol/protocol.pdf)
+
+[^protocol-orchardcommitmenttree]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 3.1: Note Commitment Trees](protocol/protocol.pdf#merkletree)
+
+[^protocol-actionstatement]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 4.17.4: Action Statement (Orchard)](protocol/protocol.pdf#actionstatement)
+
+[^protocol-merklepath]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 4.9: Merkle Path Validity](protocol/protocol.pdf#merklepath)
+
+[^protocol-sinsemilla]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 5.4.1.9: Sinsemilla Hash Function](protocol/protocol.pdf#concretesinsemillahash)
+
+[^poseidon]: [Poseidon: A New Hash Function for Zero-Knowledge Proof Systems](https://eprint.iacr.org/2019/458)
+
+[^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)
+
+[^voting-circuits]: [Zcash coinholder voting circuits](https://github.com/z-cale/voting-circuits)
+
+[^imt-impl]: [Indexed Merkle Tree implementation](https://github.com/AimyZEC/orchard/blob/main/src/delegation/imt.rs)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -209,6 +209,7 @@ Let $S = \{s_0, s_1, \ldots, s_{m-1}\}$ be the set of all Orchard
 nullifiers revealed on the consensus chain as of block height $h$, together
 with a set of sentinel values (see [Sentinel Initialization]). Sort $S$ in
 ascending order as elements of $\mathbb{F}_{q_{\mathbb{P}}}$.
+Because sentinel initialization is mandatory, $S$ is non-empty.
 
 For each pair of consecutive elements $(s_i, s_{i+1})$ where $s_i < s_{i+1}$
 and $s_{i+1} - s_i > 1$, create a leaf with:
@@ -736,7 +737,3 @@ this ZIP.
 [^poseidon]: [Poseidon: A New Hash Function for Zero-Knowledge Proof Systems](https://eprint.iacr.org/2019/458)
 
 [^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)
-
-[^voting-circuits]: [Zcash coinholder voting circuits](https://github.com/z-cale/voting-circuits)
-
-[^imt-impl]: [Indexed Merkle Tree implementation](https://github.com/AimyZEC/orchard/blob/main/src/delegation/imt.rs)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -663,19 +663,43 @@ as follows:
 
 To avoid leaking the number of notes a holder is claiming, the circuit
 SHOULD accept a fixed number of note slots $N_ {\max}$ (for example,
-$N_ {\max} = 5$). Unused slots are filled with *padded notes*: randomly
-generated note data with value 0. Padded notes satisfy all circuit
-checks (the commitment is valid, the Merkle path can use any valid leaf,
-and the non-membership check passes for random nullifiers with overwhelming
-probability).
+$N_ {\max} = 5$). Unused slots are filled with *padded notes*.
 
-An $\mathsf{is\_real}$ flag (private witness, constrained to be boolean)
-distinguishes real notes from padded notes:
+Each note slot carries a private boolean witness
+$\mathsf{is\_real} \in \{0, 1\}$, constrained by
+$\mathsf{is\_real} \cdot (1 - \mathsf{is\_real}) = 0$.
+A padded note is a slot with $\mathsf{is\_real} = 0$.
 
-- Padded notes MUST have $\mathsf{v^{old}} = 0$.
-- Merkle membership and non-membership checks MAY be skipped for padded
-  notes (conditioned on $\mathsf{is\_real} = 0$) as an optimization, but
-  performing them is also sound since padded notes use valid dummy data.
+A padded note MUST satisfy the following:
+
+- **Value.** The value MUST be 0, enforced by the constraint
+  $(1 - \mathsf{is\_real}) \cdot \mathsf{v^{old}} = 0$.
+- **Ownership.** The note is derived from the same full viewing key as
+  real notes (using a distinct diversifier index per padded slot), so it
+  passes the diversified address integrity check with the shared
+  $\mathsf{ivk}$.
+- **Note commitment integrity.** The commitment is recomputed from the
+  padded note's plaintext (value 0, random nullifier, random
+  $\text{ψ}$, fresh $\mathsf{rcm}$) and constrained to equal the
+  witnessed $\mathsf{cm}$. This check is not gated by
+  $\mathsf{is\_real}$.
+- **Merkle membership.** The Merkle path is computed for the padded
+  note, but the root equality check is gated:
+  $\mathsf{is\_real} \cdot (\mathsf{root} - \mathsf{rt^{cm}}) = 0$.
+  For padded notes ($\mathsf{is\_real} = 0$) the constraint is
+  trivially satisfied regardless of the computed root, effectively
+  skipping the membership check.
+- **Nullifier non-membership.** The IMT non-membership check is NOT
+  gated by $\mathsf{is\_real}$. Padded notes MUST provide a valid
+  non-membership proof against $\mathsf{rt^{excl}}$. Because padded
+  nullifiers are random field elements, they fall within an unrevealed
+  interval with overwhelming probability.
+- **Nullifier derivation.** The standard nullifier is derived in-circuit
+  (not gated). It is used for the non-membership check and the alternate
+  nullifier derivation but is never revealed.
+- **Alternate nullifier.** The alternate nullifier is derived and
+  published for every slot (not gated). The application verifier MAY
+  ignore alternate nullifiers corresponding to zero-value slots.
 
 
 ## Wallet Signing

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -1053,10 +1053,10 @@ batching for $N_ {\max} = 5$) is available at
 
 [^pir-nullifier-exclusion]: [Draft ZIP: Private Information Retrieval for Nullifier Exclusion Proofs](https://github.com/zcash/zips/pull/1198)
 
-[^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof)
+[^draft-str4d-orchard-balance-proof]: [Draft ZIP: Air drops, Proof-of-Balance, and Stake-weighted Polling](draft-str4d-orchard-balance-proof.md)
 
-[^voting-protocol]: [Shielded Voting Protocol](draft-valargroup-shielded-voting)
+[^voting-protocol]: [Shielded Voting Protocol](draft-valargroup-shielded-voting.md)
 
-[^zip-244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244)
+[^zip-244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244.rst)
 
-[^zip-32]: [ZIP 32: Shielded Hierarchical Deterministic Wallets](zip-0032)
+[^zip-32]: [ZIP 32: Shielded Hierarchical Deterministic Wallets](zip-0032.rst)

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -168,7 +168,7 @@ linking the querier to a nullifier range. Private information retrieval
 specification is out of scope for this document.
 
 **Hardware wallet device exposure.** When the PCZT-based hardware wallet
-signing flow (see [Hardware Wallet Signing]) is used, the device observes
+signing flow (see [Wallet Signing]) is used, the device observes
 the PCZT but learns no information about the holder's real
 Orchard balance or delegation context. The PCZT contains a 1-zatoshi
 dummy note with no on-chain counterpart; the holder's actual note
@@ -954,13 +954,39 @@ The ZIP 244 sighash commits to the full Orchard bundle structure
 $\text{ρ}$), providing the necessary cryptographic binding without
 a custom signature scheme.
 
+## Why Not a Custom Signing Protocol
+
+A future version of this specification could define a custom signing
+protocol purpose-built for proof-of-balance, rather than reusing the
+standard Orchard PCZT format. This would require ecosystem-wide
+coordination (firmware updates to all participating hardware wallets)
+but could yield several improvements:
+
+- **Binding application actions to the signature.** Many use cases want
+  to prove balance *and* take an action in a single step (e.g., casting
+  a vote). A custom signing protocol could commit to the application
+  action directly in the signature, reducing the number of ZKPs required
+  by downstream protocols.
+- **Removing the hotkey indirection.** With a richer signing format, the
+  holder could authorize actions directly from the hardware wallet
+  without delegating to an application hotkey, simplifying the trust
+  model.
+- **Improved on-device display.** A custom format could present
+  application-aware context (e.g., "Vote on proposal X with Y ZEC")
+  rather than the generic Orchard transaction fields shown today.
+
+This specification intentionally avoids a custom signing protocol to
+maximize compatibility with existing wallets. The trade-off is accepted:
+downstream protocols may require additional ZKPs or hotkey indirection
+that a purpose-built signing format could eliminate.
+
 
 # Deployment
 
 This ZIP does not specify a consensus change. Deployment considerations
 are application-specific.
 
-The hardware wallet signing flow specified in [Hardware Wallet Signing]
+The hardware wallet signing flow specified in [Wallet Signing]
 requires no firmware changes and no changes to Zcash mainchain consensus
 rules. Any hardware wallet that supports Orchard PCZT signing can
 participate immediately.
@@ -983,33 +1009,6 @@ this ZIP.
 
 
 # Open issues
-
-- **v2 signing with a new transaction format.** The signing flow
-  specified in this ZIP (v1) reuses the existing Orchard PCZT format and
-  requires no firmware changes from any hardware wallet vendor. A v2 of
-  the protocol could introduce a new transaction format purpose-built for
-  proof-of-balance, enabling:
-
-  - Finer-grained delegation from a hardware wallet to a hotkey, without
-    requiring the ZK circuit to verify blake2b.
-  - Reduction in the number of ZKPs required by downstream application
-    protocols.
-  - Better UX for what the user is signing over, with application-aware
-    context display on the device screen.
-
-  However, v2 would require a firmware update, and every user of a
-  hardware wallet would need to update their device before they could
-  participate.
-
-  If both v1 (compatible with the base Zcash transaction format) and v2
-  (application-specific format) are supported simultaneously, the system
-  SHOULD NOT publicly leak which custody method or protocol version a
-  holder is using. This will come with proving and format overheads whose
-  design can be determined closer to the time of v2 deployment.
-
-- **Memo content standardization.** The delegation memo format is
-  currently informational. A future revision could specify a structured
-  memo format to support programmatic verification of delegation intent.
 
 
 # References

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -194,8 +194,7 @@ instance and the declared balance.
 - The holder proves spend authority (not merely viewing access).
 - The construction allows a holder to participate in multiple independent
   applications using the same notes, provided each application uses a
-  distinct nullifier domain. This is a natural consequence of the
-  domain-separated alternate nullifier derivation.
+  distinct nullifier domain.
 
 
 # Non-requirements

--- a/zips/draft-valargroup-orchard-balance-proof.md
+++ b/zips/draft-valargroup-orchard-balance-proof.md
@@ -689,11 +689,11 @@ The signing flow proceeds in five steps:
    submission.
 
 Each interaction with the hardware wallet device delegates up to
-$N_{\max}$ Orchard notes. A holder with more than $N_{\max}$ notes
-repeats the flow for each batch, producing a separate application
-commitment per batch. The holder MAY choose to delegate fewer batches
-than their full note set, claiming only the balance covered by the
-delegated batches.
+$N_{\max}$ Orchard notes (we utilize the default batch size of 5).
+A holder with more than $N_{\max}$ notes repeats the flow for each batch,
+producing a separate application commitment per batch. The holder MAY choose
+to delegate fewer batches than their full note set, claiming only the balance
+covered by the delegated batches.
 
 ### Dummy Signed Note Construction
 


### PR DESCRIPTION
## Summary

- Adds a new informational draft ZIP (`draft-valargroup-orchard-balance-proof.md`) specifying the Orchard Proof-of-Balance protocol, which is intended to be used in a future Zcash voting application.
- Enables users to prove the total value of their Orchard notes without revealing individual note details, using pool snapshots and nullifier non-membership trees.
- Adds reference and credits to Daira-Emma Hopwood and Jack Grigg for the initial spec (`draft-str4d-orchard-balance-proof.md`)