### PR TITLE
[ZIP 316] Propose Revision 2 and withdraw Revision 1

### DIFF
--- a/zips/zip-0316.rst
+++ b/zips/zip-0316.rst
@@ -763,7 +763,7 @@ wallet implementors may wish to show a larger number of initial characters for
 abridged UA/UVKs to enable users to defend against partial matching attacks up
 to a higher difficulty for the adversary.
 
-'Note that if different sources show different substrings of a UA/UVK then users are
+Note that if different sources show different substrings of a UA/UVK then users are
 only able to compare the characters that are common to all of these substrings, and
 so it is only *initial* characters that contribute to satisfying this requirement.
 
@@ -961,11 +961,10 @@ in an unprivileged observer of the chain being able to distinguish transactions
 sent to addresses containing such Items from transactions sent to addresses
 that do not.
 
-In contrast, the guiding principle for ``tu`` addresses is that a ``tu``
-address MAY contain items whose interpretation in transaction construction
-could result in additional information being leaked on-chain. As such a user
-giving out a ``tu`` address should recognise that they may be giving up some
-privacy in transactions received at that address.
+In contrast, a ``tu`` address MAY contain items whose interpretation in
+transaction construction could result in additional information being leaked
+on-chain. As such a user giving out a ``tu`` address should recognise that
+they may be giving up some privacy in transactions received at that address.
 
 If a new Metadata Item type should not be allowed in ``zu`` addresses, it MUST
 be assigned in the MUST-understand Metadata range.
@@ -1069,11 +1068,12 @@ we derive the external and internal $\mathsf{ovk}$ components from the P2SH FVK
   $I_\mathsf{ovk}$ and let $\mathsf{ovk_{internal}}$ be the
   remaining $32$ bytes of $I_\mathsf{ovk}$.
 
-Since a P2SH FVK encodes the keys at a level from which both external
-and internal child keys can be derived (via the ``/**`` multipath
-notation in the descriptor template), we can derive both external and
-internal P2SH addresses without having any spending key, because child
-derivation at the Change and Index levels is non-hardened.
+Since a P2SH FVK encodes the keys, with their chain codes, at a level
+from which both external and internal child keys can be derived (via
+the ``/**`` multipath notation in the descriptor template), we can
+derive both external and internal P2SH addresses without having any
+spending key, because child derivation at the Change and Index levels
+is non-hardened.
 
 
 Deriving a UIVK from a UFVK
@@ -1466,7 +1466,7 @@ Efficiency
 The cost is dominated by 4 BLAKE2b compressions for $\ell_M \leq 128$
 bytes. A Revision 0 UA containing a Transparent Address, a Sapling
 Address, and an Orchard Address, would have $\ell_M = 128$ bytes.
-As of `Revision 2`_, a UA containing a Sapling Address and an Orchard
+A UA containing a Sapling Address and an Orchard
 Address would have $\ell_M = 106$ bytes.
 
 For longer UAs (when other Receiver Types are added) or UVKs, the cost


### PR DESCRIPTION
This re-specifies Revision 1 as Revision 2, to address the concerns expressed in https://forum.zcashcommunity.com/t/unified-addresses-composition/51024/7. 

In addition, this PR proposes a separation between UVKs and UAs, such that UVKs may still be used as practical encodings of "buckets of keys" that define an account. In addition, this proposes an encoding for P2SH viewing key information for both Revision 0 and Revision 2.

Fixes #1228 