### PR TITLE
[ZIP 2005] Update the Quantum Recoverability deployment plan

### DIFF
--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1407,7 +1407,8 @@ implies that when the pre-quantum protocol is turned off, many v5 and
 earlier outputs will no longer be spendable. v6 may change the note
 encryption in order to support memo bundles and ZSAs, if so another
 note plaintext version must be specified for inclusion of those
-features.
+features. That note plaintext version would be with $\{\mathsf{0x04}\}$ or
+greater.
 
 Note: if wallets prioritize spending non-pq-recoverable notes, it is
 conceivable that an adversary could exploit this to improve

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -3,7 +3,7 @@
     Title: Quantum Recoverability
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
             Jack Grigg <thestr4d@gmail.com>
-    Credits: Sean Bowe
+    Credits: Sean Bowe, Dev Ojha
     Status: Draft
     Category: Consensus
     Created: 2025-03-31
@@ -50,12 +50,13 @@ many of its design decisions are intentionally left open.
 
 # Abstract
 
-This ZIP proposes a change to the construction of Orchard[ZSA] notes
-starting with v6 transactions, designed to improve Zcash's long-term
-resilience against a significant potential threat to its security from
-quantum computers. It does not by itself make the protocol secure against
-quantum adversaries, but is intended to support a smoother transition to
-future versions of Zcash designed to be so.
+This ZIP proposes a change to the construction of Orchard[ZSA]
+notes, designed to improve Zcash's long-term resilience against a
+significant potential threat to its security from quantum computers.
+It does not by itself make the protocol secure against quantum
+adversaries, but is intended to support a smoother transition to
+future versions of Zcash designed to be so. We call this property
+quantum recoverability.
 
 Specifically, if it were necessary to disable the current Orchard[ZSA]
 shielded protocol in order to prevent a discrete-log-breaking adversary
@@ -68,7 +69,6 @@ If the Orchard[ZSA] protocol needed to be disabled for this reason, the
 Sapling protocol would need to be disabled as well, which would make all
 Sapling funds inaccessible. Sapling funds should be migrated to Orchard in
 order to take advantage of this change.
-
 
 # Motivation
 
@@ -112,9 +112,27 @@ Sapling [^zip-0032-sapling-child-key-derivation] [^zip-0032-sapling-internal-key
 and Orchard [^zip-0032-orchard-child-key-derivation] [^zip-0032-orchard-internal-key-derivation].)
 
 This proposal is implementable at low risk, and required changes to existing
-libraries and wallets are small. It can be folded into other changes
-necessary to implement ZSAs [^zip-0226] and Memo Bundles [^zip-0231].
+libraries and wallets are small. This proposal requires a small note
+format change, and no changes to today's Orchard circuit. We roll out
+the note plaintext change in two phases, with planned further
+restrictions in the eventual v6 transaction format. In Phase 1, every
+wallet independently updates to support receiving the new quantum
+recoverable note format, and begins using it for internal change
+notes. Each wallet is intended to warn the user, that they may see
+lower balances if they use the same seed phrase on distinct, old
+wallet software. In Phase 2, a coordinated upgrade height is decided
+upon, for wallets to begin sending quantum recoverable notes in the
+v5 transaction format. In Phase 2, wallets all still accept non
+quantum recoverable notes. This deployment is structured such that it
+is unbundled from the v6 transaction format, and the only risks to
+user funds are:
 
+* During phase 1 and phase 2, if you use the same seed on an older
+  wallet version, you will see an inaccurate balance on the older
+  wallet.
+* After the phase 2 coordinated upgrade height, if you use an older
+  wallet that did not upgrade for phase 1, you will not see incoming
+  payments from phase 2 wallets until you upgrade.
 
 # Requirements
 
@@ -163,18 +181,18 @@ necessary to implement ZSAs [^zip-0226] and Memo Bundles [^zip-0231].
 
 This subsection and the flow diagram below are non-normative.
 
-In order to support ZSAs [^zip-0226] [^zip-0227] and memo bundles
-[^zip-0231], v6 transactions require in any case a new note plaintext
-format, with lead byte $\mathtt{0x03}.$ This gives us an opportunity
-to change the way that the $\mathsf{pre\_rcm}$ value is computed for
-this new format, by including all of the note fields in $\mathsf{pre\_rcm}$.
-The resulting $\mathsf{rcm}$ is essentially a random function of the
+To support quantum recoverability, we want to adapt the way
+$\mathsf{pre\_rcm}$ is computed in the construction of notes. Namely,
+we include all of the note fields in $\mathsf{pre\_rcm}$. The
+resulting $\mathsf{rcm}$ is essentially a random function of the
 note fields — this allows us to argue that the overall commitment
 scheme is post-quantum binding, as long as the new derivation of
-$\mathsf{rcm}$ is checked in the Recovery Protocol.
+$\mathsf{rcm}$ is checked in the Recovery Protocol. To do this, we
+will make a new note plaintext version with lead byte
+$\mathtt{0x03}.$
 
-Essentially the same technique also needs to be applied to the
-function $\mathsf{Commit^{ivk}}$ that is used to derive Orchard
+Essentially the same technique must also be applied in the Recovery
+Protocol for $\mathsf{Commit^{ivk}}$, which is used to derive Orchard
 incoming viewing keys. In order to support existing keys, we have
 the Recovery Protocol check the derivations of $\mathsf{nk}$,
 $\mathsf{ak}$, and $\mathsf{rivk}$ from the secret key $\mathsf{sk}$.
@@ -186,6 +204,12 @@ case. This alternative derivation, using a new "quantum spending key"
 $\mathsf{qsk}$ and "quantum intermediate key" $\mathsf{qk}$, also
 supports more efficient use of hardware wallets in the Recovery Protocol.
 It is described in sections [Usage with FROST] and [Usage with Hardware Wallets].
+
+A new note plaintext version is specified, beginning with a
+$\{ \mathtt{0x03} \}$ byte. Wallets are intended to upgrade to
+support parsing the new note plaintext version as soon as possible,
+along with using the new note plaintext version for internal change
+notes.
 
 ## Flow diagram for the Orchard and OrchardZSA protocols
 
@@ -425,8 +449,9 @@ wallet.
 
 This is written as a set of changes to version 2025.6.2 of the protocol
 specification, and to the contents of ZIPs at the time of writing in
-October 2025 (as proposed for the NU6.1 upgrade). It will need to be merged
-with other changes for v6 transactions (memo bundles [^zip-0231] and
+October 2025 (as proposed for the NU6.1 upgrade). Another revision
+may be needed to merge with other changes in a future v6 transaction
+format (memo bundles [^zip-0231] and
 ZSAs [^zip-0226] [^zip-0227]).
 
 ### Changes to the Protocol Specification
@@ -1346,25 +1371,49 @@ doing it this way involves fewer components. This also allows us to avoid
 any security compromise and use 256-bit cryptovalues for both integrity
 and randomization, which would otherwise have been difficult.
 
-It is suggested to deploy this change with v6 transactions. That is,
-every Orchard output of a v6-onward transaction will be a pq-recoverable
-note. This implies that when the pre-quantum protocol is turned off,
-v5 and earlier outputs will no longer be spendable. Since v6 already
-changes the note encryption in order to support memo bundles and ZSAs,
-this approach to deployment reduces the risk of the kind of difficulties
-that occurred with [ZIP 212](https://zips.z.cash/zip-0212), where some
-wallets were following the old protocol after the Canopy upgrade and
-sending non-conformant note plaintexts.
+We break deployment of the new note format within the v5 transaction
+format into two phases, and then we fully enforce the new note format
+with the v6 transaction format.
 
-When a compliant wallet receives an Orchard note in a v5 or earlier
-transaction, the associated funds are not pq-recoverable and need to be
-spent to v6 in order to make them so.
+* Phase 1:
+  * Wallets should upgrade as soon as possible
+  * Wallets can parse incoming QR note plaintexts.
+  * Wallets create QR note plaintexts for internal change notes only
+  * Upon a user upgrading to Phase 1, the wallet should report the
+    risk to user. Namely, "If you use the same seed phrase on an
+    older zcash wallet, it may report an incorrect balance due to
+    not-yet being quantum-ready. Please update all your zcash
+    wallets to a recent version for accurate balance reporting".
+* Phase 2:
+  * We must agree on an upgrade height, based on the rate of
+    adoption of phase 1 amongst wallets. Then wallets upgrade to it
+  * In phase 2, after the upgrade height, wallets begin sending QR
+    external notes.
+  * There is a risk that if the recipient wallet is not yet phase 1,
+    they will not receive the payment until they upgrade their wallet
+    version, and it re-syncs.
 
-Note: if we prioritize spending non-pq-recoverable notes, it is
+We view the risks laid out above worth taking, for the benefit of
+getting users quantum recoverable sooner. There were difficulties in
+the deployment of [ZIP 212](https://zips.z.cash/zip-0212), which
+centered around upgraded wallets not being able to receive funds from
+a wallet who did not upgrade during the allotted grace period. This
+is fixed here, because within the v5 transaction format, non quantum
+recoverable notes will always be accepted by all wallets.
+
+We suggest that v6 transactions enforce quantum recoverability. This
+implies that when the pre-quantum protocol is turned off, many v5 and
+earlier outputs will no longer be spendable. v6 may change the note
+encryption in order to support memo bundles and ZSAs, if so another
+note plaintext version must be specified for inclusion of those
+features.
+
+Note: if wallets prioritize spending non-pq-recoverable notes, it is
 conceivable that an adversary could exploit this to improve
 [arity leakage attacks](https://github.com/zcash/zcash/issues/4332).
 On the other hand, adversaries can already choose note values to
-manipulate the note selection algorithm to some extent.
+manipulate the note selection algorithm to some extent. We do not
+suggest any prioritization of which note to spend for now.
 
 
 # References

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -70,6 +70,7 @@ Sapling protocol would need to be disabled as well, which would make all
 Sapling funds inaccessible. Sapling funds should be migrated to Orchard in
 order to take advantage of this change.
 
+
 # Motivation
 
 If quantum computers —or any other attack that allows finding discrete
@@ -123,11 +124,11 @@ lower balances if they use the same seed phrase on distinct, old
 wallet software. In Phase 2, a coordinated upgrade height is decided
 upon, for wallets to begin sending quantum recoverable notes in the
 v5 transaction format. In Phase 2, wallets all still accept non
-quantum recoverable notes. This deployment is structured such that it
-is unbundled from the v6 transaction format, and the only risks to
+quantum recoverable notes. This deployment is structured such that users can
+get quantum recoverability guarantees very quickly, with the only risks to
 user funds are:
 
-* During phase 1 and phase 2, if you use the same seed on an older
+* During phase 1 and phase 2, if you use the same seed on another older
   wallet version, you will see an inaccurate balance on the older
   wallet.
 * After the phase 2 coordinated upgrade height, if you use an older


### PR DESCRIPTION
This PR suggests amendments to ZIP 2005 allowing us to get started on getting wallets quantum recoverable very quickly.

TL;DR:
- Unbundle this change from the v6 transaction format
- Have wallets upgrade as soon as code is ready to allow receiving QR notes, and make their internal change notes QR
- After monitoring deployment across all wallets, decide when
- In Tx format v6, require wallets to only allow receiving QR notes.

Example code for doing this integration (Will properly integration test, and demo on mainnet later in the week w/ @greg0x after further governance work):

| Crate | Scope |
  | ----- | ----- |
  | [`orchard`](https://github.com/valargroup/qr_orchard/commit/c3a9f55e30edf0b1d05b9625ef4a4273230b6c96) | Add a [`NoteVersion` enum](https://github.com/valargroup/qr_orchard/blob/c3a9f55/src/note.rs#L24)<br>Add QR rcm derivation:  [`RandomSeed::qr_rcm()`](https://github.com/valargroup/qr_orchard/blob/c3a9f55/src/note.rs#L143)<br>Add version-aware [note commitment](https://github.com/valargroup/qr_orchard/blob/c3a9f55/src/note.rs#L370), [plaintext  encoding](https://github.com/valargroup/qr_orchard/blob/c3a9f55/src/note_encryption.rs#L183), and  [decryption](https://github.com/valargroup/qr_orchard/blob/c3a9f55/src/note_encryption.rs#L57)<br>Add per-output [`Builder::add_versioned_output()`](https://github.com/valargroup/qr_orchard/blob/c3a9f55/src/builder.rs#L627)[`zcash_primitives`](https://github.com/valargroup/qr_librustzcash/blob/230a29c6/zcash_primitives/src/transaction/builder.rs) (librustzcash) |  [`Builder::add_versioned_orchard_output()`](https://github.com/valargroup/qr_librustzcash/blob/230a29c6/zcash_primitives/src/transaction/builder.rs#L594) plumbing; git dependency on  modified `orchard` |
  | [`zcash_client_backend`](https://github.com/valargroup/qr_librustzcash/blob/230a29c6/zcash_client_backend/src/data_api/wallet.rs) (librustzcash) | Calls  [`add_versioned_orchard_output(..., NoteVersion::V3_Qr)`](https://github.com/valargroup/qr_librustzcash/blob/230a29c6/zcash_client_backend/src/data_api/wallet.rs#L1566) for change outputs (ZIP-2005 phase 1) |
