### PR TITLE
[ZIP 316] Add  FVK and OVK constructions for ZIP 48 transparent multisig accounts

### DIFF
--- a/zips/zip-0316.rst
+++ b/zips/zip-0316.rst
@@ -479,11 +479,14 @@ $\mathtt{addr}$ field:
   $\mathsf{dk}\,||\,\mathsf{I2LEOSP}_{256}(\mathsf{ivk}).$ Note that
   a zero $\mathsf{ivk}$ is not valid [#protocol-2025.6.0]_.
 
-* There is no defined way to represent a Viewing Key for a Transparent
-  P2SH Address in a UFVK or UIVK (because P2SH Addresses cannot, in general,
-  be diversified in an unlinkable way). The Typecode $\mathtt{0x01}$
-  MUST NOT be included in a UFVK or UIVK by Producers, and MUST be
-  treated as unrecognised by Consumers.
+* Consumers MUST reject a Transparent P2SH FVK Encoding that does not
+  follow this format (i.e. the length is not 3 (modulo 65), or the first
+  byte is not $\mathtt{0x00}$, or $1 \le t \le N$ does not hold, or one of
+  the public key encodings is not a possible output of $\mathsf{ser_P}$
+  for a secp256k1 curve point).
+  
+  While other, non-Multisig, Transparent P2SH FVKs are possible in principle,
+  no other types of Transparent P2SH FVK are defined in this specification.
 
 * For Transparent P2PKH Addresses that are derived according to BIP 32
   [#bip-0032]_ and BIP 44 [#bip-0044]_, the FVK and IVK Encodings have


### PR DESCRIPTION
Define FVK and corresponding external/internal ovk derivation for P2SH multisig FVKs. Add references to ZIP 48 and BIP 383 (`sortedmulti()` ordering).