### PR TITLE
Fix syntax error in dependency check status workflow

### DIFF
--- a/.github/workflows/report_updatecheck.yml
+++ b/.github/workflows/report_updatecheck.yml
@@ -27,7 +27,7 @@ jobs:
                   run_id: runId,
                });
 
-               if (artifacts.data.artifacts.some(a => a.name === 'neutral-signal') {
+               if (artifacts.data.artifacts.some(a => a.name === 'neutral-signal')) {
                  conclusion = 'neutral';
                  title = 'Dependencies are correct but not up-to-date';
                } else {


### PR DESCRIPTION
## Summary
- The github-script step in `.github/workflows/report_updatecheck.yml` had a missing closing paren on its `if` condition, so the script failed to parse and `checks.create` never ran.
- As a result, the 'Dependency check result' status from the 'Status of dependency check' workflow (added in #1237) was never posted on PRs (e.g. #1251).

Note: because `workflow_run` triggers only fire for workflow files on the default branch, the fix will only take effect on PRs opened after this is merged.

## Test plan
- [ ] Merge and confirm a subsequent PR shows the 'Dependency check result' check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)