### PR TITLE
Fix rendering errors in zip-0316.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ Released ZIPs
     <tr> <td>300</td> <td class="left"><a href="zips/zip-0300.rst">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
     <tr> <td>301</td> <td class="left"><a href="zips/zip-0301.rst">Zcash Stratum Protocol</a></td> <td>Active</td>
     <tr> <td>308</td> <td class="left"><a href="zips/zip-0308.rst">Sprout to Sapling Migration</a></td> <td>Active</td>
-    <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>[Revision 0] Active, [Revision 1] Proposed</td>
+    <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>[Revision 0] Active, [Revision 1] Withdrawn, [Revision 2] Draft</td>
     <tr> <td>317</td> <td class="left"><a href="zips/zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
     <tr> <td>320</td> <td class="left"><a href="zips/zip-0320.rst">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Active</td>
     <tr> <td>321</td> <td class="left"><a href="zips/zip-0321.rst">Payment Request URIs</a></td> <td>Active</td>
@@ -350,7 +350,7 @@ Index of ZIPs
     <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zips/zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
     <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zips/zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td>
     <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
-    <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>[Revision 0] Active, [Revision 1] Proposed</td>
+    <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>[Revision 0] Active, [Revision 1] Withdrawn, [Revision 2] Draft</td>
     <tr> <td>317</td> <td class="left"><a href="zips/zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
     <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zips/zip-0318.rst">Associated Payload Encryption</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zips/zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>

--- a/zips/zip-0316.rst
+++ b/zips/zip-0316.rst
@@ -321,22 +321,24 @@ Revisions
 
 * Revision 0: The initial version of this specification.
 
-.. _`Revision 1` (Withdrawn):
+.. _`Revision 1`:
 
-* Revision 1 proposed a variant of this specification similar to that specified
-  for `Revision 2`_ addresses having the `tu` Human-Readable Part. It faced
-  [opposition from the community](https://forum.zcashcommunity.com/t/unified-addresses-composition/51024/7)
+* Revision 1 (Withdrawn): Revision 1 proposed a variant of this specification
+  similar to that specified for `Revision 2`_ addresses having the ``tu``
+  Human-Readable Part. It faced `opposition from the community
+  <https://forum.zcashcommunity.com/t/unified-addresses-composition/51024/7>`_
   due to it being difficult to discern the privacy implications of sharing an
   address as that specified, and has been withdrawn. See
-  https://github.com/zcash/zips/blob/4acf32ac6db409d93041c463880dad6df83875e1/zips/zip-0316.rst
-  for the specification that was proposed.
+  `the previously proposed specification
+  <https://github.com/zcash/zips/blob/4acf32ac6db409d93041c463880dad6df83875e1/zips/zip-0316.rst>`_
+  for details.
 
 .. _`Revision 2`:
 
 * Revision 2: This version adds support for `MUST-understand Typecodes`_ and
   `Address Expiration Metadata`_. It introduces two new variants of Unified
-  Addresses; `zu` addresses, which are prohibited from containing transparent
-  receivers, and `tu` addresses, which allow transparent receivers to be
+  Addresses; ``zu`` addresses, which are prohibited from containing transparent
+  receivers, and ``tu`` addresses, which allow transparent receivers to be
   augmented with metadata items. For Unified Viewing Keys, this version adopts
   ``uvf`` and ``uvi`` encoding prefixes for Unified Full Viewing Keys and
   Unified Incoming Viewing Keys respectively, drops the restriction that a UVK
@@ -680,16 +682,14 @@ representation of viewing keys for P2SH addresses, which is an important use
 case with the advent of ZIP 48 [#zip-0048]_. In addition, transparent-only
 viewing keys can use Metadata Items to represent expiration heights/dates as
 described in `Address Expiration Metadata`_ that is useful in the generation of
-`tu`-prefixed addresses.
+``tu``-prefixed addresses.
 
 .. raw:: html
 
    </details>
 
-.. _`Rationale for removing Transparent Receivers from zu Unified Addresses`:
-
-Rationale for removing Transparent Receivers from `zu` Unified Addresses
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Rationale for removing Transparent Receivers from ``zu`` Unified Addresses
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 .. raw:: html
 
@@ -701,7 +701,7 @@ way for a user to visually distinguish a Unified Address that allowed the
 receipt of transparent funds from one that did not; Transparent addresses do
 not provide any privacy protection, and including them in UAs created a risk
 that Senders would fall back to transparent transfers even when the Recipient
-supports shielded protocols. Historically, the `z` address prefix indicated
+supports shielded protocols. Historically, the ``z`` address prefix indicated
 to the user that no element of the recipient address would cause information
 about the recipient to be leaked on-chain by transfers to that address.
 `Revision 2`_ restores this property.
@@ -941,8 +941,6 @@ information is available to the Sender, it is both permissible and advisable to
 set this bound more tightly; a common expiry delta used by many wallets is 40
 blocks from the current chain tip, as suggested in ZIP 203
 [#zip-0203-default-expiry]_.
-
-.. _`Typecode Registry`:
 
 Typecode Registry
 -----------------


### PR DESCRIPTION
Fix malformed `Revision 1` hyperlink target that broke the reference from the Changelog section, convert a Markdown-style link in the Revisions list to RST syntax, remove duplicate explicit targets that conflicted with section-implicit targets, and switch single backticks (rendered as `<cite>`) to double backticks (rendered as `<code>`) for consistency.

Also, update `README.rst` with the `Withdrawn` status for ZIP 316, Revision 1.