### PR TITLE
ZIP 2005: flesh out security arguments and instantiate H^{qk} as BLAKE3

### DIFF
--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -33,9 +33,11 @@ and a variable suffixed with $\star$ indicates a bit-sequence encoding of
 an elliptic curve point.
 
 For brevity, in the discussion sections of this ZIP we abbreviate
-$\mathsf{H^{rcm,Orchard}}$ as $\mathsf{H^{rcm}}$ (and similarly for other
-Orchard-specific hash function names). The changes to the protocol
-specification and to other ZIPs use the full forms.
+$\mathsf{H^{rcm,Orchard}}$ as $\mathsf{H^{rcm}}$,
+$\mathsf{PRF^{nfOrchard}}$ as $\mathsf{PRF^{nf}}$,
+$\mathcal{K}^{\mathsf{Orchard}}$ as $\mathcal{K}$,
+and similarly for other Orchard-specific hash function names. The changes
+to the protocol specification and to other ZIPs use the full forms.
 
 The term "Zcash Shielded Assets" or "ZSAs" refers to the extension to
 the Orchard shielded protocol described in ZIPs 226 and 227 [^zip-0226] [^zip-0227].
@@ -931,8 +933,7 @@ Import this definition from § 4.2.3 ‘Orchard Key Components’ [^protocol-or
 
 Import this definition from ZIP 32 [^zip-0032-orchard-internal-key-derivation]:
 
-> $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rivk\_ext}}([\mathtt{0x83}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak})$
-> $\hspace{21.58em} ||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})))$
+> $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rivk\_ext}}\big([\mathtt{0x83}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak}) \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})\kern-0.1em\big)\kern-0.15em\big)$
 
 Import these definitions from § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend], specialized to $\mathsf{leadByte} = \mathtt{0x03}$:
 
@@ -1002,18 +1003,18 @@ $\begin{array}{l}
 \mathsf{rivk\_ext},&\text{if not } \mathsf{is\_internal\_rivk} \\
 \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}),&\text{if } \mathsf{is\_internal\_rivk} \end{cases} \\
 \wedge\; \mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}) \\
-\wedge\; \text{let } \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \\
-\wedge\; \mathsf{ivk} \not\in \{0, \bot\} \\
-\wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \\
-\wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}) \\
-\wedge\; \text{let } \mathsf{noterepr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \\
-\wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{noterepr}\big) \\
-\wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) \\
-\wedge\; \mathsf{cm} \neq \bot \\
-\wedge\; \text{let } \mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}(\mathsf{cm}) \\
-\wedge\; \text{let } \mathsf{leaf} = \mathsf{MerkleCRH}(\mathsf{cm}_x, \text{ρ}) \\
-\wedge\; \mathsf{path} \text{ is a path to } \mathsf{leaf} \text{ in the rehashed commitment tree} \\
-\wedge\; \mathsf{nf} = \mathsf{DeriveNullifier_{nk}}(\text{ρ}, \text{ψ}, \mathsf{cm}) \\
+\wedge\; \text{let } \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \vphantom{\big(}\\
+\wedge\; \mathsf{ivk} \not\in \{0, \bot\} \vphantom{\Big(}\\
+\wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \vphantom{\big(}\\
+\wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}) \vphantom{\Big(}\\
+\wedge\; \text{let } \mathsf{noterepr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \vphantom{\big(}\\
+\wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{noterepr}\big) \vphantom{\Big(}\\
+\wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) \vphantom{\big(}\\
+\wedge\; \mathsf{cm} \neq \bot \vphantom{\Big(}\\
+\wedge\; \text{let } \mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}(\mathsf{cm}) \vphantom{\big(}\\
+\wedge\; \text{let } \mathsf{leaf} = \mathsf{MerkleCRH}(\mathsf{cm}_x, \text{ρ}) \vphantom{\Big(}\\
+\wedge\; \mathsf{path} \text{ is a path to } \mathsf{leaf} \text{ in the rehashed commitment tree} \vphantom{\big(}\\
+\wedge\; \mathsf{nf} = \mathsf{DeriveNullifier_{nk}}(\text{ρ}, \text{ψ}, \mathsf{cm}) \vphantom{\Big(}\\
 \}
 \end{array}$
 
@@ -1037,15 +1038,15 @@ All of the operations below need to be implemented with complete additions,
 even if they are incomplete in the current Orchard[ZSA] statement/circuit.
 
 * 7 BLAKE2b-512 compressions:
-  * 3 multiplexed between $\mathsf{H^{rivk\_ext}}$ when $\mathsf{use\_qsk}$ is true (1 compression),
+    * 3 multiplexed between $\mathsf{H^{rivk\_ext}}$ when $\mathsf{use\_qsk}$ is true (1 compression),
     and $\mathsf{H^{ask}}$ + $\mathsf{H^{nk}}$ + $\mathsf{H^{rivk\_legacy}}$ when $\mathsf{use\_qsk}$ is false (3 compressions)
-  * 1 to compute $\mathsf{H^{rivk\_int}}$
-  * 1 to compute $\mathsf{H^{\text{ψ}}}$
-  * 2 to compute $\mathsf{H^{rcm}}$
-    * we could potentially save these two by using Poseidon to implement $\mathsf{H^{rcm}}$, but it seems not worth it.
+    * 1 to compute $\mathsf{H^{rivk\_int}}$
+    * 1 to compute $\mathsf{H^{\text{ψ}}}$
+    * 2 to compute $\mathsf{H^{rcm}}$
+        * we could potentially save these two by using Poseidon to implement $\mathsf{H^{rcm}}$, but it seems not worth it.
 * 1 use of $\mathsf{H^{qk}}$
 * 1 use of $\mathsf{Commit^{ivk}}$ ($\mathsf{SinsemillaShortCommit}$)
-* 1 use of $\mathsf{NoteCommit^{Orchard}}$ ($\mathsf{SinsemillaCommit}$)
+* 1 use of $\mathsf{NoteCommit}$ ($\mathsf{SinsemillaCommit}$)
 * 1 full-width fixed-base Pallas scalar multiplication, $[\mathsf{ask}]\, \mathcal{G}^{\mathsf{Orchard}}$
 * 1 full-width variable-base Pallas scalar multiplication, $[\mathsf{ivk}]\, \mathsf{g_d}$
 * 1 Merkle tree path check
@@ -1064,7 +1065,7 @@ post-quantum knowledge-sound.
 
 ### Repairing the note commitment Merkle tree
 
-$\mathsf{MerkleCRH^{Orchard}}$ is instantiated using
+$\mathsf{MerkleCRH}$ is instantiated using
 $\mathsf{SinsimillaHash}$ [^protocol-concretesinsemillahash].
 Its collision resistance depends on the Discrete Logarithm Relation Problem
 on the Pallas curve [^protocol-sinsemillasecurity], and so it is not
@@ -1085,53 +1086,53 @@ complications due to duplicate commitments for the same note.
 
 ### Attacks against binding of note commitments
 
-We still face the problem that $\mathsf{NoteCommit^{Orchard}}$ is not
+We still face the problem that $\mathsf{NoteCommit}$ is not
 binding against a discrete-log-breaking adversary: given the discrete
 logarithm relations between bases, we can easily write a linear equation
 in the scalar field with multiple solutions of the inputs for a given
 commitment.
 
 This allows an adversary to find two distinct notes corresponding to
-openings of $\mathsf{NoteCommit^{Orchard}}$ on the same commitment.
+openings of $\mathsf{NoteCommit}$ on the same commitment.
 They create one note as an output and spend the other note — which may
 have a greater value, or a value in a different ZSA asset, breaking the
 Balance property.
 
 ### Repairing note commitments
 
-We prefer to fix this without changing $\mathsf{NoteCommit^{Orchard}}$ itself.
+We prefer to fix this without changing $\mathsf{NoteCommit}$ itself.
 Instead we change how $\mathsf{rcm}$ is computed to be a hash of $\mathsf{rseed}$ and
 $\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)$,
 as detailed in the [Specification] section.
 Specifically, when $\mathsf{leadByte} = \mathtt{0x03}$ we have:
 
-$\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm}))$
+$\hspace{2em}\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) = \mathsf{ToScalar}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm}))$
 
 $\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{encode}(\mathsf{noterepr})$
 
 ### Informal security argument for binding of note commitments
 
-We can view the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$
+We can view the output of $\mathsf{NoteCommit_{rcm}}(\mathsf{noterepr})$
 as the point addition of a randomization term
 $[\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
 and some other function of $\mathsf{rseed}$, $\mathsf{leadByte}$, and
 $\mathsf{noterepr}$.
 
 Without loss of generality, we can write that function as
-$[f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
+$[\mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
 by expanding each of the Sinemilla bases
 $\mathcal{C}_j = \mathcal{Q}(D) \text{ or } \mathcal{S}(j)$ used by
 [$\mathsf{HashToSinsimillaPoint}$](https://zips.z.cash/protocol/protocol.pdf#concretesinsemillahash)
 as $\mathcal{C}_j = [c_j]\, \mathcal{R}$ for some $c_j$. That is,
-$$\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
+$$\mathsf{NoteCommit_{rcm}}(\mathsf{noterepr}) = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
-We will model $\mathsf{H^{rcm}}$ as a random oracle independent of $f$ with
+We will model $\mathsf{H^{rcm}}$ as a random oracle independent of $\mathsf{f}$ with
 uniform output on $\mathbb{F}_{r_{\mathbb{P}}}.$ This is reasonable because
 $\mathsf{H^{rcm}}$ cannot depend on any of the $c_j$, and in any case it is
 instantiated using BLAKE2b, a conventional hash function not related to the
 Pallas curve.
 
-> The fact that $\mathsf{NoteCommit^{Orchard}}$ has
+> The fact that $\mathsf{NoteCommit}$ has
 > $\text{ψ} = \mathsf{H}^{\text{ψ}}(\mathsf{rseed}, \text{ρ})$ as an
 > input does not affect the analysis provided that $\mathsf{H^{rcm}}$ and
 > $\mathsf{H}^{\text{ψ}}$ can be treated as independent. In practice both
@@ -1152,7 +1153,7 @@ $\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}$
 and obtains a "random"
 $\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$.
 
-We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$.
+We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$.
 
 Over all Pallas curve points $P$, the number of outputs of
 $\mathsf{Extract}_{\mathbb{P}}(P)$ is $(\mathbb{F}_{r_\mathbb{P}} + 1)/2 \approx 2^{253}$ —
@@ -1164,7 +1165,7 @@ zero point $\mathcal{O}_{\mathbb{P}}$ which is mapped to $0$.
 > negligible effect.
 
 There are two values of $\mathsf{cm}$ that match $\mathsf{cm}_x$ in their $x$-coordinate.
-Because the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$ is
+Because the output of $\mathsf{NoteCommit_{rcm}}(\mathsf{noterepr})$ is
 of the form $\mathsf{cm} = F(\mathsf{noterepr}) + [\mathsf{rcm}]\, \mathcal{R}$,
 for any given note we have exactly two values of $\mathsf{rcm}$ that will pass
 the commitment check.
@@ -1197,7 +1198,7 @@ choose to attack either):
 * Case $\text{not } \mathsf{use\_qsk}$: The spender must prove knowledge of
   $\mathsf{sk}$, and that $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$
   are derived correctly from $\mathsf{sk}$. This works because the
-  derivations use post-quantum hashes (and $\mathsf{ask} \rightarrow \mathsf{ak}$
+  derivations use post-quantum hashes (and $\mathsf{ask} \mapsto \mathsf{ak}$
   is deterministic). <br>
   In particular, $\mathsf{ivk}$ is an essentially random function of
   $\mathsf{sk}$, and so we expect that an adversary has no better attack
@@ -1306,14 +1307,19 @@ or $\mathsf{SoK^{qk}}$. That is, the adversary can control:
     * $(\mathsf{nk}, \mathsf{ak}, \mathsf{qsk})$, when $\mathsf{use\_qsk} = \mathsf{true}$.
 
 We analyze $\mathsf{DeriveNullifier}$ as a function of these
-controllable inputs. Recall that $\mathsf{DeriveNullifier}$ is defined in
-§ 4.16 ‘Computing ρ values and Nullifiers’ as:
+controllable inputs. Recall that $\mathsf{DeriveNullifier}$ is defined
+in § 4.16 ‘Computing ρ values and Nullifiers’ as:
 
-$$\mathsf{DeriveNullifier_{nk}}(\text{ρ}, \text{ψ}, \mathsf{cm}) = \mathsf{Extract}_{\mathbb{P}}\big(\big[\mathsf{PRF^{nfOrchard}_{nk}}(\text{ρ}) + \text{ψ}) \bmod q_{\mathbb{P}}\big]\, \mathcal{K}^{\mathsf{Orchard}} + \mathsf{cm}\big)$$
+$$\mathsf{DeriveNullifier_{nk}}(\text{ρ}, \text{ψ}, \mathsf{cm}) :=
+    \mathsf{Extract}_{\mathbb{P}}\Big(
+      \big[(\mathsf{PRF^{nf}_{nk}}(\text{ρ}) + \text{ψ}) \bmod q_{\mathbb{P}}\big]\, \mathcal{K}
+      + \mathsf{cm}
+    \Big)$$
 
 Also recall from [Repairing note commitments] that we have
 
-$$\mathsf{cm} = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
+$$\mathsf{cm} = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})
+     + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
 $\text{ψ}$ is determined by $\mathsf{rseed}$. The nullifier corresponding to
 $(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -185,17 +185,32 @@ derivation of $\mathsf{rcm}$ is checked in the Recovery Protocol.
 
 Essentially the same technique also needs to be applied to the
 function $\mathsf{Commit^{ivk}}$ that is used to derive Orchard
-incoming viewing keys. In order to support existing keys, we have
-the Recovery Protocol check the derivations of $\mathsf{nk}$,
-$\mathsf{ak}$, and $\mathsf{rivk}$ from the secret key $\mathsf{sk}$.
+incoming viewing keys. The randomness $\mathsf{rivk}$ in
+$\mathsf{Commit^{ivk}}$ is derived from one of two random oracles,
+depending on which key material the user holds:
 
-Since this derivation of (at least) $\mathsf{ak}$ from $\mathsf{sk}$
-cannot be used in the case of FROST key generation, we also provide an
-alternative way to derive $\mathsf{rivk}$ which is to be used in that
-case. This alternative derivation, using a new "quantum spending key"
-$\mathsf{qsk}$ and "quantum intermediate key" $\mathsf{qk}$, also
-supports more efficient use of hardware wallets in the Recovery Protocol.
-It is described in sections [Usage with FROST] and [Usage with Hardware Wallets].
+* For existing Orchard keys, $\mathsf{rivk\_ext}$ is derived from
+  the secret key $\mathsf{sk}$ via $\mathsf{H^{rivk\_legacy}}(\mathsf{sk})$,
+  with $\mathsf{ak}$ and $\mathsf{nk}$ also derived from $\mathsf{sk}$.
+  The Recovery Protocol checks all three derivations.
+* For keys generated via FROST distributed key generation, or for
+  hardware wallets where exporting $\mathsf{sk}$ is undesirable, an
+  alternative "quantum spending key" $\mathsf{qsk}$ and "quantum
+  intermediate key" $\mathsf{qk}$ are used, with
+  $\mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})$.
+  The Recovery Protocol checks this derivation together with a
+  $\mathsf{SoK^{qsk}}$ proof of knowledge of $\mathsf{qsk}$ such that
+  $\mathsf{H^{qk}}(\mathsf{qsk}) = \mathsf{qk}$.
+
+Both branches are covered uniformly by the
+[Security argument for key binding](#securityargumentforkeybinding):
+each binds the keys $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ — and,
+when in use, $\mathsf{qk}$ — to the incoming-viewing key $\mathsf{ivk}$
+post-quantumly, up to a small advantage against collision-finding in
+the random oracles used for $\mathsf{rivk}$ derivation. The FROST and
+hardware-wallet use cases are described in
+[Usage with FROST](#usagewithfrost) and
+[Usage with hardware wallets](#usagewithhardwarewallets).
 
 ## Flow diagram for the Orchard and OrchardZSA protocols
 
@@ -1335,6 +1350,15 @@ $\begin{array}{l}
 
 where $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}).$
 
+The predicate intentionally does not constrain the $y$-sign of
+$\mathsf{ak}^{\mathbb{P}}$. This is consistent with Orchard's design
+choice to use $\mathsf{ak}$ as a single $\mathbb{F}_{q_{\mathbb{P}}}$
+element (the $x$-coordinate $\mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$),
+which avoids point-decompression in places that consume $\mathsf{ak}$,
+in exchange for a factor-of-2 reduction in concrete binding security.
+Accordingly, the break event below identifies witnesses up to the
+$y$-sign of $\mathsf{ak}^{\mathbb{P}}$.
+
 The flags $\mathsf{use\_qsk}$ and $\mathsf{is\_internal\_rivk}$ that
 appear in the protocol diagram do not appear in this witness — nor in
 the formal Recovery Statement above. Their roles are absorbed into the
@@ -1356,8 +1380,11 @@ $w_2$ with internal $\mathsf{rivk}$), provided both produce the same
 $\mathsf{ivk}$. A flag-based formulation would forbid only same-branch
 breaks.
 
-A **key-binding break** is a pair of distinct witnesses $(w_1, w_2)$ with shared
-$\mathsf{ivk}$ satifying the key-binding condition.
+A **key-binding break** is a pair of witnesses $(w_1, w_2)$ with
+shared $\mathsf{ivk}$ satisfying the key-binding condition, whose
+$(\mathsf{qk}, \mathsf{sk}, \mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$
+projections differ — i.e., $w_1$ and $w_2$ differ in some component
+other than the $y$-sign of $\mathsf{ak}^{\mathbb{P}}$.
 
 The random oracles used in the key-binding condition are $\mathsf{H^{rivk\_ext}}$,
 $\mathsf{H^{rivk\_legacy}}$, $\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, and
@@ -1371,54 +1398,119 @@ key-binding break.
 **Theorem (key-binding, classical ROM).** <a id="thm-key-binding-rom"></a>
 Let $\mathcal{A}$ be a classical adversary making at most $q_{\mathsf{kb}}$
 total queries to the random oracles used in the key-binding condition. Then
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
 
 **Proof sketch.**
+
+*Algebraic setup.*
 $\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk})$ is a Sinsemilla
 short commitment, of the form
 $\mathsf{ShortHash}\big([h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk}] \cdot \mathcal{S}\big)$
 for a Pedersen-like deterministic hash $h$ and a Sinsemilla base
-$\mathcal{S}$. As in the Spendability proof, $h$ does not query
-$\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$, or
-$\mathsf{H^{rivk\_int}}$: it is determined by fixed Sinsemilla bases
-and depends only on $(\mathsf{ak}, \mathsf{nk})$. By the same $y^2 = f(x)$
-argument used in Spendability (using § 5.4.9.7 for the
-$\mathsf{Extract}_{\mathbb{P}}$-style $x$-coordinate convention), a
-key-binding break implies
+$\mathcal{S}$ (TODO: verify the exact form of $h$ and $\mathcal{S}$
+from § 5.4.1.10 'Sinsemilla Commit Function'). Domain separation in
+the protocol's BLAKE2b instantiations ensures $h$ does not query
+$\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$,
+$\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, or $\mathsf{H^{nk}}$:
+$h$ depends only on fixed Sinsemilla bases and on $(\mathsf{ak}, \mathsf{nk})$.
+
+By the same $y^2 = f(x)$ argument used in the Spendability proof
+(using § 5.4.9.7 for the $\mathsf{Extract}_{\mathbb{P}}$-style
+$x$-coordinate convention), a key-binding break implies
 $$h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk} \equiv \pm\big(h(\mathsf{ak}', \mathsf{nk}') + \mathsf{rivk}'\big) \pmod{r_{\mathbb{P}}}.$$
+Define $\mathsf{G}(w) := h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk} \pmod{r_{\mathbb{P}}}$
+for a witness $w$, and let $G_i := \mathsf{G}(w_i)$ for $i \in \{1, 2\}$.
+The break condition is
+$G_1 \equiv \pm G_2 \pmod{r_{\mathbb{P}}}$.
 
-Under the random-oracle modelling, $\mathsf{rivk}$ in each case is a
-fresh, uniform $\mathbb{F}_{r_{\mathbb{P}}}$-valued random-oracle output
-keyed by deterministic inputs:
+*Final-random-oracle structure.*
+For each witness $w_i$ satisfying the key-binding condition,
+$\mathsf{rivk}_i$ is the output of a *final random oracle*
+$O_i \in \{\mathsf{H^{rivk\_ext}}, \mathsf{H^{rivk\_legacy}}, \mathsf{H^{rivk\_int}}\}$
+at a *final input* $x_i$, determined by the witness's branch and
+IVK choice:
 
-* When $\mathsf{qk} \neq \bot$: $\mathsf{rivk\_ext}$ comes from
-  $\mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})$.
-* When $\mathsf{sk} \neq \bot$: $\mathsf{rivk\_ext}$ comes from
-  $\mathsf{H^{rivk\_legacy}}(\mathsf{sk})$.
-* $\mathsf{rivk}$ is either $\mathsf{rivk\_ext}$ (external IVK), or
-* $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})$ (internal IVK).
+* qk-branch, external IVK: $O_i = \mathsf{H^{rivk\_ext}}$,
+  $x_i = (\mathsf{qk}_i, \mathsf{ak}_i, \mathsf{nk}_i)$.
+* sk-branch, external IVK: $O_i = \mathsf{H^{rivk\_legacy}}$,
+  $x_i = \mathsf{sk}_i$.
+* qk-branch, internal IVK: $O_i = \mathsf{H^{rivk\_int}}$,
+  $x_i = (\mathsf{rivk\_ext}_i, \mathsf{ak}_i, \mathsf{nk}_i)$ where
+  $\mathsf{rivk\_ext}_i = \mathsf{H^{rivk\_ext}_{qk_i}}(\mathsf{ak}_i, \mathsf{nk}_i)$.
+* sk-branch, internal IVK: $O_i = \mathsf{H^{rivk\_int}}$,
+  $x_i = (\mathsf{rivk\_ext}_i, \mathsf{ak}_i, \mathsf{nk}_i)$ where
+  $\mathsf{rivk\_ext}_i = \mathsf{H^{rivk\_legacy}}(\mathsf{sk}_i)$.
 
-In every case, the value
-$\mathsf{G}(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk}) := h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk} \pmod{r_{\mathbb{P}}}$
-is a translate of an independent uniform random-oracle output by a
-deterministic shift. For distinct triples, $\mathsf{G}$ outputs are
-each independent and uniform on $\mathbb{F}_{r_{\mathbb{P}}}$.
+In each case
+$G_i = h(\mathsf{ak}_i, \mathsf{nk}_i) + O_i(x_i) \pmod{r_{\mathbb{P}}}$,
+with the deterministic shift $h$ independent of $O_i$'s responses
+(by non-querying).
 
-The break condition $G_1 \equiv \pm G_2 \pmod{r_{\mathbb{P}}}$
-is then a linear constraint on a pair of independent uniform variables,
-satisfied with probability at most $2/r_{\mathbb{P}}$. Taking a union
-bound over the at most ${q_{\mathsf{kb}} \choose 2}$ pairs of distinct
-random-oracle queries and the two sign cases gives
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+*Independence claim per pair.*
+For distinct witnesses $w_1, w_2$ both satisfying the key-binding
+condition, $G_1$ and $G_2$ are independent uniform on
+$\mathbb{F}_{r_{\mathbb{P}}}$, except for a residual event of
+probability at most $1/r_{\mathbb{P}}$ per pair (accounting for
+upstream-RO collisions in the both-internal sub-case). By case on
+$(O_1, O_2)$:
 
-(TODO: verify the exact form of $h$ and $\mathcal{S}$ from § 5.4.1.10
-'Sinsemilla Commit Function'; verify that the $\mathsf{qk} \neq \bot$
-branch pins $\mathsf{qk}$, and that the $\mathsf{sk} \neq \bot$ branch
-pins $(\mathsf{ak}, \mathsf{nk})$, via the random-oracle inputs, so
-that distinct witnesses necessarily correspond to distinct
-random-oracle queries; verify the internal-IVK case's keying does not
-introduce a dependency that breaks the "independent uniform" claim
-above.)
+**$O_1 \neq O_2$.** The two random oracles are domain-separated
+(independent BLAKE2b instantiations), so $O_1$'s outputs are
+independent of $O_2$'s outputs. Each $G_i$ is uniform on
+$\mathbb{F}_{r_{\mathbb{P}}}$ marginally; the pair is independent.
+
+**$O_1 = O_2 \in \{\mathsf{H^{rivk\_ext}}, \mathsf{H^{rivk\_legacy}}\}$.**
+Both witnesses are in the same branch and external IVK. If
+$x_1 = x_2$, the predicate's functional determinations
+($\mathsf{rivk\_ext}_i$ from $x_i$; $\mathsf{rivk}_i = \mathsf{rivk\_ext}_i$;
+$\mathsf{ivk}_i = \mathsf{Commit^{ivk}}(\mathsf{ak}_i, \mathsf{nk}_i, \mathsf{rivk}_i)$;
+in the sk-branch additionally $\mathsf{ak}_i, \mathsf{nk}_i$ from
+$\mathsf{sk}_i$ via $\mathsf{H^{ask}}, \mathsf{H^{nk}}$) force the
+witnesses to coincide on all fields constrained by the key-binding
+condition, contradicting distinctness. Hence WLOG $x_1 \neq x_2$, so
+the two RO outputs at $x_1, x_2$ are independent uniform.
+
+**$O_1 = O_2 = \mathsf{H^{rivk\_int}}$.** Both witnesses are
+internal IVK. If $x_1 = x_2$ as $\mathsf{H^{rivk\_int}}$ inputs, then
+$\mathsf{rivk}_1 = \mathsf{rivk}_2$ and $\mathsf{ivk}_1 = \mathsf{ivk}_2$.
+Sub-cases on the upstream branches:
+
+* same upstream branch (qk×qk or sk×sk):
+  $\mathsf{rivk\_ext}_1 = \mathsf{rivk\_ext}_2$ either forces upstream
+  input coincidence (and hence witness coincidence on all constrained
+  fields, contradicting distinctness) or requires an upstream-RO
+  collision — probability at most $1/r_{\mathbb{P}}$ per pair of
+  upstream queries.
+* cross upstream branch (qk×sk):
+  $\mathsf{rivk\_ext}_1 = \mathsf{rivk\_ext}_2$ requires a cross-RO
+  collision between $\mathsf{H^{rivk\_ext}}$ and
+  $\mathsf{H^{rivk\_legacy}}$, which by domain separation is
+  probability at most $1/r_{\mathbb{P}}$ per pair of upstream queries.
+
+In every sub-case the residual $x_1 = x_2$ event has probability at
+most $1/r_{\mathbb{P}}$ per pair. Conditional on $x_1 \neq x_2$,
+$\mathsf{H^{rivk\_int}}$'s outputs at $x_1, x_2$ are independent
+uniform.
+
+*Bounding the break probability.*
+For any pair of distinct witnesses, the break condition
+$G_1 \equiv \pm G_2 \pmod{r_{\mathbb{P}}}$ holds with probability
+at most $2/r_{\mathbb{P}}$ when $G_1, G_2$ are independent uniform
+(one per sign), plus at most $1/r_{\mathbb{P}}$ residual for
+upstream collisions in the both-internal sub-case — total at most
+$3/r_{\mathbb{P}}$ per pair.
+
+Treating the five rivk-derivation random oracles
+($\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$,
+$\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, $\mathsf{H^{nk}}$) as a
+single combined uniform random oracle on the joint query domain (each
+RO contributes its outputs independently of the others), and
+union-bounding over the at most $\binom{q_{\mathsf{kb}}}{2}$ pairs
+of distinct witnesses,
+$$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3 q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2 r_{\mathbb{P}}}.$$
+
+(TODO: verify the exact form of $h$ and $\mathcal{S}$ from
+§ 5.4.1.10 'Sinsemilla Commit Function'.)
 
 ## Security argument for Spendability
 
@@ -1660,12 +1752,12 @@ $\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mat
 This completes the classical-ROM proof.
 
 The [key-binding theorem](#thm-key-binding-rom) bounds
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
 Substituting, an adversary $\mathcal{A}$ that makes at most
 $q_{\mathsf{rcm}}$ queries to $\mathsf{H^{rcm}}$ and at most
 $q_{\mathsf{kb}}$ queries to the key-binding random oracles
 wins the Spendability-collision game with probability at most
-$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1) \;+\; q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} \;+\; \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
 
 TODO (QROM lift): The reduction is straight-line and does not adaptively
 reprogram $\mathsf{H^{rcm}}$ on inputs the adversary may have queried in

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -32,6 +32,11 @@ $\underline{\mathsf{underlined}}$ variable indicates a byte sequence,
 and a variable suffixed with $\star$ indicates a bit-sequence encoding of
 an elliptic curve point.
 
+For brevity, in the discussion sections of this ZIP we abbreviate
+$\mathsf{H^{rcm,Orchard}}$ as $\mathsf{H^{rcm}}$ (and similarly for other
+Orchard-specific hash function names). The changes to the protocol
+specification and to other ZIPs use the full forms.
+
 The term "Zcash Shielded Assets" or "ZSAs" refers to the extension to
 the Orchard shielded protocol described in ZIPs 226 and 227 [^zip-0226] [^zip-0227].
 
@@ -1018,19 +1023,15 @@ and $\mathsf{nf}$ is the revealed nullifier.
 
 ### Cost
 
-From here on, we abbreviate $\mathsf{H^{rcm,Orchard}}$ to $\mathsf{H^{rcm}}$,
-etc.
-
-Note that in the "$\mathsf{use\_qsk}$" case, one BLAKE2b compression
-is required to compute $\mathsf{rivk\_ext}$ (provided $\ell_{\mathsf{qk}} \leq 504$
-bits, so that the input $\mathsf{qk} \,||\, [\mathtt{0x0D}] \,||\, \mathsf{ak} \,||\, \mathsf{nk}$
-fits in a single 128-byte BLAKE2b block), and in the
-"not $\mathsf{use\_qsk}$" case, three BLAKE2b compressions in total
-are required to compute $\mathsf{H^{ask}}$, $\mathsf{H^{nk}}$, and
-$\mathsf{H^{rivk\_legacy}}$. Since these cases are mutually exclusive,
-it is possible to multiplex the same three compression function instances.
-So, supporting "$\mathsf{use\_qsk}$" in addition to
-"not $\mathsf{use\_qsk}$" costs very little extra.
+Note that in the "$\mathsf{use\_qsk}$" case, one BLAKE2b compression is required
+to compute $\mathsf{rivk\_ext}$ (provided $\ell_{\mathsf{qk}} \leq 504$ bits, so
+that the input $\mathsf{qk} \,||\, [\mathtt{0x0D}] \,||\, \mathsf{ak} \,||\, \mathsf{nk}$
+fits in a single 128-byte BLAKE2b block), and in the "not $\mathsf{use\_qsk}$"
+case, three BLAKE2b compressions in total are required to compute $\mathsf{H^{ask}}$,
+$\mathsf{H^{nk}}$, and $\mathsf{H^{rivk\_legacy}}$. Since these cases are mutually
+exclusive, it is possible to multiplex the same three compression function instances.
+So, supporting "$\mathsf{use\_qsk}$" in addition to "not $\mathsf{use\_qsk}$" costs
+very little extra.
 
 All of the operations below need to be implemented with complete additions,
 even if they are incomplete in the current Orchard[ZSA] statement/circuit.

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -965,18 +965,16 @@ $\begin{array}{rl}
 the prover knows an auxiliary input:
 
 $\begin{array}{rl}
-  \hspace{4em}       ( \mathsf{use\_qsk} \!\!\!\!&{\small ⦂}\; \mathbb{B}, \\
-             \mathsf{is\_internal\_rivk} \!\!\!\!&{\small ⦂}\; \mathbb{B}, \\
-                           \mathsf{path} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{Orchard}}]}, \\
+  \hspace{4em}           ( \mathsf{path} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{Orchard}}]}, \\
                             \mathsf{pos} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,2^{\mathsf{MerkleDepth^{Orchard}}}-1 \}, \\
                                        K \!\!\!\!&{\small ⦂}\; \mathbb{B}^{[\ell_{\mathsf{sk}}]}, \\
                          \mathsf{\alpha} \!\!\!\!&{\small ⦂}\; \mathbb{F}_{r_{\mathbb{P}}}, \\
                 \mathsf{ak}^{\mathbb{P}} \!\!\!\!&{\small ⦂}\; \mathbb{P}^*, \\
                              \mathsf{nk} \!\!\!\!&{\small ⦂}\; \mathbb{F}_{q_{\mathbb{P}}}, \\
-                             \mathsf{qk} \!\!\!\!&{\small ⦂}\; \mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[\ell_{\mathsf{qk}}/8]}, \\
-                   \sigma_{\mathsf{qsk}} \!\!\!\!&{\small ⦂}\; \mathsf{SoK^{qsk}}\big((\mathsf{qk}), \mathsf{SigHash}\big), \\
+                      \mathsf{rivk\_ext} \!\!\!\!&{\small ⦂}\; \mathbb{F}_{r_{\mathbb{P}}}, \\
                            \mathsf{rivk} \!\!\!\!&{\small ⦂}\; \mathbb{F}_{r_{\mathbb{P}}}, \\
-                    \sigma_{\mathsf{sk}} \!\!\!\!&{\small ⦂}\; \mathsf{SoK^{sk}}\big((\mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}), \mathsf{SigHash}\big), \\
+    (\mathsf{qk}, \sigma_{\mathsf{qsk}}) \!\!\!\!&{\small ⦂}\; \big(\mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[\ell_{\mathsf{qk}}/8]} \times \mathsf{SoK^{qsk}}\big((\mathsf{qk}), \mathsf{SigHash}\big)\big) \cup \{(\bot, \bot)\}, \\
+                    \sigma_{\mathsf{sk}} \!\!\!\!&{\small ⦂}\; \mathsf{SoK^{sk}}\big((\mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}), \mathsf{SigHash}\big) \cup \{\bot\}, \\
                           \mathsf{rseed} \!\!\!\!&{\small ⦂}\; \mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[32]}, \\
                             \mathsf{g_d} \!\!\!\!&{\small ⦂}\; \mathbb{P}^*, \\
                               \mathsf{v} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,2^{\ell_{\mathsf{value}}}-1 \}, \\
@@ -986,23 +984,28 @@ $\begin{array}{rl}
 where
 
 $\begin{array}{rll}
-  \hspace{1em}\mathsf{SoK^{qsk}.Statement} \!\!\!\!&=\, \big\{\,\mathsf{qsk} \;{\small ⦂}\; \mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[\ell_{\mathsf{qsk}}/8]} &\!\!\!\!|\;\, \mathsf{qk} = \mathsf{H^{qk}}(\mathsf{qsk})\,\big\} \\
-  \hspace{1em}\mathsf{SoK^{sk}.Statement}  \!\!\!\!&=\, \big\{\,\mathsf{sk} \;{\small ⦂}\; \mathbb{B}^{[\ell_{\mathsf{sk}}]} &\!\!\!\!|\;\, \mathsf{ak}^{\mathbb{P}} = [\mathsf{H^{ask}}(\mathsf{sk})]\, \mathcal{G}^{\mathsf{Orchard}} \\
-                && \;\wedge\; \mathsf{nk} = \mathsf{H^{nk}} \\
-                && \;\wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_legacy}}(\mathsf{sk})\,\big\}
+  \hspace{1em}\mathsf{BindKeys^{sk}}(\mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}) =
+    \big(&\!\!\!\! \mathsf{ak}^{\mathbb{P}} = [\mathsf{H^{ask}}(\mathsf{sk})]\, \mathcal{G}^{\mathsf{Orchard}} \\
+         &\!\!\!\! \wedge\; \mathsf{nk} = \mathsf{H^{nk}}(\mathsf{sk}) \\
+         &\!\!\!\! \wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_legacy}}(\mathsf{sk}) \,\big)
+\end{array}$
+
+and
+
+$\begin{array}{rll}
+  \hspace{1em}\mathsf{SoK^{qsk}.Statement} \!\!\!&=\, \big\{\,\mathsf{qsk} \;{\small ⦂}\; \mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[\ell_{\mathsf{qsk}}/8]} &\!\!\!\!|\;\, \mathsf{qk} = \mathsf{H^{qk}}(\mathsf{qsk}) \,\big\} \\
+  \hspace{1em}\mathsf{SoK^{sk}.Statement}  \!\!\!&=\, \big\{\,\mathsf{sk} \;{\small ⦂}\; \mathbb{B}^{[\ell_{\mathsf{sk}}]} &\!\!\!\!|\;\, \mathsf{BindKeys^{sk}}(\mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}) \,\big\}
 \end{array}$
 
 such that the following conditions hold:
 
 $\begin{array}{l}
-\{\;\, \mathsf{use\_qsk} \Rightarrow \big(\;\, \mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}}) \\
-\hspace{6.7em} \wedge\; \mathsf{SoK^{qsk}.Validate}\big((\mathsf{qk}), \mathsf{SigHash}, \sigma_{\mathsf{qsk}}\big) \\
-\hspace{6.7em} \wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})\,\big) \\
-\wedge\; \text{not } \mathsf{use\_qsk} \Rightarrow \mathsf{SoK^{sk}.Validate}\big((\mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}), \mathsf{SigHash}, \sigma_{\mathsf{sk}}\big) \\
-\wedge\; \mathsf{rivk} = \begin{cases}
-\mathsf{rivk\_ext},&\text{if not } \mathsf{is\_internal\_rivk} \\
-\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}),&\text{if } \mathsf{is\_internal\_rivk} \end{cases} \\
-\wedge\; \mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}) \\
+\{\;\,   \mathsf{rk} = \mathsf{SpendAuthSig^{Orchard}.RandomizePublic}(\alpha, \mathsf{ak}^{\mathbb{P}}) \vphantom{\big(}\\
+\wedge\; \mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}) \vphantom{\Big(}\\
+\wedge\; \big((\mathsf{qk}, \sigma_{\mathsf{qsk}}) = (\bot, \bot)\big) \neq \big(\sigma_{\mathsf{sk}} = \bot\big) \vphantom{\big(}\\
+\wedge\; (\mathsf{qk}, \sigma_{\mathsf{qsk}}) \neq (\bot, \bot) \Rightarrow \big(\, \mathsf{SoK^{qsk}.Validate}\big((\mathsf{qk}), \mathsf{SigHash}, \sigma_{\mathsf{qsk}}\big) \kern0.05em\wedge\, \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})\kern0.05em\big) \vphantom{\Big(}\\
+\wedge\; \sigma_{\mathsf{sk}} \neq \bot \Rightarrow \mathsf{SoK^{sk}.Validate}\big((\mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}), \mathsf{SigHash}, \sigma_{\mathsf{sk}}\big) \vphantom{\big(}\\
+\wedge\; \mathsf{rivk} \in \big\{\, \mathsf{rivk\_ext},\, \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) \,\big\} \vphantom{\Big(}\\
 \wedge\; \text{let } \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \vphantom{\big(}\\
 \wedge\; \mathsf{ivk} \not\in \{0, \bot\} \vphantom{\Big(}\\
 \wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \vphantom{\big(}\\
@@ -1192,10 +1195,10 @@ $\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ivk}$.
 Unfortunately that's not true; $\mathsf{Commit^{ivk}}$ is instantiated by
 $\mathsf{SinsemillaShortCommit}$ which is not post-quantum binding.
 
-There are two cases depending on $\mathsf{use\_qsk}$ (the adversary can
-choose to attack either):
+There are two cases depending on which witness branch the adversary
+uses (they can choose to attack either, or both simultaneously):
 
-* Case $\text{not } \mathsf{use\_qsk}$: The spender must prove knowledge of
+* Case $\mathsf{sk} \neq \bot$: The spender must prove knowledge of
   $\mathsf{sk}$, and that $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$
   are derived correctly from $\mathsf{sk}$. This works because the
   derivations use post-quantum hashes (and $\mathsf{ask} \mapsto \mathsf{ak}$
@@ -1212,10 +1215,11 @@ choose to attack either):
   $T \ll r_{\mathbb{P}}$. This is also infeasible for a quantum adversary
   using a Grover search for reasonable values of $T$.
 
-* Case $\mathsf{use\_qsk}$: This case is almost the same except that
+* Case $\mathsf{qk} \neq \bot$: This case is almost the same except that
   $\mathsf{ivk}$ is now an essentially random function of
   $(\mathsf{nk}, \mathsf{ak}, \mathsf{qk})$. The success probability
-  in terms of $T$ is also the same as for $\text{not } \mathsf{use\_qsk}$.
+  in terms of $T$ is also the same as for the $\mathsf{sk} \neq \bot$
+  case.
 
 The above security argument means that provided we also check the uses of
 $\mathsf{H^{rcm}}$ and $\mathsf{H}^{\text{ψ}}$ in the post-quantum
@@ -1238,8 +1242,8 @@ will need to use complete curve additions to implement Sinsemilla.
 In order to adapt this argument to the quantum setting, we need to consider
 *collapsing* hash functions as defined in [^Unruh2015] [^Unruh2016].
 
-TODO: $\mathsf{Extract}_{\mathbb{P}}$ is not collapsing.
-Is $\mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$ collapsing?
+TODO: does $\mathsf{Extract}_{\mathbb{P}}$ cause any difficulty for lifting
+to QROM?
 
 By the argument in [^Bernstein2009], the best known *generic* quantum
 attack on a hash function is simply the classical attack of [^vOW1999].
@@ -1252,37 +1256,169 @@ output size of 253 bits does not exclude a hash function from being collapsing.
 TODO: discuss [^CBHSU2017] (sponge security), [^Unruh2015] [^Unruh2016]
 (collapse-binding property).
 
-### Informal security argument for binding of ivk
+### Security argument for key binding
 
-The security of Orchard against double-spending also depends on the binding
-property of $\mathsf{Commit^{ivk}}$. Informally, the security argument is
-that there is only one value of $\mathsf{ivk}$ corresponding to a given
-$(\mathsf{g_d}, \mathsf{pk_d})$ (which are committed to by the note
-commitment), and so this binds $\mathsf{nk}$ and $\mathsf{ak}$ to the
-correct values for the committed note.
+The security of Orchard against several attacks depends on cryptographic
+keys being bound to a recoverable note's $\mathsf{ivk}$. Different
+Orchard properties need different components of the key witness pinned:
 
-If the binding property of $\mathsf{Commit^{ivk}}$ fails, then so do
-the security arguments for the Balance and Spend Authorization properties,
-because we can no longer infer that $\mathsf{nk}$ and $\mathsf{ak}$ are the
-correct values.
+* **Nullifier-binding** (used by the Balance argument and by the
+  [Spendability argument](#securityargumentforspendability) below
+  — the latter via the
+  [$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning)):
+  $\mathsf{nk}$ uniquely determined by $\mathsf{ivk}$.
+* **Spend Authorization**: $\mathsf{qk}$ uniquely determined by
+  $\mathsf{ivk}$ when $\mathsf{qk} \neq \bot$ (i.e., when
+  $\mathsf{use\_qsk} = \mathsf{true}$).
 
-There is a complication: contrary to the situation with note commitments,
-addresses may be used over the long term and it may not be feasible or
-desirable to switch to new addresses. Fortunately, the Orchard protocol
-specified each of $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$ to be
-derived from $\mathsf{sk}$ via $\mathsf{PRF^{expand}}$. ($\mathsf{rivk}$
-is derived differently for an "internal IVK", but that is also via
-$\mathsf{PRF^{expand}}$.)
+The formal key-binding condition stated below covers both of these
+uniformly: a key-binding break is a pair of distinct witnesses sharing
+the same $\mathsf{ivk}$, where each witness carries the full key tuple
+— $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ plus whichever of
+$\mathsf{qk}$ or $\mathsf{sk}$ is in use. If key binding fails, the
+Balance, Spendability, and Spend Authorization arguments each lose
+their corresponding pinning step.
 
-We use essentially the same fix as for $\mathsf{NoteCommit^{Orchard}}$,
-with $\mathsf{rivk}$ in place of $\mathsf{rcm}$. We check the derivation
-of all of $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$ from $\mathsf{sk}$.
-Looking carefully at the structure of the derivations relative to the
-ones for $\mathsf{NoteCommit^{Orchard}}$, we can see that $\mathsf{sk}$
-is in a roughly similar position to $\mathsf{rseed}$, and
-$(\mathsf{ak}, \mathsf{nk})$ to $\text{ψ}$. Because these are the only
-inputs to the commitment, the checks are sufficient to ensure they are
-all bound by it.
+Relative to the situation with note commitments where it was reasonable
+to only obtain quantum recoverability for newly output Orchard notes,
+there is a complication. Addresses may be used over the long term and
+it may not be desirable to switch to new addresses, or to avoid funds
+being sent to old ones. Fortunately, the Orchard protocol specified each
+of $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$ to be derived from
+$\mathsf{sk}$ via $\mathsf{PRF^{expand}}$, which is assumed collapsing.
+($\mathsf{rivk}$ is derived differently for an "internal IVK", but that
+is also via $\mathsf{PRF^{expand}}$.)
+
+Classically, the binding of $\mathsf{Commit^{ivk}}$ —instantiated via
+Sinsemilla— fails against a discrete-log-breaking adversary, similarly
+to $\mathsf{NoteCommit}$. We use essentially the same fix as for
+$\mathsf{NoteCommit}$, with the $\mathsf{rivk}$-derivation hashes
+playing the role of $\mathsf{H^{rcm}}$. The Recovery Statement checks
+the derivation of $\mathsf{rivk}$:
+
+* When $\mathsf{qk} \neq \bot$,
+  $\mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})$.
+* When $\mathsf{sk} \neq \bot$,
+  $\mathsf{rivk\_ext} = \mathsf{H^{rivk\_legacy}}(\mathsf{sk})$, with
+  $\mathsf{ak}$ and $\mathsf{nk}$ also derived from $\mathsf{sk}$ via
+  $\mathsf{H^{ask}}$ and $\mathsf{H^{nk}}$.
+
+Exactly one of $\mathsf{qk}$ and $\mathsf{sk}$ is non-$\bot$ per
+witness; this is equivalent to case-splitting by $\mathsf{use\_qsk}$.
+
+In either case, $\mathsf{rivk}$ is then either $\mathsf{rivk\_ext}$
+directly (external IVK) or
+$\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})$ (internal
+IVK). All of these hashes are modelled as independent random oracles for
+the key-binding argument.
+
+As in the [Recovery Statement](#proposedrecoverystatement), we have:
+
+$\begin{array}{rll}
+  \hspace{1em}\mathsf{BindKeys^{sk}}(\mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}) =
+    \big(&\!\!\!\! \mathsf{ak}^{\mathbb{P}} = [\mathsf{H^{ask}}(\mathsf{sk})]\, \mathcal{G}^{\mathsf{Orchard}} \\
+         &\!\!\!\! \wedge\; \mathsf{nk} = \mathsf{H^{nk}}(\mathsf{sk}) \\
+         &\!\!\!\! \wedge\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_legacy}}(\mathsf{sk}) \,\big)
+\end{array}$
+
+Let the key-binding condition on a witness
+$w = (\mathsf{ivk}, \mathsf{qk}, \mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}, \mathsf{rivk})$ be:
+
+$\begin{array}{l}
+\;\;\;   (\mathsf{sk} = \bot) \neq (\mathsf{qk} = \bot) \\
+\wedge\; \mathsf{qk} \neq \bot \Rightarrow \big(\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk}) \,\big) \\
+\wedge\; \mathsf{sk} \neq \bot \Rightarrow \mathsf{BindKeys^{sk}}(\mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}) \\
+\wedge\; \mathsf{rivk} \in \big\{\, \mathsf{rivk\_ext},\, \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) \,\big\} \\
+\wedge\; \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \\
+\wedge\; \mathsf{ivk} \not\in \{0, \bot\}
+\end{array}$
+
+where $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}}).$
+
+The flags $\mathsf{use\_qsk}$ and $\mathsf{is\_internal\_rivk}$ that
+appear in the protocol diagram do not appear in this witness — nor in
+the formal Recovery Statement above. Their roles are absorbed into the
+witness's structural form:
+
+* $\mathsf{use\_qsk}$ is encoded in
+  $(\mathsf{sk} = \bot) \neq (\mathsf{qk} = \bot)$: exactly one of
+  $\mathsf{sk}$ and $\mathsf{qk}$ is non-$\bot$, and the branch-specific
+  constraints apply to whichever is present.
+* $\mathsf{is\_internal\_rivk}$ is encoded in
+  $\mathsf{rivk} \in \big\{\mathsf{rivk\_ext},\, \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})\big\}$:
+  both $\mathsf{rivk}$ derivations are admitted simultaneously.
+
+This formulation is strictly stronger than a flag-conditioned one: a
+key-binding break can have $w_1$ and $w_2$ in different branches across
+either flag (e.g., $w_1$ with $\mathsf{qk} \neq \bot$ and $w_2$ with
+$\mathsf{sk} \neq \bot$, or $w_1$ with external $\mathsf{rivk}$ and
+$w_2$ with internal $\mathsf{rivk}$), provided both produce the same
+$\mathsf{ivk}$. A flag-based formulation would forbid only same-branch
+breaks.
+
+A **key-binding break** is a pair of distinct witnesses $(w_1, w_2)$ with shared
+$\mathsf{ivk}$ satifying the key-binding condition.
+
+The random oracles used in the key-binding condition are $\mathsf{H^{rivk\_ext}}$,
+$\mathsf{H^{rivk\_legacy}}$, $\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, and
+$\mathsf{H^{nk}}$.
+
+Let $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$
+be the probability, over $\mathcal{A}$'s randomness and at most $q_{\mathsf{kb}}$
+queries in total to these random oracles, that $\mathcal{A}$ outputs a
+key-binding break.
+
+**Theorem (key-binding, classical ROM).** <a id="thm-key-binding-rom"></a>
+Let $\mathcal{A}$ be a classical adversary making at most $q_{\mathsf{kb}}$
+total queries to the random oracles used in the key-binding condition. Then
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+
+**Proof sketch.**
+$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk})$ is a Sinsemilla
+short commitment, of the form
+$\mathsf{ShortHash}\big([h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk}] \cdot \mathcal{S}\big)$
+for a Pedersen-like deterministic hash $h$ and a Sinsemilla base
+$\mathcal{S}$. As in the Spendability proof, $h$ does not query
+$\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$, or
+$\mathsf{H^{rivk\_int}}$: it is determined by fixed Sinsemilla bases
+and depends only on $(\mathsf{ak}, \mathsf{nk})$. By the same $y^2 = f(x)$
+argument used in Spendability (using § 5.4.9.7 for the
+$\mathsf{Extract}_{\mathbb{P}}$-style $x$-coordinate convention), a
+key-binding break implies
+$$h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk} \equiv \pm\big(h(\mathsf{ak}', \mathsf{nk}') + \mathsf{rivk}'\big) \pmod{r_{\mathbb{P}}}.$$
+
+Under the random-oracle modelling, $\mathsf{rivk}$ in each case is a
+fresh, uniform $\mathbb{F}_{r_{\mathbb{P}}}$-valued random-oracle output
+keyed by deterministic inputs:
+
+* When $\mathsf{qk} \neq \bot$: $\mathsf{rivk\_ext}$ comes from
+  $\mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})$.
+* When $\mathsf{sk} \neq \bot$: $\mathsf{rivk\_ext}$ comes from
+  $\mathsf{H^{rivk\_legacy}}(\mathsf{sk})$.
+* $\mathsf{rivk}$ is either $\mathsf{rivk\_ext}$ (external IVK), or
+* $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})$ (internal IVK).
+
+In every case, the value
+$\mathsf{G}(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk}) := h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk} \pmod{r_{\mathbb{P}}}$
+is a translate of an independent uniform random-oracle output by a
+deterministic shift. For distinct triples, $\mathsf{G}$ outputs are
+each independent and uniform on $\mathbb{F}_{r_{\mathbb{P}}}$.
+
+The break condition $G_1 \equiv \pm G_2 \pmod{r_{\mathbb{P}}}$
+is then a linear constraint on a pair of independent uniform variables,
+satisfied with probability at most $2/r_{\mathbb{P}}$. Taking a union
+bound over the at most ${q_{\mathsf{kb}} \choose 2}$ pairs of distinct
+random-oracle queries and the two sign cases gives
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+
+(TODO: verify the exact form of $h$ and $\mathcal{S}$ from § 5.4.1.10
+'Sinsemilla Commit Function'; verify that the $\mathsf{qk} \neq \bot$
+branch pins $\mathsf{qk}$, and that the $\mathsf{sk} \neq \bot$ branch
+pins $(\mathsf{ak}, \mathsf{nk})$, via the random-oracle inputs, so
+that distinct witnesses necessarily correspond to distinct
+random-oracle queries; verify the internal-IVK case's keying does not
+introduce a dependency that breaks the "independent uniform" claim
+above.)
 
 ## Security argument for Spendability
 
@@ -1300,11 +1436,12 @@ involved.
 Since each function in the Recovery Statement is deterministic, the
 free variables that the adversary can control are the sources of the
 derivation digraph within that statement and either $\mathsf{SoK^{sk}}$
-or $\mathsf{SoK^{qk}}$. That is, the adversary can control:
-
-* $(\text{ρ}, \mathsf{g_d}, \mathsf{rseed}, \mathsf{is\_internal\_rivk}, \mathsf{use\_qsk})$ and
-    * $\mathsf{sk}$, when $\mathsf{use\_qsk} = \mathsf{false}$;
-    * $(\mathsf{nk}, \mathsf{ak}, \mathsf{qsk})$, when $\mathsf{use\_qsk} = \mathsf{true}$.
+or $\mathsf{SoK^{qk}}$. That is, the adversary can control all of
+$$(\text{ρ}, \mathsf{g_d}, \mathsf{rseed}, \mathsf{sk}, \mathsf{nk}, \mathsf{ak}, \mathsf{qk}, \mathsf{qsk}, \mathsf{rivk})$$
+subject to $(\mathsf{sk} = \bot) \neq (\mathsf{qk} = \bot)$. The
+choice between external and internal IVK is encoded in
+$\mathsf{rivk}$'s value (either $\mathsf{rivk\_ext}$ or
+$\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})$).
 
 We analyze $\mathsf{DeriveNullifier}$ as a function of these
 controllable inputs. Recall that $\mathsf{DeriveNullifier}$ is defined
@@ -1321,45 +1458,99 @@ Also recall from [Repairing note commitments] that we have
 $$\mathsf{cm} = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})
      + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
-$\text{ψ}$ is determined by $\mathsf{rseed}$. The nullifier corresponding to
+Let $K_{\kern-.08em\mathcal{R}}$ denote the discrete logarithm of
+$\mathcal{K}$ with respect to $\mathcal{R}$. This is well-defined and
+nonzero: $\mathcal{R}$ generates the prime-order Pallas group, so any
+non-identity Pallas point has a unique nonzero discrete logarithm with
+respect to it; and $\mathcal{K}$ is non-identity by construction.
+
+Recall that $\text{ψ}$ is determined by $\mathsf{rseed}$ via
+$\text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{rseed}}(\text{ρ})$.
+The nullifier corresponding to
 $(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
 is then
-$$\mathsf{Extract}_{\mathbb{P}}\big([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}) + g(\mathsf{nk}, \text{ρ}, \mathsf{rseed})]\, \mathcal{R}\big)$$
+$$\mathsf{Extract}_{\mathbb{P}}\Big(
+    \big[
+      \big((\mathsf{PRF^{nf}_{nk}}(\text{ρ}) + \text{ψ}) \bmod q_{\mathbb{P}}\big) \cdot K_{\kern-.08em\mathcal{R}}
+      + \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})
+    \big]\, \mathcal{R}
+  \Big).$$
 
-for some $g$ depending on the discrete logarithm of $\mathcal{K}^{\mathsf{Orchard}}$ wrt $\mathcal{R}$.
+We model $\mathsf{H^{rcm}}$ as a random oracle with output uniform on
+$\mathbb{F}_{r_{\mathbb{P}}}$. The functions $\mathsf{f}$,
+$\mathsf{H}^{\text{ψ}}$, and $\mathsf{PRF^{nf}}$ are deterministic
+functions of $\mathsf{notetuple}$ that **do not query $\mathsf{H^{rcm}}$**:
+$\mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ is the
+Sinsemilla-base lift; $\mathsf{H}^{\text{ψ}}$ and $\mathsf{PRF^{nf}}$ are
+conventional hash functions.
 
-We give a reduction-based argument that any classical adversary in the
-Random Oracle Model who finds two valid Recovery Statement witnesses for
-distinct underlying notes with colliding nullifiers, succeeds with
-probability bounded by $q(q-1)/r_{\mathbb{P}}$, where $q$ is the number
-of $\mathsf{H^{rcm}}$ queries the adversary makes. The bound depends only
-on the query count, not on running time, and applies to any adversary
-regardless of attack strategy.
+> The non-querying constraint rules out trivializing instantiations such
+> as $\mathsf{f}({\small •}) = -\mathsf{H^{rcm}}({\small •})$.
+> In the concrete protocol, it reflects that $\mathsf{f}$ depends only on
+> fixed Sinsemilla bases; and that the hashes $\mathsf{H}^{\text{ψ}}$,
+> $\mathsf{PRF^{nf}}$, and $\mathsf{H^{rcm}}$ use distinct domain
+> separators, so can be considered unrelated to each other.
 
-We model $\mathsf{H^{rcm}}$ as a random oracle with output uniform
-on $\mathbb{F}_{r_{\mathbb{P}}}$. The functions $f$ and $g$ are deterministic
-functions of their inputs — a structural property of the algebraic
-decomposition derived above. $f$ depends on
-$(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ via the Sinsemilla
-bases $\mathcal{C}_j = [c_j]\, \mathcal{R}$; $g$ depends on
-$(\mathsf{nk}, \text{ρ}, \mathsf{rseed})$ via $\mathsf{PRF^{nfOrchard}}$,
-$\mathsf{H}^{\text{ψ}}$, and the discrete logarithm of
-$\mathcal{K}^{\mathsf{Orchard}}$ wrt $\mathcal{R}$. Neither is modelled as
-a random oracle.
+A key-binding break is as defined above in the
+[Security argument for key binding](#securityargumentforkeybinding).
 
-We are *not* assuming $\mathsf{Commit^{ivk}}$ is binding, nor that any
-of the key-derivation hashes are collision-resistant. The argument here
-covers only $\mathsf{NoteCommit}$ binding — it argues that $\mathsf{nf}$
+Let $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$
+be the probability, over $\mathcal{A}$'s randomness and at most
+$q_{\mathsf{kb}}$ queries to the random oracles used in the
+key-binding argument, that $\mathcal{A}$ outputs a key-binding break.
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$ is
+bounded separately by that argument; the bound below is unconditional,
+but is only useful to the extent that
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$ is
+small.
+
+We give a reduction-based argument that any classical adversary
+$\mathcal{A}$ in the Random Oracle Model attempting to find two valid
+[Recovery Statement](#proposedrecoverystatement) witnesses for distinct
+underlying notes that have colliding nullifiers, succeeds with probability at most
+$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$,
+where $q_{\mathsf{rcm}}$ is the number of queries $\mathcal{A}$ makes
+to $\mathsf{H^{rcm}}$, and $q_{\mathsf{kb}}$ is as defined above.
+The bound depends only on $q_{\mathsf{rcm}}$ and on
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$,
+not on running time.
+
+The components $\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}$
+are fields of $\mathsf{notetuple}$ by definition; and $\text{ρ}$,
+$\mathsf{g_d}$, $\mathsf{pk_d}$, and $\text{ψ}$ are fields of
+$\mathsf{noterepr}$, hence of $\mathsf{notetuple}$.
+
+**$\mathsf{ivk}$-pinning lemma.** <a id="lemma-ivk-pinning"></a>
+For any valid Recovery Statement witness $w$ with
+$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$,
+the value $\mathsf{ivk} = \log_{\mathsf{g_d}}(\mathsf{pk_d})$ is
+well-defined, since $\mathsf{g_d} \neq \mathcal{O}_{\mathbb{P}}$ on the
+prime-order Pallas curve and
+$\mathsf{ivk} \in [0, q_{\mathbb{P}}) \subseteq [0, r_{\mathbb{P}})$;
+$\mathsf{ivk}$ is therefore uniquely determined by $\mathsf{notetuple}$.
+
+**$\mathsf{PRF^{nf}}$-pinning lemma.** <a id="lemma-prf-nf-pinning"></a>
+Suppose $\mathcal{A}$'s output $(w_1, w_2)$ does not contain a
+key-binding break. Then for each $i \in \{1, 2\}$,
+$\mathsf{PRF^{nf}_{\mathsf{nk}_i}}(\text{ρ}_i)$ is uniquely determined
+by $\mathsf{notetuple}_i$: by the conditioning,
+$(\mathsf{ak}_i, \mathsf{nk}_i, \mathsf{rivk}_i)$ is the only opening of
+$\mathsf{ivk}_i$ appearing in $\mathcal{A}$'s output, so $\mathsf{nk}_i$
+is a function of $\mathsf{ivk}_i$, which is in turn a function of
+$\mathsf{notetuple}_i$ by the $\mathsf{ivk}$-pinning lemma; and
+$\text{ρ}_i$ is a field of $\mathsf{notetuple}_i$.
+
+The argument here covers nullifier-binding — it argues that $\mathsf{nf}$
 binds the underlying note ($\mathsf{noterepr}$, plus $\mathsf{rseed}$ and
-$\mathsf{leadByte}$) under $\mathsf{H^{rcm}}$-as-random-oracle
-alone.
+$\mathsf{leadByte}$) under $\mathsf{H^{rcm}}$ modelled as a random oracle
+and the [key-binding theorem](#thm-key-binding-rom).
 
 **Theorem (distinct-note Spendability, classical ROM).** <a id="thm-spendability"></a>
 Let $\mathcal{A}$ be a classical adversary with oracle access to
-$\mathsf{H^{rcm}}$ modelled as a random oracle with output uniform on
-$\mathbb{F}_{r_{\mathbb{P}}}$, making at most $q$ oracle queries. The
-*Spendability-collision* game has $\mathcal{A}$ output two Recovery
-Statement witnesses $\mathsf{w}_1, \mathsf{w}_2$ satisfying:
+$\mathsf{H^{rcm}}$ having output uniform on $\mathbb{F}_{r_{\mathbb{P}}}$,
+making at most $q_{\mathsf{rcm}}$ oracle queries. The *Spendability-collision*
+game has $\mathcal{A}$ output two Recovery Statement witnesses $w_1, w_2$
+satisfying:
 
 <a id="thm-spendability-validity"></a>**Validity of witnesses**
 :   both witnesses satisfy the
@@ -1367,47 +1558,121 @@ Statement witnesses $\mathsf{w}_1, \mathsf{w}_2$ satisfying:
 
 <a id="thm-spendability-distinct"></a>**Distinct underlying notes**
 :   the $\mathsf{H^{rcm}}$-input tuples
-    $r_i := (\mathsf{rseed}_i, \mathsf{leadByte}_i, \mathsf{noterepr}_i)$
-    satisfy $r_1 \neq r_2$.
+    $\mathsf{notetuple}_i := (\mathsf{rseed}_i, \mathsf{leadByte}_i, \mathsf{noterepr}_i)$
+    satisfy $\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$.
 
 <a id="thm-spendability-collide"></a>**Colliding nullifiers**
 :   $\mathsf{nf}_1 = \mathsf{nf}_2$.
 
 Then $\mathcal{A}$ wins this game with probability at most
-$\binom{q}{2} \cdot 2/r_{\mathbb{P}} = q(q-1)/r_{\mathbb{P}}$, taken over
-the random oracle's responses and any internal randomness of $\mathcal{A}$.
+$$\Big({\textstyle{q_{\mathsf{rcm}}} \atop \textstyle{2}}\Big) \cdot \frac{2}{r_{\mathbb{P}}}
+    + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})
+  = \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}),$$
+taken over the random oracle's responses and any internal randomness of
+$\mathcal{A}$.
 
-For the Pallas curve we have $r_{\mathbb{P}} \approx 2^{254}$, so any
-adversary making at most $q \le 2^{80}$ random-oracle queries wins with
-probability at most approximately $2^{-94}$.
+This bound is essentially tight against classical generic adversaries.
+Maurer [^Maurer2002] (Section 2, p. 5) establishes a matching upper
+bound of ${k \choose 2}/N$ on the success probability of any
+classical algorithm in finding a collision against a random oracle with
+an $N$-element output space using $k$ queries. Maurer's bound applies
+to the *equality* event $F_i = F_j$; our win condition allows
+$F_i = \pm F_j$ (two winning configurations per pair instead of one).
+Applying Maurer with $N = r_{\mathbb{P}}$ (the $\mathsf{H^{rcm}}$
+output space) gives ${q_{\mathsf{rcm}} \choose 2}/r_{\mathbb{P}}$ for
+the equality event; doubling for the sign relaxation gives our
+$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}}$ bound.
+Classical parallel collision search [^Bernstein2009] (top of p. 8)
+achieves the equality-event regime up to a constant factor; the same
+adversaries achieve a constant fraction of the doubled bound for the
+$\pm$-equivalence event.
 
 **Reduction.** We construct a simulated environment in which
-$\mathsf{H^{rcm}}$ is replaced by a lazily-sampled random oracle.
-The simulation maintains a table
-$T : \mathsf{H^{rcm}}\text{-input} \to \mathbb{F}_{r_{\mathbb{P}}}$,
-initially empty. On each query
-$r = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ from
-$\mathcal{A}$, the simulation returns $T[r]$ if defined, or otherwise
-samples a fresh $h \leftarrow \mathbb{F}_{r_{\mathbb{P}}}$, records
-$T[r] := h$, and returns $h$. After at most $q$ such queries,
-$\mathcal{A}$ outputs $(\mathsf{w}_1, \mathsf{w}_2)$ satisfying
-[(validity)](#thm-spendability-validity),
-[(distinct underlying notes)](#thm-spendability-distinct), and
-[(colliding nullifiers)](#thm-spendability-collide).
+$\mathsf{H^{rcm}}$ is replaced by a lazily-sampled random oracle. The
+simulation maintains a table
+$T : \mathsf{NoteTuple} \to \mathbb{F}_{r_{\mathbb{P}}}$, initially empty.
+On each query $\mathsf{notetuple}$ from $\mathcal{A}$, the simulation
+returns $T[\mathsf{notetuple}]$ if defined, or otherwise samples a fresh
+$h \leftarrow \mathbb{F}_{r_{\mathbb{P}}}$, records
+$T[\mathsf{notetuple}] := h$, and returns $h$. After at most $q$ such
+queries, $\mathcal{A}$ outputs $(w_1, w_2)$ satisfying
+[**Validity of witnesses**](#thm-spendability-validity),
+[**Distinct underlying notes**](#thm-spendability-distinct), and
+[**Colliding nullifiers**](#thm-spendability-collide).
 
-The collision $\mathsf{nf}_1 = \mathsf{nf}_2$ implies that
-$[H_1 + f_1 + g_1]\, \mathcal{R}$ and $[H_2 + f_2 + g_2]\, \mathcal{R}$
-share an $x$-coordinate, hence are either equal or each other's
-negation:
+$\mathsf{rseed}_i$, $\mathsf{leadByte}_i$, $\mathsf{noterepr}_i$,
+$\text{ρ}_i$, $\text{ψ}_i$ are fields of $\mathsf{notetuple}_i$
+(directly or via $\mathsf{noterepr}_i$). The probability that
+$(w_1, w_2)$ contains a key-binding break is at most
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$; for the rest
+of the analysis we condition on the complement.
 
-$$H_1 + f_1 + g_1 \equiv \pm(H_2 + f_2 + g_2) \pmod{r_{\mathbb{P}}},$$
+Under this conditioning, define
+$$\mathsf{F}(\mathsf{notetuple}) := \mathsf{H^{rcm}}(\mathsf{notetuple}) +
+\mathsf{f}(\mathsf{notetuple}) + \big((\mathsf{PRF^{nf}_{nk}}(\text{ρ}) +
+\text{ψ}) \bmod q_{\mathbb{P}}\big) \cdot K_{\kern-.08em\mathcal{R}}
+\pmod{r_{\mathbb{P}}},$$
 
-where $H_i := \mathsf{H^{rcm}}(r_i)$. By
-[(distinct underlying notes)](#thm-spendability-distinct) we have
-$r_1 \neq r_2$, so $T[r_1]$ and $T[r_2]$ are sampled independently and
-uniformly from $\mathbb{F}_{r_{\mathbb{P}}}$.
+where $\mathsf{rseed}, \text{ρ}, \text{ψ}$ are fields of
+$\mathsf{notetuple}$ and $\mathsf{PRF^{nf}_{nk}}(\text{ρ})$ is
+determined by $\mathsf{notetuple}$ via the
+[$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning).
 
-TODO: Probability bound (step 5) and QROM follow-up (step 6) go here.
+The collision $\mathsf{nf}_1 = \mathsf{nf}_2$ holds iff
+$$\mathsf{Extract}_{\mathbb{P}}\big([\mathsf{F}(\mathsf{notetuple}_1)]\, \mathcal{R}\big)
+= \mathsf{Extract}_{\mathbb{P}}\big([\mathsf{F}(\mathsf{notetuple}_2)]\, \mathcal{R}\big).$$
+$\mathsf{Extract}_{\mathbb{P}}$ is defined in § 5.4.9.7 'Coordinate Extractor
+for Pallas' [^protocol-concreteextractorpallas] as the $x$-coordinate of its
+argument for non-identity points, with the identity mapping to 0. Since Pallas is
+a short-Weierstrass curve and no Pallas point has $x$-coordinate 0, two Pallas
+points have equal $\mathsf{Extract}_{\mathbb{P}}$ values iff they are equal or
+each other's negation:
+$$\mathsf{F}(\mathsf{notetuple}_1) \equiv \pm \mathsf{F}(\mathsf{notetuple}_2) \pmod{r_{\mathbb{P}}}.$$
+
+By [**Distinct underlying notes**](#thm-spendability-distinct),
+$\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$, so $T[\mathsf{notetuple}_1]$ and
+$T[\mathsf{notetuple}_2]$ are sampled independently and uniformly from
+$\mathbb{F}_{r_{\mathbb{P}}}$. The remaining terms in $\mathsf{F}(\mathsf{notetuple})$
+($\mathsf{f}$ and the $\mathsf{PRF^{nf}}$ contribution scaled by
+$K_{\kern-.08em\mathcal{R}}$) are deterministic functions of $\mathsf{notetuple}$
+that do not query $\mathsf{H^{rcm}}$.
+Since the non-querying constraint makes the deterministic shifts
+independent of the $\mathsf{H^{rcm}}$ oracle's responses, and
+$T[\mathsf{notetuple}_1]$, $T[\mathsf{notetuple}_2]$ are independently
+uniform on $\mathbb{F}_{r_{\mathbb{P}}}$,
+$\mathsf{F}(\mathsf{notetuple}_1)$ and $\mathsf{F}(\mathsf{notetuple}_2)$
+are each independent and uniform on $\mathbb{F}_{r_{\mathbb{P}}}$.
+
+The win condition $F_1 \equiv \pm F_2$ is then a linear constraint on a
+pair of independent uniform variables, satisfied with probability at most
+$2/r_{\mathbb{P}}$ (each sign contributes $1/r_{\mathbb{P}}$).
+
+Taking a union bound over the at most ${q_{\mathsf{rcm}} \choose 2}$ pairs of
+distinct $\mathsf{H^{rcm}}$ queries and the two sign cases gives
+a winning probability, conditional on $(w_1, w_2)$ not constituting
+a key-binding break, of at most
+${q_{\mathsf{rcm}} \choose 2} \cdot \frac{2}{r_{\mathbb{P}}} = \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}}$.
+Decomposing on whether such a break occurs (probability at most
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$) and applying
+$\Pr[\text{win}] \leq \Pr[\text{win} \mid \neg\,\text{break}] + \Pr[\text{break}]$
+gives the theorem's overall claim of
+$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$.
+This completes the classical-ROM proof.
+
+The [key-binding theorem](#thm-key-binding-rom) bounds
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+Substituting, an adversary $\mathcal{A}$ that makes at most
+$q_{\mathsf{rcm}}$ queries to $\mathsf{H^{rcm}}$ and at most
+$q_{\mathsf{kb}}$ queries to the key-binding random oracles
+wins the Spendability-collision game with probability at most
+$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1) \;+\; q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
+
+TODO (QROM lift): The reduction is straight-line and does not adaptively
+reprogram $\mathsf{H^{rcm}}$ on inputs the adversary may have queried in
+superposition, so we expect a clean lift to the quantum random-oracle
+model via standard QROM techniques [^Unruh2015] [^Unruh2016] [^CMSZ2021]
+[^CDDGS2025], with at most a small loss factor. The technical conditions
+have not yet been verified.
 
 ## Effects of discrete-log-breaking attacks before the switch to the Recovery Protocol
 
@@ -1501,6 +1766,8 @@ manipulate the note selection algorithm to some extent.
 
 [^protocol-concretespendauthsig]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 5.4.7.1: Spend Authorization Signature (Sapling and Orchard)](protocol/protocol.pdf#concretespendauthsig)
 
+[^protocol-concreteextractorpallas]: [Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 5.4.9.7: Coordinate Extractor for Pallas](protocol/protocol.pdf#concreteextractorpallas)
+
 [^zip-0032-sapling-child-key-derivation]: [ZIP 32: Shielded Hierarchical Deterministic Wallets — Sapling child key derivation](zip-0032.rst#sapling-child-key-derivation)
 
 [^zip-0032-sapling-internal-key-derivation]: [ZIP 32: Shielded Hierarchical Deterministic Wallets — Sapling internal key derivation](zip-0032.rst#sapling-internal-key-derivation)
@@ -1538,6 +1805,8 @@ manipulate the note selection algorithm to some extent.
 [^vOW1999]: [Parallel collision search with cryptanalytic applications. Paul C. van Oorschot and Michael Wiener.](https://link.springer.com/article/10.1007/PL00003816)
 
 [^Bernstein2009]: [Cost analysis of hash collisions: Will quantum computers make SHARCS obsolete? Daniel J. Bernstein.](https://cr.yp.to/hash/collisioncost-20090517.pdf)
+
+[^Maurer2002]: [Indistinguishability of Random Systems. Ueli Maurer.](https://crypto.ethz.ch/publications/files/Maurer02.pdf) Advances in Cryptology — EUROCRYPT 2002, LNCS vol. 2332, pp. 110–132.
 
 [^Unruh2015]: [Computationally binding quantum commitments. Dominique Unruh.](https://eprint.iacr.org/2015/361)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1679,76 +1679,55 @@ achieves the equality-event regime up to a constant factor; the same
 adversaries achieve a constant fraction of the doubled bound for the
 $\pm$-equivalence event.
 
-**Reduction.** We construct a simulated environment in which
-$\mathsf{H^{rcm}}$ is replaced by a lazily-sampled random oracle. The
-simulation maintains a table
-$T : \mathsf{NoteTuple} \to \mathbb{F}_{r_{\mathbb{P}}}$, initially empty.
-On each query $\mathsf{notetuple}$ from $\mathcal{A}$, the simulation
-returns $T[\mathsf{notetuple}]$ if defined, or otherwise samples a fresh
-$h \leftarrow \mathbb{F}_{r_{\mathbb{P}}}$, records
-$T[\mathsf{notetuple}] := h$, and returns $h$. After at most $q$ such
-queries, $\mathcal{A}$ outputs $(w_1, w_2)$ satisfying
+**Proof sketch.**
+$\mathcal{A}$ makes at most $q_{\mathsf{rcm}}$ queries to
+$\mathsf{H^{rcm}}$ before outputting $(w_1, w_2)$ satisfying
 [**Validity of witnesses**](#thm-spendability-validity),
 [**Distinct underlying notes**](#thm-spendability-distinct), and
-[**Colliding nullifiers**](#thm-spendability-collide).
+[**Colliding nullifiers**](#thm-spendability-collide). The probability
+that $(w_1, w_2)$ contains a key-binding break is at most
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$; condition on
+the complement.
 
-$\mathsf{rseed}_i$, $\mathsf{leadByte}_i$, $\mathsf{noterepr}_i$,
-$\text{ρ}_i$, $\text{ψ}_i$ are fields of $\mathsf{notetuple}_i$
-(directly or via $\mathsf{noterepr}_i$). The probability that
-$(w_1, w_2)$ contains a key-binding break is at most
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$; for the rest
-of the analysis we condition on the complement.
-
+*Algebraic setup.*
 Under this conditioning, define
 $$\mathsf{F}(\mathsf{notetuple}) := \mathsf{H^{rcm}}(\mathsf{notetuple}) +
 \mathsf{f}(\mathsf{notetuple}) + \big((\mathsf{PRF^{nf}_{nk}}(\text{ρ}) +
 \text{ψ}) \bmod q_{\mathbb{P}}\big) \cdot K_{\kern-.08em\mathcal{R}}
 \pmod{r_{\mathbb{P}}},$$
-
 where $\mathsf{rseed}, \text{ρ}, \text{ψ}$ are fields of
 $\mathsf{notetuple}$ and $\mathsf{PRF^{nf}_{nk}}(\text{ρ})$ is
 determined by $\mathsf{notetuple}$ via the
-[$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning).
+[$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning), and let
+$F_i := \mathsf{F}(\mathsf{notetuple}_i)$ for $i \in \{1, 2\}$.
 
-The collision $\mathsf{nf}_1 = \mathsf{nf}_2$ holds iff
-$$\mathsf{Extract}_{\mathbb{P}}\big([\mathsf{F}(\mathsf{notetuple}_1)]\, \mathcal{R}\big)
-= \mathsf{Extract}_{\mathbb{P}}\big([\mathsf{F}(\mathsf{notetuple}_2)]\, \mathcal{R}\big).$$
-$\mathsf{Extract}_{\mathbb{P}}$ is defined in § 5.4.9.7 'Coordinate Extractor
-for Pallas' [^protocol-concreteextractorpallas] as the $x$-coordinate of its
-argument for non-identity points, with the identity mapping to 0. Since Pallas is
-a short-Weierstrass curve and no Pallas point has $x$-coordinate 0, two Pallas
-points have equal $\mathsf{Extract}_{\mathbb{P}}$ values iff they are equal or
-each other's negation:
-$$\mathsf{F}(\mathsf{notetuple}_1) \equiv \pm \mathsf{F}(\mathsf{notetuple}_2) \pmod{r_{\mathbb{P}}}.$$
+$\mathsf{Extract}_{\mathbb{P}}$ (§ 5.4.9.7 'Coordinate Extractor for
+Pallas' [^protocol-concreteextractorpallas]) is the $x$-coordinate of
+its argument for non-identity points, with the identity mapping to $0$.
+Since Pallas has the form $y^2 = f(x)$ and no Pallas point has
+$x$-coordinate $0$, the collision $\mathsf{nf}_1 = \mathsf{nf}_2$
+holds iff $F_1 \equiv \pm F_2 \pmod{r_{\mathbb{P}}}$.
 
+*Independence claim per pair.*
 By [**Distinct underlying notes**](#thm-spendability-distinct),
-$\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$, so $T[\mathsf{notetuple}_1]$ and
-$T[\mathsf{notetuple}_2]$ are sampled independently and uniformly from
-$\mathbb{F}_{r_{\mathbb{P}}}$. The remaining terms in $\mathsf{F}(\mathsf{notetuple})$
-($\mathsf{f}$ and the $\mathsf{PRF^{nf}}$ contribution scaled by
-$K_{\kern-.08em\mathcal{R}}$) are deterministic functions of $\mathsf{notetuple}$
-that do not query $\mathsf{H^{rcm}}$.
-Since the non-querying constraint makes the deterministic shifts
-independent of the $\mathsf{H^{rcm}}$ oracle's responses, and
-$T[\mathsf{notetuple}_1]$, $T[\mathsf{notetuple}_2]$ are independently
-uniform on $\mathbb{F}_{r_{\mathbb{P}}}$,
-$\mathsf{F}(\mathsf{notetuple}_1)$ and $\mathsf{F}(\mathsf{notetuple}_2)$
-are each independent and uniform on $\mathbb{F}_{r_{\mathbb{P}}}$.
+$\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$, so the
+$\mathsf{H^{rcm}}$ outputs at $\mathsf{notetuple}_1, \mathsf{notetuple}_2$
+are independent uniform on $\mathbb{F}_{r_{\mathbb{P}}}$. The
+deterministic shifts ($\mathsf{f}$ and the $\mathsf{PRF^{nf}}$
+contribution scaled by $K_{\kern-.08em\mathcal{R}}$) do not query
+$\mathsf{H^{rcm}}$, so they are independent of its responses. Hence
+$F_1$ and $F_2$ are independent uniform on $\mathbb{F}_{r_{\mathbb{P}}}$.
 
-The win condition $F_1 \equiv \pm F_2$ is then a linear constraint on a
-pair of independent uniform variables, satisfied with probability at most
-$2/r_{\mathbb{P}}$ (each sign contributes $1/r_{\mathbb{P}}$).
-
-Taking a union bound over the at most ${q_{\mathsf{rcm}} \choose 2}$ pairs of
-distinct $\mathsf{H^{rcm}}$ queries and the two sign cases gives
-a winning probability, conditional on $(w_1, w_2)$ not constituting
-a key-binding break, of at most
-${q_{\mathsf{rcm}} \choose 2} \cdot \frac{2}{r_{\mathbb{P}}} = \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}}$.
-Decomposing on whether such a break occurs (probability at most
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$) and applying
-$\Pr[\text{win}] \leq \Pr[\text{win} \mid \neg\,\text{break}] + \Pr[\text{break}]$
-gives the theorem's overall claim of
-$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$.
+*Bounding the win probability.*
+The win condition $F_1 \equiv \pm F_2$ is a linear constraint on a
+pair of independent uniform variables, satisfied with probability at
+most $2/r_{\mathbb{P}}$ (one per sign). Union-bounding over the at
+most $\binom{q_{\mathsf{rcm}}}{2}$ pairs of distinct
+$\mathsf{H^{rcm}}$ queries:
+$$\Pr[\text{win} \mid \neg\,\text{break}] \leq \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}}.$$
+Decomposing on whether a key-binding break occurs and applying
+$\Pr[\text{win}] \leq \Pr[\text{win} \mid \neg\,\text{break}] + \Pr[\text{break}]$:
+$$\Pr[\text{win}] \leq \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}).$$
 This completes the classical-ROM proof.
 
 The [key-binding theorem](#thm-key-binding-rom) bounds

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1100,8 +1100,9 @@ $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{note
 
 $\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{encode}(\mathsf{noterepr})$
 
-Then we view the output of
-$\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$
+### Informal security argument for binding of note commitments
+
+We can view the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$
 as the point addition of a randomization term
 $[\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
 and some other function of $\mathsf{rseed}$, $\mathsf{leadByte}$, and
@@ -1115,11 +1116,11 @@ $\mathcal{C}_j = \mathcal{Q}(D) \text{ or } \mathcal{S}(j)$ used by
 as $\mathcal{C}_j = [c_j]\, \mathcal{R}$ for some $c_j$. That is,
 $$\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) = [\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
-First we informally argue security in the classical ROM. We will model
-$\mathsf{H^{rcm}}$ as a random oracle independent of $f$ with uniform
-output on $\mathbb{F}_{r_{\mathbb{P}}}$. This is reasonable because
+We will model $\mathsf{H^{rcm}}$ as a random oracle independent of $f$ with
+uniform output on $\mathbb{F}_{r_{\mathbb{P}}}.$ This is reasonable because
 $\mathsf{H^{rcm}}$ cannot depend on any of the $c_j$, and in any case it is
-likely to be a conventional hash function not related to the Pallas curve.
+instantiated using BLAKE2b, a conventional hash function not related to the
+Pallas curve.
 
 > The fact that $\mathsf{NoteCommit^{Orchard}}$ has
 > $\text{ψ} = \mathsf{H}^{\text{ψ}}(\mathsf{rseed}, \text{ρ})$ as an
@@ -1130,54 +1131,81 @@ likely to be a conventional hash function not related to the Pallas curve.
 > as BLAKE2b-512 can be modelled as a random oracle. Note that since the
 > input to $\mathsf{H^{rcm}}$ needs more than one BLAKE2b input block, we
 > require that a HAIFA sponge can be modelled as a random oracle which is
-> justified by [^ACMT2025].
+> justified by [^ACMT2025]. It is possible that there could be
+> better-than-generic quantum attacks against BLAKE2b-512, but none have
+> been published to our knowledge. In practice, we consider it reasonable to
+> assume that BLAKE2b-512 has the properties needed for $\mathsf{H^{rcm}}$
+> to be collapsing. Taking the 512-bit BLAKE2b output modulo
+> $r_{\mathbb{P}} \approx 2^{254}$ cannot introduce a problem.
 
 For each $\mathsf{H^{rcm}}$ oracle query the adversary chooses
 $\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}$
 and obtains a "random"
-$\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$,
-such that the distribution of
-$\mathsf{rcm} + [f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$
-is computationally indistinguishable from the uniform distribution on
-$\mathbb{F}_{r_\mathbb{P}}$.
-Therefore $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$
-is computationally indistinguishable from an output of
-$\mathsf{Extract}_{\mathbb{P}}$ applied to uniformly distributed
-Pallas curve points. The number of such outputs is
-$(\mathbb{F}_{r_\mathbb{P}} + 1)/2$ (one for each possible
-$x$-coordinate of Pallas curve points, plus one for the zero point
-$\mathcal{O}_{\mathbb{P}}$ which is mapped to $0$).
+$\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$.
+
+We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$.
+
+Over all Pallas curve points $P$, the number of outputs of
+$\mathsf{Extract}_{\mathbb{P}}(P)$ is $(\mathbb{F}_{r_\mathbb{P}} + 1)/2 \approx 2^{253}$ —
+one for each possible $x$-coordinate of Pallas curve points, plus one for the
+zero point $\mathcal{O}_{\mathbb{P}}$ which is mapped to $0$.
 
 > Only one point maps to $0$, as opposed to two points mapping to every
 > other possible output of $\mathsf{Extract}_{\mathbb{P}}$, but that has
 > negligible effect.
 
-The number of queries needed to find a collision therefore follows a
-distribution negligibly far from that expected for a collision attack on
-an ideal hash function mapping from the input domain to a set of size
-$(\mathbb{F}_{r_\mathbb{P}} + 1)/2 \approx 2^{253}$.
+There are two values of $\mathsf{cm}$ that match $\mathsf{cm}_x$ in their $x$-coordinate.
+Because the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$ is
+of the form $\mathsf{cm} = F(\mathsf{noterepr}) + [\mathsf{rcm}]\, \mathcal{R}$,
+for any given note we have exactly two values of $\mathsf{rcm}$ that will pass
+the commitment check.
 
-In order to adapt this argument to the quantum setting, we need to consider
-*collapsing* hash functions as defined in [^Unruh2015] [^Unruh2016].
+Suppose there are $N$ legitimate notes in the tree. The adversary is trying
+to find a note that will pass the commitment check without actually being a
+note in the tree. As argued above, the distribution of $\mathsf{rcm}$ is
+indistinguishable from uniform-random on $\mathbb{F}_{r_\mathbb{P}}$. The
+success probability for each attempt in a classical search is therefore
+$2N/r_{\mathbb{P}}$ where $r_{\mathbb{P}}$ is the order of the Pallas curve,
+and that is negligible because $N \leq 2^{32} \ll r_{\mathbb{P}}$. This is
+also infeasible for a quantum adversary using a Grover search.
 
-TODO: $\mathsf{Extract}_{\mathbb{P}}$ is not collapsing.
-Is $\mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$ collapsing?
+We're not finished yet because we also have to prove that the nullifier is
+computed deterministically for a given note.
 
-By the argument in [^Bernstein2009], the best known *generic* quantum
-attack on a hash function is simply the classical attack of [^vOW1999].
-(In particular, the Brassard–Høyer–Tapp algorithm [^BHT1997] is entirely
-unimplementable for a 253-bit output size: to achieve the claimed speed-up,
-it would require running Grover's algorithm with a quantum circuit that
-does random accesses to a $2^{92.3}$-bit quantum memory.) Therefore, an
-output size of 253 bits does not exclude a hash function from being
-post-quantum collision-resistant. It is possible that there could be
-better-than-generic quantum attacks against BLAKE2b, but none have been
-published to our knowledge. In practice, we consider it reasonable to
-assume that BLAKE2b-512 has the properties needed for $\mathsf{H^{rcm}}$
-to be post-quantum collision-resistant.
+All of the inputs to $\mathsf{DeriveNullifier}$ are things we committed to
+in the protocol so far *except* $\mathsf{nk}$. By the same argument used
+pre-quantumly, there is only one $\mathsf{ivk}$ for a given
+$(\mathsf{g_d}, \mathsf{pk_d})$. So in order to just use the existing
+protocol for this part, we would need to prove that there is only one
+$\mathsf{nk}$ (that is feasible to find) such that
+$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ivk}$.
+Unfortunately that's not true; $\mathsf{Commit^{ivk}}$ is instantiated by
+$\mathsf{SinsemillaShortCommit}$ which is not post-quantum binding.
 
-TODO: discuss [^CBHSU2017] (sponge security), [^Unruh2015] [^Unruh2016]
-(collapse-binding property).
+There are two cases depending on $\mathsf{use\_qsk}$ (the adversary can
+choose to attack either):
+
+* Case $\text{not } \mathsf{use\_qsk}$: The spender must prove knowledge of
+  $\mathsf{sk}$, and that $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$
+  are derived correctly from $\mathsf{sk}$. This works because the
+  derivations use post-quantum hashes (and $\mathsf{ask} \rightarrow \mathsf{ak}$
+  is deterministic). <br>
+  In particular, $\mathsf{ivk}$ is an essentially random function of
+  $\mathsf{sk}$, and so we expect that an adversary has no better attack
+  than to search for values of $\mathsf{sk}$ (possibly using a Grover search)
+  to find one that reproduces a given $\mathsf{ivk}$. Since $\mathsf{ivk}$
+  must be an $x$-coordinate of a Pallas curve point (see the note at the end of
+  [§ 4.2.3 Orchard Key Components](https://zips.z.cash/protocol/protocol.pdf#orchardkeycomponents)),
+  it can take on $(r_{\mathbb{P}}-1)/2$ values. So if there are $T$ targets
+  the success probability for each attempt in a classical search is
+  $2T/(r_{\mathbb{P}}-1)$, which is negligible provided that
+  $T \ll r_{\mathbb{P}}$. This is also infeasible for a quantum adversary
+  using a Grover search for reasonable values of $T$.
+
+* Case $\mathsf{use\_qsk}$: This case is almost the same except that
+  $\mathsf{ivk}$ is now an essentially random function of
+  $(\mathsf{nk}, \mathsf{ak}, \mathsf{qk})$. The success probability
+  in terms of $T$ is also the same as for $\text{not } \mathsf{use\_qsk}$.
 
 The above security argument means that provided we also check the uses of
 $\mathsf{H^{rcm}}$ and $\mathsf{H}^{\text{ψ}}$ in the post-quantum
@@ -1195,7 +1223,26 @@ necessary to defend against a discrete-log-breaking or quantum adversary.
 Therefore, the post-quantum [Recovery Statement](#proposedrecoverystatement)
 will need to use complete curve additions to implement Sinsemilla.
 
-### Attacks against binding of ivk
+### Adaptation to the quantum setting
+
+In order to adapt this argument to the quantum setting, we need to consider
+*collapsing* hash functions as defined in [^Unruh2015] [^Unruh2016].
+
+TODO: $\mathsf{Extract}_{\mathbb{P}}$ is not collapsing.
+Is $\mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$ collapsing?
+
+By the argument in [^Bernstein2009], the best known *generic* quantum
+attack on a hash function is simply the classical attack of [^vOW1999].
+(In particular, the Brassard–Høyer–Tapp algorithm [^BHT1997] is entirely
+unimplementable for a 253-bit output size: to achieve the claimed speed-up,
+it would require running Grover's algorithm with a quantum circuit that
+does random accesses to a $2^{92.3}$-bit quantum memory.) Therefore, an
+output size of 253 bits does not exclude a hash function from being collapsing.
+
+TODO: discuss [^CBHSU2017] (sponge security), [^Unruh2015] [^Unruh2016]
+(collapse-binding property).
+
+### Informal security argument for binding of ivk
 
 The security of Orchard against double-spending also depends on the binding
 property of $\mathsf{Commit^{ivk}}$. Informally, the security argument is
@@ -1221,65 +1268,6 @@ with $\mathsf{rivk}$ in place of $\mathsf{rcm}$.
 There is a complication: contrary to the situation with note commitments,
 addresses may be used over the long term and it may not be feasible or
 desirable to switch to new addresses.
-
-## Informal Security Argument
-
-The informal security argument that we can only spend valid notes goes as
-follows:
-
-If $\mathsf{H^{rcm}}$ and $\mathsf{H^{\text{φ}}}$ are treated as random oracles,
-$\mathsf{rcm}$ is an unpredictable function of the note fields. There are two
-values of $\mathsf{cm}$ that match $\mathsf{cm}_x$ in their $x$-coordinate.
-Because the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$ is
-of the form $\mathsf{cm} = F(\mathsf{noterepr}) + [\mathsf{rcm}]\, \mathcal{R}$,
-for any given note we have exactly two values of $\mathsf{rcm}$ that will pass
-the commitment check.
-
-Suppose there are $N$ legitimate notes in the tree. The adversary is trying
-to find (possibly using a Grover search) a note that will pass the commitment
-check without actually being a note in the tree. The success probability for
-each attempt in a classical search is $2N/r_{\mathbb{P}}$ where $r_{\mathbb{P}}$
-is the order of the Pallas curve, and that is negligible because
-$N \leq 2^{32} \ll r_{\mathbb{P}}$. This is also infeasible for a quantum
-adversary using a Grover search.
-
-We're not finished yet because we also have to prove that the nullifier is
-computed deterministically for a given note.
-
-All of the inputs to $\mathsf{DeriveNullifier}$ are things we committed to
-in the protocol so far *except* $\mathsf{nk}$. By the same argument used
-pre-quantumly, there is only one $\mathsf{ivk}$ for a given
-$(\mathsf{g_d}, \mathsf{pk_d})$. So in order to just use the existing
-protocol for this part, we would need to prove that there is only one
-$\mathsf{nk}$ (that is feasible to find) such that
-$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ivk}$.
-Unfortunately that's not true; $\mathsf{Commit^{ivk}}$ is instantiated by
-$\mathsf{SinsemillaShortCommit}$ which is not post-quantum binding.
-
-There are two cases depending on $\mathsf{use\_qsk}$ (the adversary can
-choose to attack either):
-
-* Case $\text{not } \mathsf{use\_qsk}$: The spender must prove knowledge of
-  $\mathsf{sk}$, and that $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$
-  are derived correctly from $\mathsf{sk}$. This works because the
-  derivations use post-quantum hashes (and $\mathsf{ask} \rightarrow \mathsf{ak}$
-  is deterministic). <br>  
-  In particular, $\mathsf{ivk}$ is an essentially random function of
-  $\mathsf{sk}$, and so we expect that an adversary has no better attack
-  than to search for values of $\mathsf{sk}$ (possibly using a Grover search)
-  to find one that reproduces a given $\mathsf{ivk}$. Since $\mathsf{ivk}$
-  must be an $x$-coordinate of a Pallas curve point (see the note at the end of
-  [§ 4.2.3 Orchard Key Components](https://zips.z.cash/protocol/protocol.pdf#orchardkeycomponents)),
-  it can take on $(r_{\mathbb{P}}-1)/2$ values. So if there are $T$ targets
-  the success probability for each attempt in a classical search is
-  $2T/(r_{\mathbb{P}}-1)$, which is negligible provided that
-  $T \ll r_{\mathbb{P}}$. This is also infeasible for a quantum adversary
-  using a Grover search for reasonable values of $T$.
-
-* Case $\mathsf{use\_qsk}$: This case is almost the same except that
-  $\mathsf{ivk}$ is now an essentially random function of
-  $(\mathsf{nk}, \mathsf{ak}, \mathsf{qk})$. The success probability
-  in terms of $T$ is also the same as for $\text{not } \mathsf{use\_qsk}$.
 
 ## Security argument for Spendability
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1265,18 +1265,23 @@ the security arguments for the Balance and Spend Authorization properties,
 because we can no longer infer that $\mathsf{nk}$ and $\mathsf{ak}$ are the
 correct values.
 
-Fortunately, the Orchard protocol specified $\mathsf{rivk}$ to be
-derived from $\mathsf{sk}$.
-
-(There is a complication in that $\mathsf{rivk}$ is derived differently
-for an "internal IVK".)
-
-We use essentially the same fix as for $\mathsf{NoteCommit^{Orchard}}$,
-with $\mathsf{rivk}$ in place of $\mathsf{rcm}$.
-
 There is a complication: contrary to the situation with note commitments,
 addresses may be used over the long term and it may not be feasible or
-desirable to switch to new addresses.
+desirable to switch to new addresses. Fortunately, the Orchard protocol
+specified each of $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$ to be
+derived from $\mathsf{sk}$ via $\mathsf{PRF^{expand}}$. ($\mathsf{rivk}$
+is derived differently for an "internal IVK", but that is also via
+$\mathsf{PRF^{expand}}$.)
+
+We use essentially the same fix as for $\mathsf{NoteCommit^{Orchard}}$,
+with $\mathsf{rivk}$ in place of $\mathsf{rcm}$. We check the derivation
+of all of $\mathsf{ak}$, $\mathsf{nk}$, and $\mathsf{rivk}$ from $\mathsf{sk}$.
+Looking carefully at the structure of the derivations relative to the
+ones for $\mathsf{NoteCommit^{Orchard}}$, we can see that $\mathsf{sk}$
+is in a roughly similar position to $\mathsf{rseed}$, and
+$(\mathsf{ak}, \mathsf{nk})$ to $\text{ψ}$. Because these are the only
+inputs to the commitment, the checks are sufficient to ensure they are
+all bound by it.
 
 ## Security argument for Spendability
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -439,8 +439,8 @@ $\mathsf{qsk}$ to the host wallet, and the $\mathsf{SoK^{qsk}}$ proof would be
 produced there.
 
 In either option, $\mathsf{ask}$ would remain on the hardware wallet which
-would continue to produce RedDSA spend authorization signatures (or its part
-of the FROST multi-signing protocol).
+would continue to produce RedDSA spend authorization signatures (or perform
+its part of the FROST multi-signing protocol).
 
 #### Threat model
 
@@ -625,11 +625,8 @@ in the algorithm with:
 >
 > $\hspace{1.0em}$ let $\mathsf{nk} = \mathsf{H^{nk}}(\mathsf{sk})$ <br>
 > $\hspace{1.0em}$ if $\mathsf{use\_qsk}$: <br>
-> $\hspace{2.5em}$     obtain a $\mathsf{SpendAuthSig^{Orchard}}$ public key $\mathsf{ak}^{\mathbb{P}} \;{\small ⦂}\; \mathbb{P}^*$ by any suitably secure method <br>
-> $\hspace{3.5em}$     that ensures the last bit of $\mathsf{repr}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$ is $0$. Possible methods include direct generation <br>
-> $\hspace{3.5em}$     of an Orchard spend-authorizing key $\mathsf{ask} \;{\small ⦂}\; \mathbb{F}^{*}_{r_{\mathbb{P}}}$ followed by $\mathsf{ak}^{\mathbb{P}} = \mathsf{SpendAuthSig^{Orchard}.DerivePublic}(\mathsf{ask})$, <br>
-> $\hspace{3.5em}$     or FROST distributed key generation [^zip-0312-key-generation] in which the corresponding spend-authorization <br>
-> $\hspace{3.5em}$     material is $t$-of-$n$ shared among the participants. <br>
+> $\hspace{2.5em}$     obtain a $\mathsf{SpendAuthSig^{Orchard}}$ public key $\mathsf{ak}^{\mathbb{P}} \;{\small ⦂}\; \mathbb{P}^*$ by any suitably secure <br>
+> $\hspace{3.5em}$       method that ensures the last bit of $\mathsf{repr}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$ is $0$ (see below). <br>
 > $\hspace{2.5em}$     let $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}^{\mathbb{P}})$ <br>
 > $\hspace{2.5em}$     let $\mathsf{qsk} = \mathsf{H^{qsk}}(\mathsf{sk})$ <br>
 > $\hspace{2.5em}$     let $\mathsf{qk} = \mathsf{H^{qk}}(\mathsf{qsk})$ <br>
@@ -643,6 +640,16 @@ in the algorithm with:
 > $\hspace{2.5em}$     let $\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}(\mathsf{ak}_{\mathbb{P}})$ <br>
 > $\hspace{2.5em}$     let $\mathsf{qsk} = \mathsf{qk} = \bot$ (there are no quantum spending/intermediate keys in this case) <br>
 > $\hspace{2.5em}$     let $\mathsf{rivk} = \mathsf{H^{rivk}}(\mathsf{sk})$
+
+Add before "As explained in § 3.1":
+
+> When $\mathsf{use\_qsk}$ is true, possible methods of generating
+> $\mathsf{ak}^{\mathbb{P}}$ include direct generation of an Orchard Spend
+> authorizing key $\mathsf{ask} \;{\small ⦂}\; \mathbb{F}^{*}_{r_{\mathbb{P}}}$ followed by
+> $\mathsf{ak}^{\mathbb{P}} = \mathsf{SpendAuthSig^{Orchard}.DerivePublic}(\mathsf{ask})$,
+> or FROST distributed key generation [^zip-0312-key-generation] in which the
+> corresponding spend-authorization material is $t$-of-$n$ shared among the
+> participants.
 
 Add the following notes:
 
@@ -1011,6 +1018,9 @@ and $\mathsf{nf}$ is the revealed nullifier.
 
 ### Cost
 
+From here on, we abbreviate $\mathsf{H^{rcm,Orchard}}$ to $\mathsf{H^{rcm}}$,
+etc.
+
 Note that in the "$\mathsf{use\_qsk}$" case, one BLAKE2b compression
 is required to compute $\mathsf{rivk\_ext}$ (provided $\ell_{\mathsf{qk}} \leq 504$
 bits, so that the input $\mathsf{qk} \,||\, [\mathtt{0x0D}] \,||\, \mathsf{ak} \,||\, \mathsf{nk}$
@@ -1055,9 +1065,8 @@ post-quantum knowledge-sound.
 
 $\mathsf{MerkleCRH^{Orchard}}$ is instantiated using
 $\mathsf{SinsimillaHash}$ [^protocol-concretesinsemillahash].
-Its collision resistance depends on the Discrete Logarithm Relation
-Problem on the Pallas curve [^protocol-sinsemillasecurity], and so it
-is not
+Its collision resistance depends on the Discrete Logarithm Relation Problem
+on the Pallas curve [^protocol-sinsemillasecurity], and so it is not
 post-quantum collision-resistant or collapsing. However, because the note
 commitment tree is public, it is possible to re-hash all of its leaves to
 construct a new Merkle tree using a collapsing hash function.
@@ -1096,7 +1105,7 @@ $\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}
 as detailed in the [Specification] section.
 Specifically, when $\mathsf{leadByte} = \mathtt{0x03}$ we have:
 
-$\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm}))$
+$\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm}))$
 
 $\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{encode}(\mathsf{noterepr})$
 
@@ -1104,7 +1113,7 @@ $\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \ma
 
 We can view the output of $\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr})$
 as the point addition of a randomization term
-$[\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
+$[\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
 and some other function of $\mathsf{rseed}$, $\mathsf{leadByte}$, and
 $\mathsf{noterepr}$.
 
@@ -1114,7 +1123,7 @@ by expanding each of the Sinemilla bases
 $\mathcal{C}_j = \mathcal{Q}(D) \text{ or } \mathcal{S}(j)$ used by
 [$\mathsf{HashToSinsimillaPoint}$](https://zips.z.cash/protocol/protocol.pdf#concretesinsemillahash)
 as $\mathcal{C}_j = [c_j]\, \mathcal{R}$ for some $c_j$. That is,
-$$\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) = [\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
+$$\mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
 We will model $\mathsf{H^{rcm}}$ as a random oracle independent of $f$ with
 uniform output on $\mathbb{F}_{r_{\mathbb{P}}}.$ This is reasonable because
@@ -1141,9 +1150,9 @@ Pallas curve.
 For each $\mathsf{H^{rcm}}$ oracle query the adversary chooses
 $\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}$
 and obtains a "random"
-$\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$.
+$\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$.
 
-We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$.
+We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$.
 
 Over all Pallas curve points $P$, the number of outputs of
 $\mathsf{Extract}_{\mathbb{P}}(P)$ is $(\mathbb{F}_{r_\mathbb{P}} + 1)/2 \approx 2^{253}$ —
@@ -1229,7 +1238,7 @@ In order to adapt this argument to the quantum setting, we need to consider
 *collapsing* hash functions as defined in [^Unruh2015] [^Unruh2016].
 
 TODO: $\mathsf{Extract}_{\mathbb{P}}$ is not collapsing.
-Is $\mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$ collapsing?
+Is $\mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$ collapsing?
 
 By the argument in [^Bernstein2009], the best known *generic* quantum
 attack on a hash function is simply the classical attack of [^vOW1999].
@@ -1274,7 +1283,7 @@ desirable to switch to new addresses.
 DeriveNullifier is based on a Pedersen hash. In the current Orchard
 protocol, the property that it is infeasible to find two distinct
 Orchard notes with the same nullifier (including possible nullfiers
-of split OrchardZSA notes), depends on the collision-resistance of
+of split OrchardZSA notes), depends on the collision resistance of
 that hash, which would not hold against a discrete-log-breaking
 adversary.
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -631,7 +631,7 @@ in the algorithm with:
 > * $\mathsf{H^{nk}}(\mathsf{sk}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{sk}}([\mathtt{0x07}])\kern-0.1em\big)$
 > * $\mathsf{H^{rivk}}(\mathsf{sk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{sk}}([\mathtt{0x08}])\kern-0.1em\big)$
 > * $\mathsf{H^{qsk}}(\mathsf{sk}) = \mathsf{truncate}_{32}\big(\mathsf{PRF^{expand}_{sk}}([\mathtt{0x0C}])\kern-0.1em\big)$
-> * $\mathsf{H^{qk}}(\mathsf{qsk}) = \textsf{BLAKE2s\kern0.1em-256}(\texttt{“Zcash\_qk”}, \mathsf{qsk})$.
+> * $\mathsf{H^{qk}}(\mathsf{qsk}) = \mathsf{BLAKE3.derive\_key}(\texttt{“Zcash ZIP 2005 qk-derivation v1”}, \mathsf{qsk}, 32)$ [^BLAKE3].
 > * $\mathsf{H}^{\mathsf{rivk\_ext}}_{\mathsf{qk}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{qk}}\big([\mathtt{0x0D}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak}) \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})\kern-0.1em\big)\kern-0.15em\big)$.
 > 
 > $\mathsf{ask} \;{\small ⦂}\; \mathbb{F}^{*}_{r_{\mathbb{P}}}$,
@@ -1062,7 +1062,7 @@ even if they are incomplete in the current Orchard[ZSA] statement/circuit.
     * 1 to compute $\mathsf{H^{\text{ψ}}}$
     * 2 to compute $\mathsf{H^{rcm}}$
         * we could potentially save these two by using Poseidon to implement $\mathsf{H^{rcm}}$, but it seems not worth it.
-* 1 use of $\mathsf{H^{qk}}$
+* 1 BLAKE3 compression for $\mathsf{H^{qk}}$ (with the $\mathsf{derive\_key}$ context key precomputed as a constant)
 * 1 use of $\mathsf{Commit^{ivk}}$ ($\mathsf{SinsemillaShortCommit}$)
 * 1 use of $\mathsf{NoteCommit}$ ($\mathsf{SinsemillaCommit}$)
 * 1 full-width fixed-base Pallas scalar multiplication, $[\mathsf{ask}]\, \mathcal{G}^{\mathsf{Orchard}}$
@@ -1897,6 +1897,8 @@ manipulate the note selection algorithm to some extent.
 [^vOW1999]: [Parallel collision search with cryptanalytic applications. Paul C. van Oorschot and Michael Wiener.](https://link.springer.com/article/10.1007/PL00003816)
 
 [^Bernstein2009]: [Cost analysis of hash collisions: Will quantum computers make SHARCS obsolete? Daniel J. Bernstein.](https://cr.yp.to/hash/collisioncost-20090517.pdf)
+
+[^BLAKE3]: [BLAKE3: One Function, Fast Everywhere. Jack O'Connor, Jean-Philippe Aumasson, Samuel Neves, and Zooko Wilcox-O'Hearn, 2020.](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) See § 2.1.2 for the `derive_key` mode.
 
 [^Maurer2002]: [Indistinguishability of Random Systems. Ueli Maurer.](https://crypto.ethz.ch/publications/files/Maurer02.pdf) Advances in Cryptology — EUROCRYPT 2002, LNCS vol. 2332, pp. 110–132.
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1080,9 +1080,8 @@ Suppose this has been done.
 Note: when we rehash the commitment tree, we could include both $\text{ρ}$ and
 $\mathsf{cm}_x$ for each note (i.e. what is currently the leaf layer becomes
 $\mathsf{MerkleCRH}(\text{ρ}, \mathsf{cm}_x)$ where $\mathsf{MerkleCRH}$
-is pq-collision-resistant). This change might not be necessary; it just
-removes potential complications due to duplicate commitments for the same
-note.
+is collapsing). This change might not be necessary; it just removes potential
+complications due to duplicate commitments for the same note.
 
 ### Attacks against binding of note commitments
 
@@ -1297,9 +1296,6 @@ Does this mean it is possible to break Spendability for the given
 Recovery Statement? As it turns out, no, but the argument is somewhat
 involved.
 
-TODO: this argument is too handwavy and depends on the ROM; it needs
-further work for a quantum adversary.
-
 Since each function in the Recovery Statement is deterministic, the
 free variables that the adversary can control are the sources of the
 derivation digraph within that statement and either $\mathsf{SoK^{sk}}$
@@ -1309,67 +1305,103 @@ or $\mathsf{SoK^{qk}}$. That is, the adversary can control:
     * $\mathsf{sk}$, when $\mathsf{use\_qsk} = \mathsf{false}$;
     * $(\mathsf{nk}, \mathsf{ak}, \mathsf{qsk})$, when $\mathsf{use\_qsk} = \mathsf{true}$.
 
-As we argued earlier in section [Repairing note commitments],
-$\mathsf{rcm}$ binds $\mathsf{rseed}$ and $\mathsf{pre\_rcm}$, and all
-of the other inputs to $\mathsf{NoteCommit}$ are also included in
-$\mathsf{pre\_rcm}$. Therefore, given the independence assumption between
-$\mathsf{H^{rcm}}$ and $f$ described earlier, $\mathsf{cm}$ binds all
-of the values in the Recovery Statement that the adversary can control.
-
-We can then analyze $\mathsf{DeriveNullifier}$ in essentially the same
-way we analyzed $\mathsf{NoteCommit}$.
-
-Recall that $\mathsf{DeriveNullifier}$ is defined in
+We analyze $\mathsf{DeriveNullifier}$ as a function of these
+controllable inputs. Recall that $\mathsf{DeriveNullifier}$ is defined in
 § 4.16 ‘Computing ρ values and Nullifiers’ as:
 
 $$\mathsf{DeriveNullifier_{nk}}(\text{ρ}, \text{ψ}, \mathsf{cm}) = \mathsf{Extract}_{\mathbb{P}}\big(\big[\mathsf{PRF^{nfOrchard}_{nk}}(\text{ρ}) + \text{ψ}) \bmod q_{\mathbb{P}}\big]\, \mathcal{K}^{\mathsf{Orchard}} + \mathsf{cm}\big)$$
 
 Also recall from [Repairing note commitments] that we have
 
-$$\mathsf{cm} = [\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
+$$\mathsf{cm} = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
 $\text{ψ}$ is determined by $\mathsf{rseed}$. The nullifier corresponding to
-$(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ is
-then
-$$\mathsf{Extract}_{\mathbb{P}}\big([\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}) + g(\mathsf{nk}, \text{ρ}, \mathsf{rseed})]\, \mathcal{R}\big)$$
+$(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+is then
+$$\mathsf{Extract}_{\mathbb{P}}\big([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + f(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}) + g(\mathsf{nk}, \text{ρ}, \mathsf{rseed})]\, \mathcal{R}\big)$$
 
 for some $g$ depending on the discrete logarithm of $\mathcal{K}^{\mathsf{Orchard}}$ wrt $\mathcal{R}$.
 
-The intuition is that an adversary cannot vary any of the inputs it controls without causing an
-unpredictable change to both $\mathsf{cm}$ and $\mathsf{nf}$. This is because every such input
-goes through a function that can be modelled as a random oracle on the way to deriving
-$\mathsf{cm}$ and $\mathsf{nf}$:
+We give a reduction-based argument that any classical adversary in the
+Random Oracle Model who finds two valid Recovery Statement witnesses for
+distinct underlying notes with colliding nullifiers, succeeds with
+probability bounded by $q(q-1)/r_{\mathbb{P}}$, where $q$ is the number
+of $\mathsf{H^{rcm}}$ queries the adversary makes. The bound depends only
+on the query count, not on running time, and applies to any adversary
+regardless of attack strategy.
 
-* $\text{ρ}$ goes through $\mathsf{H}^{\text{ψ}}$ to derive $\text{ψ}$, and through
-  $\mathsf{PRF^{nfOrchard}_{nk}}$ which is instantiated as Poseidon to derive $\mathsf{nf}$;
-* $\mathsf{g_d}$ goes through $\mathsf{H^{rcm}}$;
-* because $\mathsf{g_d} \mapsto \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d}$ is 1-1, any
-  change to $\mathsf{ivk}$ for a given $\mathsf{g_d}$ results in a change to $\mathsf{pk_d}$,
-  which goes through $\mathsf{H^{rcm}}$;
-* $\mathsf{rseed}$ goes through $\mathsf{H}^{\text{ψ}}$ and then $\mathsf{H^{rcm}}$;
-* $\mathsf{use\_qsk}$ only has two possible values, and therefore can't increase the adversary's
-  advantage by more than a factor of $2$ provided that both alternatives are otherwise secure;
-* when $\mathsf{use\_qsk} = \mathsf{false}$:
-    * $\mathsf{sk}$ goes through $\mathsf{H^{rivk\_legacy}}$;
-    * $\mathsf{nk}$ goes through $\mathsf{H^{nk}}$;
-    * $\mathsf{ak}$ goes through $\mathsf{H^{ask}}$;
-* when $\mathsf{use\_qsk} = \mathsf{true}$:
-    * $\mathsf{qsk}$ goes through $\mathsf{H^{qk}}$ and $\mathsf{H^{rivk\_ext}}$;
-    * $\mathsf{nk}$ goes through $\mathsf{H^{rivk\_ext}}$;
-    * $\mathsf{ak}$ goes through $\mathsf{H^{rivk\_ext}}$;
+We model $\mathsf{H^{rcm}}$ as a random oracle with output uniform
+on $\mathbb{F}_{r_{\mathbb{P}}}$. The functions $f$ and $g$ are deterministic
+functions of their inputs — a structural property of the algebraic
+decomposition derived above. $f$ depends on
+$(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ via the Sinsemilla
+bases $\mathcal{C}_j = [c_j]\, \mathcal{R}$; $g$ depends on
+$(\mathsf{nk}, \text{ρ}, \mathsf{rseed})$ via $\mathsf{PRF^{nfOrchard}}$,
+$\mathsf{H}^{\text{ψ}}$, and the discrete logarithm of
+$\mathcal{K}^{\mathsf{Orchard}}$ wrt $\mathcal{R}$. Neither is modelled as
+a random oracle.
 
-Note that while $f$ and $g$ are individually random oracles on their inputs, their
-sum modulo $q_{\mathbb{P}}$ could potentially be subject to a meet-in-the-middle attack.
-This might be possible if the inputs that the adversary can control could be split so
-that some affect only $\mathsf{H^{rcm,Orchard}}$ and $f$, and others affect only $g$.
-(Note that $\mathsf{H^{rcm,Orchard}}$ and $f$ have the same inputs and are each random
-oracles on all of their inputs.) But $\mathsf{noterepr}$ includes $\text{ρ}$, and we have
-already established that $\mathsf{nk}$ cannot be varied without affecting $\mathsf{pk_d}$.
-So with a little work we can see that such splitting is not possible.
+We are *not* assuming $\mathsf{Commit^{ivk}}$ is binding, nor that any
+of the key-derivation hashes are collision-resistant. The argument here
+covers only $\mathsf{NoteCommit}$ binding — it argues that $\mathsf{nf}$
+binds the underlying note ($\mathsf{noterepr}$, plus $\mathsf{rseed}$ and
+$\mathsf{leadByte}$) under $\mathsf{H^{rcm}}$-as-random-oracle
+alone.
 
-An adversary could also attempt to cause a collision in $\mathsf{nf}$ by causing a
-collision on $\mathsf{Extract}_{\mathbb{P}}$, but this is also not feasible if
-$\mathsf{H^{rcm,Orchard}}$ can be modelled as a random oracle.
+**Theorem (distinct-note Spendability, classical ROM).** <a id="thm-spendability"></a>
+Let $\mathcal{A}$ be a classical adversary with oracle access to
+$\mathsf{H^{rcm}}$ modelled as a random oracle with output uniform on
+$\mathbb{F}_{r_{\mathbb{P}}}$, making at most $q$ oracle queries. The
+*Spendability-collision* game has $\mathcal{A}$ output two Recovery
+Statement witnesses $\mathsf{w}_1, \mathsf{w}_2$ satisfying:
+
+<a id="thm-spendability-validity"></a>**Validity of witnesses**
+:   both witnesses satisfy the
+    [Proposed Recovery Statement](#proposedrecoverystatement).
+
+<a id="thm-spendability-distinct"></a>**Distinct underlying notes**
+:   the $\mathsf{H^{rcm}}$-input tuples
+    $r_i := (\mathsf{rseed}_i, \mathsf{leadByte}_i, \mathsf{noterepr}_i)$
+    satisfy $r_1 \neq r_2$.
+
+<a id="thm-spendability-collide"></a>**Colliding nullifiers**
+:   $\mathsf{nf}_1 = \mathsf{nf}_2$.
+
+Then $\mathcal{A}$ wins this game with probability at most
+$\binom{q}{2} \cdot 2/r_{\mathbb{P}} = q(q-1)/r_{\mathbb{P}}$, taken over
+the random oracle's responses and any internal randomness of $\mathcal{A}$.
+
+For the Pallas curve we have $r_{\mathbb{P}} \approx 2^{254}$, so any
+adversary making at most $q \le 2^{80}$ random-oracle queries wins with
+probability at most approximately $2^{-94}$.
+
+**Reduction.** We construct a simulated environment in which
+$\mathsf{H^{rcm}}$ is replaced by a lazily-sampled random oracle.
+The simulation maintains a table
+$T : \mathsf{H^{rcm}}\text{-input} \to \mathbb{F}_{r_{\mathbb{P}}}$,
+initially empty. On each query
+$r = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ from
+$\mathcal{A}$, the simulation returns $T[r]$ if defined, or otherwise
+samples a fresh $h \leftarrow \mathbb{F}_{r_{\mathbb{P}}}$, records
+$T[r] := h$, and returns $h$. After at most $q$ such queries,
+$\mathcal{A}$ outputs $(\mathsf{w}_1, \mathsf{w}_2)$ satisfying
+[(validity)](#thm-spendability-validity),
+[(distinct underlying notes)](#thm-spendability-distinct), and
+[(colliding nullifiers)](#thm-spendability-collide).
+
+The collision $\mathsf{nf}_1 = \mathsf{nf}_2$ implies that
+$[H_1 + f_1 + g_1]\, \mathcal{R}$ and $[H_2 + f_2 + g_2]\, \mathcal{R}$
+share an $x$-coordinate, hence are either equal or each other's
+negation:
+
+$$H_1 + f_1 + g_1 \equiv \pm(H_2 + f_2 + g_2) \pmod{r_{\mathbb{P}}},$$
+
+where $H_i := \mathsf{H^{rcm}}(r_i)$. By
+[(distinct underlying notes)](#thm-spendability-distinct) we have
+$r_1 \neq r_2$, so $T[r_1]$ and $T[r_2]$ are sampled independently and
+uniformly from $\mathbb{F}_{r_{\mathbb{P}}}$.
+
+TODO: Probability bound (step 5) and QROM follow-up (step 6) go here.
 
 ## Effects of discrete-log-breaking attacks before the switch to the Recovery Protocol
 


### PR DESCRIPTION
## Security arguments

Flesh out and tighten the informal-to-formal security arguments in the Rationale section:

- Repair the informal binding-of-ivk argument and remove duplication.
- Rewrite the informal Spendability argument as a classical-ROM reduction with an explicit theorem and proof sketch.
- Tighten the key-binding argument:
  - Lift `use_qsk` and `is_internal_rivk` into the $\bot$-structure of the witness. This ensures that cross-branch attacks automatically fall into scope.
  - Restructure the proof sketch around a "final random oracle" formulation. WLOG-distinctness is argued per case from predicate determinism rather than from a vague witness-distinctness claim.
  - Correct the bound to $\frac{3 q_{\mathsf{kb}}(q_{\mathsf{kb}} - 1)}{2 r_{\mathbb{P}}}$ to account for the upstream-RO collision residual in the both-internal sub-case (which the previous $\frac{q_{\mathsf{kb}}(q_{\mathsf{kb}} - 1)}{r_{\mathbb{P}}}$ bound missed). Propagate the corrected constant to the Spendability theorem's combined bound.
  - Make explicit that the $y$-sign of $\mathsf{ak}^{\mathbb{P}}$ is intentionally not part of the binding equivalence class — consistent with Orchard's intentional design decision to use $\mathsf{ak}$ as a single $\mathbb{F}_ {q_{\mathbb{P}}}$ element.
- Update the high-level summary's binding-argument paragraph to describe both branches symmetrically, matching the formal statement.
- Harmonize the Spendability proof's structure with the key-binding proof: RO model used directly without an explicit lazy-sampling table.

## $\mathsf{H}^{\mathsf{qk}}$ instantiation

Switch $\mathsf{H}^{\mathsf{qk}}$ from BLAKE2s-256 to `BLAKE3.derive_key` with context string `"Zcash ZIP 2005 qk-derivation v1"` and 32-byte output. Requires one BLAKE3 compression in the $\mathsf{SoK}^{\mathsf{qsk}}$ circuit, with the `derive_key` context key precomputed as a constant.

## Notational consistency

- Establish a convention to omit $\mathsf{Orchard}$ superscripts in Terminology.
- Adopt the convention that function names use `\mathsf` and output values are math-italic.
- Italic subsection labels in the Spendability proof (Algebraic setup / Independence claim per pair / Bounding the win probability), as in the key-binding proof. Also use the $F_i := \mathsf{F}(\mathsf{notetuple}_i)$ shorthand.

🤖 Filed with [Claude Code](https://claude.com/claude-code)