### PR TITLE
ZIP 213: align anchor-depth rationale with ZIP 315 (3 blocks)

### DIFF
--- a/zips/zip-0213.rst
+++ b/zips/zip-0213.rst
@@ -130,9 +130,9 @@ be shielded immediately.
 Enforcing coinbase maturity at the consensus level for Sapling outputs would incur
 significant complexity in the consensus rules, because it would require special-casing
 coinbase note commitments in the Sapling commitment tree. The standard recommendation when
-spending a note is to select an anchor 10 blocks back from the current chain tip, which
-acts as a de-facto 10-block maturity on all notes, coinbase included. This might be
-proposed as a consensus rule in future.
+spending a note is to select an anchor 3 blocks back from the current chain tip (see ZIP
+315 [#zip-0315]_), which acts as a de-facto 3-block maturity on all notes, coinbase
+included. This might be proposed as a consensus rule in future.
 
 There is another reason for shielded coinbase maturity being unnecessary: shielded
 coinbase outputs have the same effect on economic activity as regular shielded outputs.
@@ -205,3 +205,4 @@ References
 .. [#zip-0207] `ZIP 207: Funding Streams <zip-0207.rst>`_
 .. [#zip-0250] `ZIP 250: Deployment of the Heartwood Network Upgrade <zip-0250.rst>`_
 .. [#zip-0252] `ZIP 252: Deployment of the NU5 Network Upgrade <zip-0252.rst>`_
+.. [#zip-0315] `ZIP 315: Best Practices for Wallet Implementations <zip-0315.rst>`_

--- a/zips/zip-0213.rst
+++ b/zips/zip-0213.rst
@@ -131,7 +131,7 @@ Enforcing coinbase maturity at the consensus level for Sapling outputs would inc
 significant complexity in the consensus rules, because it would require special-casing
 coinbase note commitments in the Sapling commitment tree. The standard recommendation when
 spending a note is to select an anchor 3 blocks back from the current chain tip (see ZIP
-315 [#zip-0315]_), which acts as a de-facto 3-block maturity on all notes, coinbase
+315 [#zip-0315-anchor-selection]_), which acts as a de-facto 3-block maturity on all notes, coinbase
 included. This might be proposed as a consensus rule in future.
 
 There is another reason for shielded coinbase maturity being unnecessary: shielded
@@ -205,4 +205,4 @@ References
 .. [#zip-0207] `ZIP 207: Funding Streams <zip-0207.rst>`_
 .. [#zip-0250] `ZIP 250: Deployment of the Heartwood Network Upgrade <zip-0250.rst>`_
 .. [#zip-0252] `ZIP 252: Deployment of the NU5 Network Upgrade <zip-0252.rst>`_
-.. [#zip-0315] `ZIP 315: Best Practices for Wallet Implementations <zip-0315.rst>`_
+.. [#zip-0315-anchor-selection] `ZIP 315: Best Practices for Wallet Implementations — Anchor selection <zip-0315.rst#anchor-selection>`_


### PR DESCRIPTION
## Summary
- Updates ZIP 213's Rationale section to reference an anchor 3 blocks back from the chain tip (matching ZIP 315) instead of the older "10 blocks" advice.
- Adds a `[#zip-0315]` footnote in the References section.

The conflicting guidance was confusing for new implementers onboarding to the protocol. The change is purely in the (non-normative) Rationale section, so ZIP 213's `Final` status is unaffected.

Closes #1265

## Test plan
- [ ] Confirm the rendered ZIP 213 Rationale paragraph reads naturally and the `[#zip-0315]` footnote resolves.
- [ ] Verify CI link/dest checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)