### PR TITLE
Add Dev Ojha as ZIP editor

### DIFF
--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -9,6 +9,7 @@
           Kris Nuttycombe <kris@nutty.land>
           Sam H. Smith <sam@shieldedlabs.net>
           Sean Bowe <sean@bowe.tech>
+          Dev Ojha <dev@valargroup.dev>
   Original-Authors: Josh Cincinnati
                     George Tankersley
                     Deirdre Connolly
@@ -192,6 +193,7 @@ The current ZIP Editors are:
 * Arya, associated with the Zcash Foundation.
 * Mark Henderson and Sam H. Smith, associated with Shielded Labs.
 * Sean Bowe, associated with Project Tachyon.
+* Dev Ojha, associated with Valar Group.
 
 All can be reached at zips@z.cash. The current design of the ZIP Process
 dictates that there are always at least two ZIP Editors, including at least


### PR DESCRIPTION
Add Dev Ojha as a zip editor.

Offline ACK'd by @nuttycom 

Will cause a git conflcit with #1267 , but this PR is made from the zcash repo so we can easily adjust conflicts after.

EDIT: Conflict resolved