### PR TITLE
ZIP 2005: Improve security argument; drop leadByte and AssetBase from H^{rcm,Orchard}; commit to deployment option 1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,6 @@ written.
     <tr> <td>226</td> <td class="left"><a href="zips/zip-0226.rst">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/618">zips#618</a></td>
     <tr> <td>227</td> <td class="left"><a href="zips/zip-0227.rst">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/618">zips#618</a></td>
     <tr> <td><span class="reserved">228</span></td> <td class="left"><a class="reserved" href="zips/zip-0228.rst">Asset Swaps for Zcash Shielded Assets</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/776">zips#776</a></td>
-    <tr> <td>230</td> <td class="left"><a href="zips/zip-0230.rst">Version 6 Transaction Format</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/686">zips#686</a></td>
     <tr> <td>231</td> <td class="left"><a href="zips/zip-0231.md">Memo Bundles</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/627">zips#627</a></td>
     <tr> <td>233</td> <td class="left"><a href="zips/zip-0233.md">Network Sustainability Mechanism: Removing Funds From Circulation</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/922">zips#922</a></td>
     <tr> <td>234</td> <td class="left"><a href="zips/zip-0234.md">Network Sustainability Mechanism: Issuance Smoothing</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/923">zips#923</a></td>
@@ -250,6 +249,7 @@ Withdrawn, Rejected, or Obsolete ZIPs
     <tr> <th>ZIP</th> <th>Title</th> <th>Status</th> </tr>
     <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zips/zip-0210.rst">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zips/zip-0220.rst">Zcash Shielded Assets</a></strike></td> <td>Withdrawn</td>
+    <tr> <td><strike>230</strike></td> <td class="left"><strike><a href="zips/zip-0230.rst">Withdrawn Version 6 Transaction Format</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>254</strike></td> <td class="left"><strike><a href="zips/zip-0254.md">Deployment of the NU7 Network Upgrade (Withdrawn)</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zips/zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
     <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zips/zip-1001.rst">Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>Obsolete</td>
@@ -316,7 +316,7 @@ Index of ZIPs
     <tr> <td>226</td> <td class="left"><a href="zips/zip-0226.rst">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td>
     <tr> <td>227</td> <td class="left"><a href="zips/zip-0227.rst">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">228</span></td> <td class="left"><a class="reserved" href="zips/zip-0228.rst">Asset Swaps for Zcash Shielded Assets</a></td> <td>Reserved</td>
-    <tr> <td>230</td> <td class="left"><a href="zips/zip-0230.rst">Version 6 Transaction Format</a></td> <td>Draft</td>
+    <tr> <td><strike>230</strike></td> <td class="left"><strike><a href="zips/zip-0230.rst">Withdrawn Version 6 Transaction Format</a></strike></td> <td>Withdrawn</td>
     <tr> <td>231</td> <td class="left"><a href="zips/zip-0231.md">Memo Bundles</a></td> <td>Draft</td>
     <tr> <td>233</td> <td class="left"><a href="zips/zip-0233.md">Network Sustainability Mechanism: Removing Funds From Circulation</a></td> <td>Draft</td>
     <tr> <td>234</td> <td class="left"><a href="zips/zip-0234.md">Network Sustainability Mechanism: Issuance Smoothing</a></td> <td>Draft</td>

--- a/zips/zip-0226.rst
+++ b/zips/zip-0226.rst
@@ -42,7 +42,7 @@ Abstract
 This ZIP (ZIP 226) proposes the Orchard Zcash Shielded Assets (OrchardZSA) protocol, in conjunction with ZIP 227 [#zip-0227]_. The OrchardZSA protocol is an extension of the Orchard protocol that enables the issuance, transfer and burn of custom Assets on the Zcash chain. The issuance of such Assets is defined in ZIP 227 [#zip-0227]_, while the transfer and burn of such Assets is defined in this ZIP (ZIP 226).
 While the proposed OrchardZSA protocol is a modification to the Orchard protocol, it has been designed with adaptation to possible future shielded protocols in mind.
 
-This ZIP is defined relative to the Zcash protocol with the changes specified in ZIP 2005 [#zip-2005]_ applied. ZIP 2005 (Orchard Quantum Recoverability) is expected to deploy before any ZSA activation; the references in this document to $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{\text{ψ},Orchard}}$, recoverable note plaintexts (lead byte $\mathtt{0x03}$), and related constructs are to be interpreted as defined by ZIP 2005's modifications to the protocol specification.
+This ZIP is defined relative to the Zcash protocol with the changes specified in ZIP 2005 [#zip-2005]_ applied. ZIP 2005 (Orchard Quantum Recoverability) is expected to deploy before any ZSA activation; the references in this document to $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{\text{ψ},Orchard}}$, recoverable note plaintexts, and related constructs are to be interpreted as defined by ZIP 2005's modifications to the protocol specification.
 
 Motivation
 ==========
@@ -159,7 +159,7 @@ The nullifier is generated in the same manner as in the Orchard protocol §4.16 
 The OrchardZSA note plaintext also includes the Asset Base $\mathsf{asset\_base} : \mathbb{B}^{[\ell_{\mathbb{P}}]}$ in addition to the components in the Orchard note plaintext [#protocol-notept]_.
 The explicit encoding of the note plaintext is provided in ZIP 230 [#zip-0230-orchard-note-plaintext]_.
 
-When § 4.7.3 'Sending Notes (Orchard)' [#protocol-orchardsend]_ or § 4.8.3 'Dummy Notes (Orchard)' [#protocol-orcharddummynotes]_ are invoked directly or indirectly in the computation of $\text{ρ}$ and $\text{ψ}$ for an OrchardZSA note, $\mathsf{leadByte}$ MUST be set to $\mathtt{0x03}$.
+When § 4.7.3 'Sending Notes (Orchard)' [#protocol-orchardsend]_ or § 4.8.3 'Dummy Notes (Orchard)' [#protocol-orcharddummynotes]_ are invoked directly or indirectly in the computation of $\text{ρ}$ and $\text{ψ}$ for an OrchardZSA note, $\mathsf{leadByte}$ MUST be set to {{ZSALEADBYTE}}.
 
 The explicit order of addition of the note commitments to the note commitment tree is specified in ZIP 227 [#zip-0227-note-commitment-order]_.
 
@@ -392,11 +392,9 @@ The following requirements on wallets are specified and motivated in ZIP 230
   ZEC asset. For other consequences see ZIP 230.
 
 * *All* wallets should be ready to receive funds in outputs of v6 transactions as soon
-  as ZSAs activate — in particular to support decrypting recoverable note plaintexts
-  (lead byte $\mathtt{0x03}$) [#zip-0230-note-plaintexts]_. The consequence of not doing so would
-  be that funds sent to Orchard addresses of a wallet without this support could be
-  temporarily inaccessible, until the wallet is upgraded to fully support v6 and to
-  rescan outputs since v6 activation.
+  as ZSAs activate. The consequence of not doing so would be that funds sent to Orchard
+  addresses of a wallet without this support could be temporarily inaccessible, until
+  the wallet is upgraded to fully support v6 and to rescan outputs since v6 activation.
 
 Sighash modifications relative to ZIP 244 [#zip-0244]_
 ------------------------------------------------------

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -1,7 +1,7 @@
 ::
 
   ZIP: 230
-  Title: Version 6 Transaction Format
+  Title: Withdrawn Version 6 Transaction Format
   Owners: Daira-Emma Hopwood <daira@jacaranda.org>
           Jack Grigg <thestr4d@gmail.com>
           Sean Bowe <ewillbefull@gmail.com>
@@ -11,7 +11,7 @@
   Original-Authors: Greg Pfeil
                     Deirdre Connolly
   Credits: Ying Tong Lai
-  Status: Draft
+  Status: Withdrawn
   Category: Consensus
   Created: 2023-04-18
   License: MIT
@@ -35,6 +35,10 @@ The character § is used when referring to sections of the Zcash Protocol Specif
 Abstract
 ========
 
+.. warning::
+    This ZIP has been obsoleted by ZIP 248 [#zip-0248]_, and will not be deployed. Transaction
+    version number 6 is now defined by ZIP 248.
+
 This proposal defines a new Zcash peer-to-peer transaction format, which supports the
 changes being deployed in Network Upgrade 7 [#draft-arya-deploy-nu7]_. It follows the same design
 pattern as the v5 transaction format [#zip-0225]_.
@@ -46,7 +50,7 @@ Motivation
 The OrchardZSA protocol requires serialized data elements that are distinct from
 any previous Zcash transaction. Since ZIP 244 was activated in NU5, the
 v5 and later serialized transaction formats are not consensus-critical.
-Thus, this ZIP defines format that can easily accommodate future extensions,
+Thus, this ZIP defines a format that can easily accommodate future extensions,
 where elements or a given pool are kept separate.
 
 
@@ -720,5 +724,5 @@ References
 .. [#zip-0301] `ZIP 301: Zcash Stratum Protocol <zip-0301.rst>`_
 .. [#zip-2002-motivation] `ZIP 231: Explicit Fees — Motivation <zip-2002.rst#motivation>`_
 .. [#zip-2005] `ZIP 2005: Quantum Recoverability <zip-2005.md>`_
-.. [#zip-2005-security-analysis] `ZIP 2005: Quantum Recoverability — Security Analysis <zip-2005.md#security-analysis>`_
+.. [#zip-2005-security-analysis] `ZIP 2005: Quantum Recoverability — Security Analysis <zip-2005.md#securityanalysis>`_
 .. [#draft-arya-deploy-nu7] `draft-arya-deploy-nu7: Deployment of the NU7 Network Upgrade <draft-arya-deploy-nu7.md>`_

--- a/zips/zip-0230.rst
+++ b/zips/zip-0230.rst
@@ -39,6 +39,11 @@ Abstract
     This ZIP has been obsoleted by ZIP 248 [#zip-0248]_, and will not be deployed. Transaction
     version number 6 is now defined by ZIP 248.
 
+    Occurrences of the note plaintext lead byte constant it introduced (originally $\mathtt{0x03}$)
+    have been changed to "{{LEADBYTE}}", to clarify that this ZIP does not reserve that lead byte
+    value, and to avoid confusion with the different specification of lead byte $\mathtt{0x03}$ in
+    ZIP 2005 [#zip-2005]_.
+
 This proposal defines a new Zcash peer-to-peer transaction format, which supports the
 changes being deployed in Network Upgrade 7 [#draft-arya-deploy-nu7]_. It follows the same design
 pattern as the v5 transaction format [#zip-0225]_.
@@ -491,11 +496,11 @@ An issuance note description, ``IssueNoteDescription`` contains the following fi
 Note Plaintexts
 ---------------
 
-New note plaintext formats using lead byte $\mathtt{0x03}$ are introduced for
+New note plaintext formats using lead byte {{LEADBYTE}} are introduced for
 Sapling and Orchard, in order to support memo bundles and (for Orchard) ZSAs and
 quantum recoverability.
 
-The $\mathsf{leadByte}$ MUST be $\mathtt{0x03}$ for all note plaintexts in v6
+The $\mathsf{leadByte}$ MUST be {{LEADBYTE}} for all note plaintexts in v6
 transactions.
 
 Sapling Note Plaintext
@@ -550,8 +555,8 @@ The encodings of $\mathsf{d}$, $\mathsf{v}$, and $\mathsf{rseed}$ remain unchang
 Non-normative note: The *use* of the $\mathsf{rseed}$ in Orchard note decryption
 changes, but its type and encoding do not.
 
-Rationale for requiring the lead byte to be 0x03 in v6
-``````````````````````````````````````````````````````
+Rationale for requiring the lead byte to be {{LEADBYTE}} in v6
+``````````````````````````````````````````````````````````````
 
 It was decided to synchronize the changes to note encryption required for
 quantum recoverability, ZSA support, and memo bundles with a change to the
@@ -636,7 +641,7 @@ Support for receiving funds in v6 transactions
 
 Zcash wallets MUST support parsing and processing v6 transactions by the time
 they are allowed on the network (scheduled for NU7 activation). This includes
-detecting and decrypting lead-byte $\mathtt{0x03}$ note plaintexts and memo
+detecting and decrypting lead-byte {{LEADBYTE}} note plaintexts and memo
 bundles.
 
 The necessary changes to note decryption are specified in ZIP 231 [#zip-0231]_,
@@ -652,7 +657,7 @@ once that support is added.
 Rationale for being ready to receive v6 transactions at their activation
 ````````````````````````````````````````````````````````````````````````
 
-Note plaintexts with lead byte $\mathtt{0x03}$, which are required for Orchard
+Note plaintexts with lead byte {{LEADBYTE}}, which are required for Orchard
 notes in v6 transactions, can be sent to any Orchard address.
 
 These notes use a different computation of $\mathsf{rcm}$ and $\text{ψ}$ from
@@ -664,7 +669,7 @@ attempting to non-conformantly use the note decryption algorithm for lead byte
 $\mathtt{0x02}$ would compute a different note commitment $\mathsf{cm}_x$ and
 would reject the note.
 
-If wallets do not support v6 transactions and lead-byte $\mathtt{0x03}$ note
+If wallets do not support v6 transactions and lead-byte {{LEADBYTE}} note
 decryption immediately, then funds may be sent to them that they cannot receive.
 This affects both the existing Orchard functionality, and receiving non-native
 ZSA assets.

--- a/zips/zip-0231.md
+++ b/zips/zip-0231.md
@@ -487,7 +487,7 @@ In § 5.5 ‘Encodings of Note Plaintexts and Memo Fields’ [^protocol-notepten
     >
     > $\begin{array}{|c|c|c|c|c|} \hline \raisebox{0.6ex}{\mathstrut} \text{8-bit } \mathsf{leadByte} & \text{88-bit } \mathsf{d} & \text{64-bit } \mathsf{v} & \text{256-bit } \mathsf{rseed} & \text{32-byte } \mathsf{K^{memo}} \\\hline \end{array}$
     >
-    > * A byte 0x03, indicating this version of the encoding of a v6-onward
+    > * A byte {{MBLEADBYTE}}, indicating this version of the encoding of a v6-onward
     >   Sapling or Orchard note plaintext.
     > * 11 bytes specifying $\mathsf{d}$.
     > * 8 bytes specifying $\mathsf{v}$.
@@ -582,6 +582,11 @@ synchronization.
 ## Interaction with ZIP 302 [^zip-0302]
 
 TBD
+
+## Note plaintext lead byte assignment
+
+The lead byte to be used for this proposal, denoted as {{MBLEADBYTE}} above, has
+not yet been assigned.
 
 
 # Rationale

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -582,11 +582,11 @@ with
 > $\mathsf{ZIP2005ActivationHeight}$ specifies the first block height at which
 > recoverable note plaintexts with lead byte $\mathtt{0x03}$ are allowed to
 > occur in Orchard outputs. Orchard note plaintexts sent to *wallet-internal*
-> addresses SHOULD use lead byte $\mathtt{0x03}$ starting from this height.
-> Orchard note plaintexts in v5 transactions sent to *external* addresses
-> SHOULD use lead byte $\mathtt{0x02}$ until wallet support for receiving note
-> plaintexts with lead byte $\mathtt{0x03}$ is widespread in the Zcash
-> ecosystem.
+> addresses, and dummy note plaintexts, SHOULD use lead byte $\mathtt{0x03}$
+> starting from this height. Orchard note plaintexts in v5 transactions sent
+> to *external* addresses SHOULD use lead byte $\mathtt{0x02}$ until wallet
+> support for receiving note plaintexts with lead byte $\mathtt{0x03}$ is
+> widespread in the Zcash ecosystem.
 >
 > In other cases, senders SHOULD choose the highest note plaintext lead byte
 > allowed according to $\mathsf{allowedLeadBytes}.$
@@ -821,6 +821,10 @@ Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 
 and use $\mathsf{g}\star_{\mathsf{d}}$, $\mathsf{pk}\star_{\mathsf{d}}$,
 in the inputs to $\mathsf{NoteCommit^{Orchard}}$.
+
+Per § 3.2.1, use $\mathsf{leadByte} = \mathtt{0x03}$ starting from
+$\mathsf{ZIP2005ActivationHeight}$. The choice is operationally irrelevant
+for dummy notes, since their plaintexts cannot be decrypted.
 
 #### § 4.20.2 and § 4.20.3 ‘Decryption using an Incoming/Full Viewing Key (Sapling and Orchard)’
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -737,18 +737,15 @@ Add the following notes:
 
 Add after the definition of $\mathsf{leadByte}$:
 
-> Define $\mathsf{H^{rcm,Sapling}_{rseed}}(\_, \_) = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big)$
+> Define $\mathsf{H^{esk,Sapling}_{rseed}}(\_) = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}])\kern-0.1em\big)$.
 >
-> Define $\mathsf{H^{esk,Sapling}_{rseed}}(\_, \_) = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}])\kern-0.1em\big)$.
->
-> ($\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{esk,Sapling}}$ intentionally
-> take arguments that are unused.)
+> ($\mathsf{H^{esk,Sapling}}$ intentionally takes an argument that is unused.)
 
 Replace the lines deriving $\mathsf{rcm}$ and $\mathsf{esk}$ with
 
-> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot)$
+> Derive $\mathsf{rcm} = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big)$
 > 
-> Derive $\mathsf{esk} = \mathsf{H^{esk,Sapling}_{rseed}}(\bot, \bot)$
+> Derive $\mathsf{esk} = \mathsf{H^{esk,Sapling}_{rseed}}(\bot)$
 
 #### § 4.7.3 ‘Sending Notes (Orchard)’
 
@@ -790,14 +787,9 @@ with
 
 #### § 4.8.2 ‘Dummy Notes (Sapling)’
 
-Add
-
-> Let $\mathsf{H^{rcm,Sapling}}$ be as defined in
-> § 4.7.2 ‘Sending Notes (Sapling)’.
-
 Replace the line deriving $\mathsf{rcm}$ with
 
-> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot)$
+> Derive $\mathsf{rcm} = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big)$
 
 #### § 4.8.3 ‘Dummy Notes (Orchard)’
 
@@ -825,8 +817,7 @@ in the inputs to $\mathsf{NoteCommit^{Orchard}}$.
 
 For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
 
-> Let $\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{esk,Sapling}}$
-> be as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
+> Let $\mathsf{H^{esk,Sapling}}$ be as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
 >
 > Let $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{esk,Orchard}}$,
 > and $\mathsf{H^{\text{ψ},Orchard}}$ be as defined in
@@ -880,9 +871,9 @@ with
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot),&\!\!\!\text{if Sapling and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
+>                    \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Sapling} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x03}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -890,7 +881,7 @@ The order of operations has to be altered because the derivation of
 $\mathsf{rcm}$ can depend on $\mathsf{g_d}$ and $\mathsf{pk_d}$.
 The definitions of $\mathsf{pre\_rcm}$ and $\mathsf{pre\_esk}$ are moved into
 § 4.7.2 ‘Sending Notes (Sapling)’ and § 4.7.3 ‘Sending Notes (Orchard)’ which
-define $\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{rcm,Orchard}}$ respectively.
+define $\mathsf{H^{rcm,Orchard}}$.
 
 For § 4.20.3, replace
 
@@ -908,9 +899,9 @@ with
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot),&\!\!\!\text{if Sapling and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
+>                    \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Sapling} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x03}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1275,8 +1275,15 @@ will need to use complete curve additions to implement Sinsemilla.
 In order to adapt this argument to the quantum setting, we need to consider
 *collapsing* hash functions as defined in [^Unruh2015] [^Unruh2016].
 
-TODO: does $\mathsf{Extract}_{\mathbb{P}}$ cause any difficulty for lifting
-to QROM?
+$\mathsf{Extract}_{\mathbb{P}}$ does not interfere with the QROM lift:
+it is a deterministic 2-to-1 map on non-identity Pallas points
+(sending $P$ and $-P$ to the same $x$-coordinate) and does not query
+$\mathsf{H^{rcm}}$ or any other random oracle, so it composes with the
+underlying random oracle the same way classically and quantumly. The
+factor of 2 from the 2-to-1 reduction is already absorbed into the
+break-probability bound (each $\mathsf{cm}_x$ has exactly two valid
+$\mathsf{cm}$ values, hence exactly two valid $\mathsf{rcm}$ values, as
+stated above).
 
 By the argument in [^Bernstein2009], the best known *generic* quantum
 attack on a hash function is simply the classical attack of [^vOW1999].

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1130,19 +1130,20 @@ $\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \ma
 
 ### Informal security argument for binding of note commitments
 
-We can view the output of $\mathsf{NoteCommit_{rcm}}(\mathsf{noterepr})$
+We can view the output of $\mathsf{NoteCommit_{rcm}}$ for
+$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
 as the point addition of a randomization term
 $[\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
-and some other function of $\mathsf{rseed}$, $\mathsf{leadByte}$, and
-$\mathsf{noterepr}$.
+and some other function of $\mathsf{notetuple}$.
 
 Without loss of generality, we can write that function as
-$[\mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
+$[\mathsf{f}(\mathsf{notetuple})]\, \mathcal{R}$,
 by expanding each of the Sinemilla bases
 $\mathcal{C}_j = \mathcal{Q}(D) \text{ or } \mathcal{S}(j)$ used by
 [$\mathsf{HashToSinsimillaPoint}$](https://zips.z.cash/protocol/protocol.pdf#concretesinsemillahash)
 as $\mathcal{C}_j = [c_j]\, \mathcal{R}$ for some $c_j$. That is,
-$$\mathsf{NoteCommit_{rcm}}(\mathsf{noterepr}) = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
+the note commitment for $\mathsf{notetuple}$ is
+$$[\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{notetuple})]\, \mathcal{R}.$$
 
 We will model $\mathsf{H^{rcm}}$ as a random oracle independent of $\mathsf{f}$ with
 uniform output on $\mathbb{F}_{r_{\mathbb{P}}}.$ This is reasonable because
@@ -1167,11 +1168,11 @@ Pallas curve.
 > $r_{\mathbb{P}} \approx 2^{254}$ cannot introduce a problem.
 
 For each $\mathsf{H^{rcm}}$ oracle query the adversary chooses
-$\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}$
+$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
 and obtains a "random"
 $\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$.
 
-We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R})$.
+We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{notetuple})]\, \mathcal{R})$.
 
 Over all Pallas curve points $P$, the number of outputs of
 $\mathsf{Extract}_{\mathbb{P}}(P)$ is $(\mathbb{F}_{r_\mathbb{P}} + 1)/2 \approx 2^{253}$ —
@@ -1183,8 +1184,8 @@ zero point $\mathcal{O}_{\mathbb{P}}$ which is mapped to $0$.
 > negligible effect.
 
 There are two values of $\mathsf{cm}$ that match $\mathsf{cm}_x$ in their $x$-coordinate.
-Because the output of $\mathsf{NoteCommit_{rcm}}(\mathsf{noterepr})$ is
-of the form $\mathsf{cm} = F(\mathsf{noterepr}) + [\mathsf{rcm}]\, \mathcal{R}$,
+Because the output of $\mathsf{NoteCommit_{rcm}}$ for $\mathsf{notetuple}$ is
+of the form $\mathsf{cm} = [\mathsf{f}(\mathsf{notetuple}) + \mathsf{rcm}]\, \mathcal{R}$,
 for any given note we have exactly two values of $\mathsf{rcm}$ that will pass
 the commitment check.
 
@@ -1239,7 +1240,8 @@ uses (they can choose to attack either, or both simultaneously):
 The above security argument means that provided we also check the uses of
 $\mathsf{H^{rcm}}$ and $\mathsf{H}^{\text{ψ}}$ in the post-quantum
 [Recovery Statement](#proposedrecoverystatement), Orchard note commitments
-can be considered binding on all of the note fields.
+can be considered binding on the note tuple
+$(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$.
 
 Note that the argument associated with
 [Theorem 5.4.4](https://zips.z.cash/protocol/protocol.pdf#thmsinsemillaex)
@@ -1571,9 +1573,9 @@ $$\mathsf{Extract}_{\mathbb{P}}\Big(
 We model $\mathsf{H^{rcm}}$ as a random oracle with output uniform on
 $\mathbb{F}_{r_{\mathbb{P}}}$. The functions $\mathsf{f}$,
 $\mathsf{H}^{\text{ψ}}$, and $\mathsf{PRF^{nf}}$ are deterministic
-functions of $\mathsf{notetuple}$ that **do not query $\mathsf{H^{rcm}}$**:
-$\mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$ is the
-Sinsemilla-base lift; $\mathsf{H}^{\text{ψ}}$ and $\mathsf{PRF^{nf}}$ are
+functions of $\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+that **do not query $\mathsf{H^{rcm}}$**: $\mathsf{f}(\mathsf{notetuple})$
+is the Sinsemilla-base lift; $\mathsf{H}^{\text{ψ}}$ and $\mathsf{PRF^{nf}}$ are
 conventional hash functions.
 
 > The non-querying constraint rules out trivializing instantiations such
@@ -1598,8 +1600,8 @@ small.
 
 We give a reduction-based argument that any classical adversary
 $\mathcal{A}$ in the Random Oracle Model attempting to find two valid
-[Recovery Statement](#proposedrecoverystatement) witnesses for distinct
-underlying notes that have colliding nullifiers, succeeds with probability at most
+[Recovery Statement](#proposedrecoverystatement) witnesses with distinct
+note tuples that have colliding nullifiers, succeeds with probability at most
 $\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} + \varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$,
 where $q_{\mathsf{rcm}}$ is the number of queries $\mathcal{A}$ makes
 to $\mathsf{H^{rcm}}$, and $q_{\mathsf{kb}}$ is as defined above.
@@ -1633,11 +1635,11 @@ $\mathsf{notetuple}_i$ by the $\mathsf{ivk}$-pinning lemma; and
 $\text{ρ}_i$ is a field of $\mathsf{notetuple}_i$.
 
 The argument here covers nullifier-binding — it argues that $\mathsf{nf}$
-binds the underlying note ($\mathsf{noterepr}$, plus $\mathsf{rseed}$ and
-$\mathsf{leadByte}$) under $\mathsf{H^{rcm}}$ modelled as a random oracle
+binds the note tuple $(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+under $\mathsf{H^{rcm}}$ modelled as a random oracle
 and the [key-binding theorem](#thm-key-binding-rom).
 
-**Theorem (distinct-note Spendability, classical ROM).** <a id="thm-spendability"></a>
+**Theorem (distinct-notetuple Spendability, classical ROM).** <a id="thm-spendability"></a>
 Let $\mathcal{A}$ be a classical adversary with oracle access to
 $\mathsf{H^{rcm}}$ having output uniform on $\mathbb{F}_{r_{\mathbb{P}}}$,
 making at most $q_{\mathsf{rcm}}$ oracle queries. The *Spendability-collision*
@@ -1648,7 +1650,7 @@ satisfying:
 :   both witnesses satisfy the
     [Proposed Recovery Statement](#proposedrecoverystatement).
 
-<a id="thm-spendability-distinct"></a>**Distinct underlying notes**
+<a id="thm-spendability-distinct"></a>**Distinct note tuples**
 :   the $\mathsf{H^{rcm}}$-input tuples
     $\mathsf{notetuple}_i := (\mathsf{rseed}_i, \mathsf{leadByte}_i, \mathsf{noterepr}_i)$
     satisfy $\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$.
@@ -1683,7 +1685,7 @@ $\pm$-equivalence event.
 $\mathcal{A}$ makes at most $q_{\mathsf{rcm}}$ queries to
 $\mathsf{H^{rcm}}$ before outputting $(w_1, w_2)$ satisfying
 [**Validity of witnesses**](#thm-spendability-validity),
-[**Distinct underlying notes**](#thm-spendability-distinct), and
+[**Distinct note tuples**](#thm-spendability-distinct), and
 [**Colliding nullifiers**](#thm-spendability-collide). The probability
 that $(w_1, w_2)$ contains a key-binding break is at most
 $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$; condition on
@@ -1709,7 +1711,7 @@ $x$-coordinate $0$, the collision $\mathsf{nf}_1 = \mathsf{nf}_2$
 holds iff $F_1 \equiv \pm F_2 \pmod{r_{\mathbb{P}}}$.
 
 *Independence claim per pair.*
-By [**Distinct underlying notes**](#thm-spendability-distinct),
+By [**Distinct note tuples**](#thm-spendability-distinct),
 $\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$, so the
 $\mathsf{H^{rcm}}$ outputs at $\mathsf{notetuple}_1, \mathsf{notetuple}_2$
 are independent uniform on $\mathbb{F}_{r_{\mathbb{P}}}$. The

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1422,12 +1422,22 @@ $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3\, q_{\math
 **Proof sketch.**
 
 *Algebraic setup.*
-$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk})$ is a Sinsemilla
-short commitment, of the form
-$\mathsf{ShortHash}\big([h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk}] \cdot \mathcal{S}\big)$
-for a Pedersen-like deterministic hash $h$ and a Sinsemilla base
-$\mathcal{S}$ (TODO: verify the exact form of $h$ and $\mathcal{S}$
-from § 5.4.1.10 'Sinsemilla Commit Function'). Domain separation in
+By § 5.4.1.10 “Sinsemilla commitments”,
+$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) =
+\mathsf{Extract}_{\mathbb{P}}\big(M' + [\mathsf{rivk}]\, \mathcal{S}\big)$,
+where
+$\mathcal{S} := \mathsf{GroupHash}^{\mathbb{P}}(\texttt{“z.cash:Orchard-CommitIvk-r”}, \texttt{“”})$
+is the rivk-randomization base and
+$M' := \mathsf{SinsemillaHashToPoint}\big(\texttt{“z.cash:Orchard-CommitIvk-M”},\,
+\mathsf{LEBSP}(\mathsf{ak}) \,\Vert\, \mathsf{LEBSP}(\mathsf{nk})\big)$
+(see § 5.4.1.10 for the exact bit-sequence encoding).
+By expanding the Sinsemilla bases used inside $\mathsf{SinsemillaHashToPoint}$
+as scalar multiples of $\mathcal{S}$, without loss of generality we have
+$M' = [h(\mathsf{ak}, \mathsf{nk})]\, \mathcal{S}$ for a Pedersen-like
+deterministic scalar hash $h$. Therefore
+$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) =
+\mathsf{Extract}_{\mathbb{P}}\big([h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk}]\, \mathcal{S}\big)$.
+Domain separation in
 the protocol's BLAKE2b instantiations ensures $h$ does not query
 $\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$,
 $\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, or $\mathsf{H^{nk}}$:
@@ -1528,8 +1538,6 @@ union-bounding over the at most $\binom{q_{\mathsf{kb}}}{2}$ pairs
 of distinct witnesses,
 $$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3 q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2 r_{\mathbb{P}}}.$$
 
-(TODO: verify the exact form of $h$ and $\mathcal{S}$ from
-§ 5.4.1.10 'Sinsemilla Commit Function'.)
 
 ## Security argument for Spendability
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -48,8 +48,7 @@ protocol after the deployment of ZSAs.
 
 The terms "recoverable note" and "recoverable note plaintext" refer to a
 note or note plaintext that was created according to this proposal. As
-initially deployed, these are necessarily Orchard or OrchardZSA notes or
-note plaintexts.
+initially deployed, these are necessarily Orchard notes or note plaintexts.
 
 The term "Recovery Protocol" refers to a potential new shielded protocol
 that would allow recovery of funds held in recoverable Orchard[ZSA] notes.
@@ -170,12 +169,9 @@ as changes necessary to implement Memo Bundles [^zip-0231] and/or ZSAs [^zip-022
 
 This subsection and the flow diagram below are non-normative.
 
-The Quantum Recoverability proposal was originally designed to be
-deployed alongside ZSAs [^zip-0226] [^zip-0227] and memo bundles
-[^zip-0231]. Whether or not that is still the case, we retain the
-same approach of defining a new note plaintext format, with lead byte
-$\mathtt{0x03}.$ The $\mathsf{pre\_rcm}$ value is computed differently
-for this new format, by including all of the note fields in
+This proposal defines a new note plaintext format for Orchard notes,
+with lead byte $\mathtt{0x03}.$ The $\mathsf{pre\_rcm}$ value is computed
+differently for this new format, by including all of the note fields in
 $\mathsf{pre\_rcm}$. This means that an adversary constrained to treat
 the PRF used to derive $\mathsf{rcm}$ from $\mathsf{pre\_rcm}$ as a
 random oracle, could not vary any note field without producing a
@@ -306,17 +302,6 @@ graph BT
 ```
 
 # Specification
-
-## Usage with Zcash Shielded Assets
-
-This proposal has been designed to activate either prior to, or at the same
-time as, any possible activation of ZSAs [^zip-0226] [^zip-0227].
-
-Whether or not ZSAs are deployed at the same time, the proposal anticipates that an
-$\mathsf{AssetBase}$ field will be added to note plaintexts with lead byte $\mathtt{0x03}$.
-This field will be set to the 32-byte constant
-$\mathsf{LEBS2OSP}_{\ell_{\mathbb{P}}}​​\big(\mathsf{repr}_{\mathbb{P}​}(\mathcal{V}^{\mathsf{Orchard}})\kern-0.1em\big)$
-as long as ZSAs are not deployed.
 
 ## Usage with FROST
 
@@ -527,13 +512,17 @@ from the seed phrase (with or without SLIP 39 Shamir backup [^slip-0039]).
 A deployment that does not use ZIP 32 is responsible for the security of
 its own backup arrangements.
 
+## Usage with other proposals requiring note plaintext format changes
+
+This proposal was originally designed to be deployed alongside ZSAs [^zip-0226]
+[^zip-0227] and memo bundles [^zip-0231], which also defined a new note
+plaintext format. Since this proposal now defines lead byte $\mathtt{0x03}$,
+those proposals will need to use a new lead byte value or values.
+
 ## Specification Updates
 
 This is written as a set of changes to version 2025.6.2 of the protocol
-specification, and to the contents of ZIPs as of February 2026. If other
-changes for v6 transactions (memo bundles [^zip-0231], ZSAs [^zip-0226]
-[^zip-0227]) are deployed simultaneously, these changes will need to be
-merged with theirs.
+specification, and to the contents of ZIPs as of May 2026.
 
 ### Changes to the Protocol Specification
 
@@ -550,17 +539,51 @@ Replace the paragraph
 
 with
 
+> Let the constant $\mathsf{ZIP2005ActivationHeight}$ be as defined in
+> [[ZIP 2005, Deployment]](#deployment).
+>
 > Define $\mathsf{allowedLeadBytes^{protocol}}(\mathsf{height}, \mathsf{txVersion}) =$
 > $\hspace{2em} \begin{cases}
 >   \{ \mathtt{0x01} \},&\!\!\!\text{if } \mathsf{height} < \mathsf{CanopyActivationHeight} \\
 >   \{ \mathtt{0x01}, \mathtt{0x02} \},&\!\!\!\text{if } \mathsf{CanopyActivationHeight} \leq \mathsf{height} < \mathsf{CanopyActivationHeight} + \mathsf{ZIP212GracePeriod} \\
->   \{ \mathtt{0x02} \},&\!\!\!\text{if } \mathsf{CanopyActivationHeight} + \mathsf{ZIP212GracePeriod} \leq \mathsf{height} \text{ and } \mathsf{txVersion} < 6 \\
+>   \{ \mathtt{0x02} \},&\!\!\!\text{if } \mathsf{CanopyActivationHeight} + \mathsf{ZIP212GracePeriod} \leq \mathsf{height} \text{ and } \\
+>                       &\;\; (\mathsf{height} < \mathsf{ZIP2005ActivationHeight} \text{ or } \mathsf{protocol} \neq \mathsf{Orchard}) \\
+>   \{ \mathtt{0x02}, \mathtt{0x03} \},&\!\!\!\text{if } \mathsf{ZIP2005ActivationHeight} \leq \mathsf{height} \text{ and } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{txVersion} < 6 \\
 >   \{ \mathtt{0x03} \},&\!\!\!\text{otherwise.}
 > \end{cases}$
 
-and delete "or $\mathsf{txVersion}$" from "It is intentional that the
-definition of $\mathsf{allowedLeadBytes}$ does not currently depend on
-$\mathsf{protocol}$ or $\mathsf{txVersion}$."
+Replace
+
+> Senders SHOULD choose the highest note plaintext lead byte allowed under this
+> condition.
+
+with
+
+> $\mathsf{ZIP2005ActivationHeight}$ specifies the first block height at which
+> recoverable note plaintexts with lead byte $\mathtt{0x03}$ are allowed to
+> occur in Orchard outputs. Orchard note plaintexts sent to *wallet-internal*
+> addresses SHOULD use lead byte $\mathtt{0x03}$ starting from this height.
+> Orchard note plaintexts in v5 transactions sent to *external* addresses
+> SHOULD use lead byte $\mathtt{0x02}$ until wallet support for receiving note
+> plaintexts with lead byte $\mathtt{0x03}$ is widespread in the Zcash
+> ecosystem.
+>
+> In other cases, senders SHOULD choose the highest note plaintext lead byte
+> allowed according to $\mathsf{allowedLeadBytes}.$
+
+Delete the non-normative note:
+
+> * It is intentional that the definition of $\mathsf{allowedLeadBytes}$ does
+>   not currently depend on $\mathsf{protocol}$ or $\mathsf{txVersion}.$ It
+>   might do so in future.
+
+Add the non-normative note:
+
+> * For Orchard note plaintexts sent in v6 transactions [^zip-0248], the only
+>   allowed lead byte value is $\mathtt{0x03}.$
+
+It is assumed for these changes that v6 transactions will not activate before
+$\mathsf{ZIP2005ActivationHeight}$.
 
 #### § 4.1.2 ‘Pseudo Random Functions’
 
@@ -1760,24 +1783,27 @@ have not yet been verified.
 TBD: explain that such attacks can break Balance and Spendability, including
 Spendability for transactions after switching to the Recovery Protocol.
 
-Note that with [Deployment](#deployment) option 2 (deploying at the same time as
-v6 transactions), we can identify the precise set of note commitments for
-recoverable (lead byte $\mathtt{0x03}$) Orchard notes, since they are exactly
-the commitments for Orchard outputs of v6 transactions. However, we cannot
-identify the precise set of nullifiers for recoverable notes: an Orchard action
-in a v6 transaction could be spending either a recoverable or non-recoverable
-note, and their nullifier sets are indistinguishable.
+Note that we can precisely identify the set of note commitments for recoverable
+Orchard notes in v6 transactions, even if we cannot decrypt them, since only
+recoverable notes are allowed in that case. However, Orchard notes in v5
+transactions after $\mathsf{ZIP2005ActivationHeight}$ could be either
+recoverable or not.
+
+We cannot identify the precise set of nullifiers for recoverable notes: an
+Orchard action in a v6 transaction could be spending either a recoverable or
+non-recoverable note, and their nullifier sets are indistinguishable.
 
 On the other hand, within the Recovery Statement we know that the
 note being spent is recoverable.
 
 # Deployment
 
-As far as I'm aware, all existing Zcash wallets already derive
-$(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ from a spending key
-$\mathsf{sk}$ in the way specified for the
-$\mathsf{use\_qsk} = \mathsf{false}$ case in
-§ 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents].
+Let $\mathsf{ZIP2005ActivationHeight}$ be {{TBD}}.
+
+As far as the author of this ZIP is aware, all existing Zcash wallets already
+derive $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ from a spending key
+$\mathsf{sk}$ in the way specified for the $\mathsf{use\_qsk} = \mathsf{false}$
+case in § 4.2.3 ‘Orchard Key Components’ [^protocol-orchardkeycomponents].
 
 FROST distributed key generation requires the $\mathsf{use\_qsk} = \mathsf{true}$ case.
 There is no significant existing deployment of FROST, so we can
@@ -1791,26 +1817,23 @@ doing it this way involves fewer components. This also allows us to avoid
 any security compromise and use 256-bit cryptovalues for both integrity
 and randomization, which would otherwise have been difficult.
 
-There are two options for deployment:
+Two options were considered for deployment:
 
-1. Deploy this change prior to the next network upgrade. This would
-   optimize time-to-deployment. An activation height is still needed
-   so that wallets do not start sending recoverable note plaintexts
-   before the receiving wallet can have been expected to upgrade.
+1. Deploy this change prior to the next network upgrade. This optimizes
+   time-to-deployment. An activation height is still needed, in order to
+   identify a height from which wallets must re-scan if they are missing
+   recoverable notes due to late deployment.
 2. Deploy this change at the same time as the next network upgrade (NU7),
    at the same time as v6 transactions.
 
-With either option, it is proposed to enforce this change with v6
-transactions. That is, every Orchard output of a v6-onward transaction
-will be a recoverable note. This implies that when the pre-quantum
-protocol is turned off, v5 and earlier outputs will no longer be spendable.
+With either option, it is proposed to enforce this change with v6 transactions.
+That is, every Orchard output of a v6-onward transaction will be a recoverable
+note.
 
-Deploying via a transaction-version bump (rather than as a soft addition
-within v5) reduces the risk of the kind of difficulties that occurred with
-[ZIP 212](https://zips.z.cash/zip-0212), where some wallets were following
-the old protocol after the Canopy upgrade and sending non-conformant note
-plaintexts. If memo bundles or ZSAs are deployed simultaneously, those
-changes share the same version-bump signal.
+This ZIP currently reflects the first option. The risk of some wallets
+not having deployed support for receiving the new note plaintext format
+is mitigated by initially only using that format for note plaintexts sent
+to wallet-internal addresses.
 
 When a compliant wallet receives an Orchard note with lead byte
 $\mathtt{0x02}$, the associated funds are not recoverable and need to be
@@ -1870,6 +1893,8 @@ manipulate the note selection algorithm to some extent.
 [^zip-0230]: [ZIP 230: Version 6 Transaction Format](zip-0230.rst)
 
 [^zip-0231]: [ZIP 231: Memo Bundles](zip-0231.rst)
+
+[^zip-0248]: [ZIP 248: Extensible Transaction Format (PR: zcash/zips#1156)](https://github.com/zcash/zips/pull/1156)
 
 [^zip-0312]: [ZIP 312: FROST for Spend Authorization Multisignatures](zip-0312.rst)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -2088,31 +2088,31 @@ manipulate the note selection algorithm to some extent.
 
 [^pq-zcash]: Post-Quantum Zcash ([video](https://www.youtube.com/watch?v=T2B5f297d-Y), [slides](https://docs.google.com/presentation/d/1BHBiSOEO5zt40KWBbRXVMGIIuAcT2hfPWZQ3pT_8tm8/edit?slide=id.g335164f3026_0_113#slide=id.g335164f3026_0_113)). Presentation by Daira-Emma Hopwood at ZconVI.
 
-[^BHT1997]: [Quantum Algorithm for the Collision Problem. Gilles Brassard, Peter Høyer, and Alain Tapp.](https://arxiv.org/abs/quant-ph/9705002)
+[^BHT1997]: [Quantum Algorithm for the Collision Problem. Gilles Brassard, Peter Høyer, and Alain Tapp.](https://arxiv.org/abs/quant-ph/9705002). Also published in LATIN 1998, LNCS vol. 1380, pp. 163–169.
 
 [^vOW1999]: [Parallel collision search with cryptanalytic applications. Paul C. van Oorschot and Michael Wiener.](https://link.springer.com/article/10.1007/PL00003816)
 
-[^Bernstein2009]: [Cost analysis of hash collisions: Will quantum computers make SHARCS obsolete? Daniel J. Bernstein.](https://cr.yp.to/hash/collisioncost-20090517.pdf)
+[^Bernstein2009]: [Cost analysis of hash collisions: Will quantum computers make SHARCS obsolete? Daniel J. Bernstein.](https://cr.yp.to/hash/collisioncost-20090517.pdf). Presented at SHARCS 2009.
 
 [^BLAKE3]: [BLAKE3: One Function, Fast Everywhere. Jack O'Connor, Jean-Philippe Aumasson, Samuel Neves, and Zooko Wilcox, 2020.](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) See § 2.1.2 for the `derive_key` mode.
 
-[^Maurer2002]: [Indistinguishability of Random Systems. Ueli Maurer.](https://crypto.ethz.ch/publications/files/Maurer02.pdf) Advances in Cryptology — EUROCRYPT 2002, LNCS vol. 2332, pp. 110–132.
+[^Maurer2002]: [Indistinguishability of Random Systems. Ueli Maurer.](https://crypto.ethz.ch/publications/files/Maurer02.pdf). Also published in Advances in Cryptology — EUROCRYPT 2002, LNCS vol. 2332, pp. 110–132.
 
-[^Unruh2015]: [Computationally binding quantum commitments. Dominique Unruh.](https://eprint.iacr.org/2015/361)
+[^Unruh2015]: [Computationally binding quantum commitments. Dominique Unruh.](https://eprint.iacr.org/2015/361). Also published in EUROCRYPT 2016, LNCS vol. 9666.
 
-[^Unruh2016]: [Collapse-binding quantum commitments without random oracles. Dominique Unruh.](https://eprint.iacr.org/2016/508)
+[^Unruh2016]: [Collapse-binding quantum commitments without random oracles. Dominique Unruh.](https://eprint.iacr.org/2016/508). Also published in ASIACRYPT 2016, LNCS vol. 10032.
 
-[^CBHSU2017]: [Post-quantum security of the sponge construction. Jan Czajkowski, Leon Groot Bruinderink, Andreas Hülsing, Christian Schaffner, and Dominique Unruh.](https://eprint.iacr.org/2017/771)
+[^CBHSU2017]: [Post-quantum security of the sponge construction. Jan Czajkowski, Leon Groot Bruinderink, Andreas Hülsing, Christian Schaffner, and Dominique Unruh.](https://eprint.iacr.org/2017/771). Also published in PQCrypto 2018, LNCS vol. 10786.
 
-[^Fehr2018]: [Classical Proofs for the Quantum Collapsing Property of Classical Hash Functions. Serge Fehr.](https://eprint.iacr.org/2018/887)
+[^Fehr2018]: [Classical Proofs for the Quantum Collapsing Property of Classical Hash Functions. Serge Fehr.](https://eprint.iacr.org/2018/887). Also published in TCC 2018, LNCS vol. 11240, pp. 315–338.
 
-[^Zhandry2018]: [How to Record Quantum Queries, and Applications to Quantum Indifferentiability. Mark Zhandry.](https://eprint.iacr.org/2018/276)
+[^Zhandry2018]: [How to Record Quantum Queries, and Applications to Quantum Indifferentiability. Mark Zhandry.](https://eprint.iacr.org/2018/276). Also published in CRYPTO 2019, LNCS vol. 11693.
 
-[^CFHL2021]: [On the Compressed-Oracle Technique, and Post-Quantum Security of Proofs of Sequential Work. Kai-Min Chung, Serge Fehr, Yu-Hsuan Huang, and Tai-Ning Liao.](https://eprint.iacr.org/2020/1305)
+[^CFHL2021]: [On the Compressed-Oracle Technique, and Post-Quantum Security of Proofs of Sequential Work. Kai-Min Chung, Serge Fehr, Yu-Hsuan Huang, and Tai-Ning Liao.](https://eprint.iacr.org/2020/1305). Also published in EUROCRYPT 2021, LNCS vol. 12826.
 
-[^CMSZ2021]: [Post-Quantum Succinct Arguments: Breaking the Quantum Rewinding Barrier. Alessandro Chiesa, Fermi Ma, Nicholas Spooner, and Mark Zhandr.](https://eprint.iacr.org/2021/334)
+[^CMSZ2021]: [Post-Quantum Succinct Arguments: Breaking the Quantum Rewinding Barrier. Alessandro Chiesa, Fermi Ma, Nicholas Spooner, and Mark Zhandr.](https://eprint.iacr.org/2021/334). Also published in FOCS 2021.
 
-[^GM2022]: [Collapseability of Tree Hashes. Aldo Gunsing and Bart Mennink.](https://eprint.iacr.org/2022/248)
+[^GM2022]: [Collapseability of Tree Hashes. Aldo Gunsing and Bart Mennink.](https://eprint.iacr.org/2022/248). Also published in PQCrypto 2020, LNCS vol. 12100, pp. 524–544.
 
 [^CDDGS2025]: [Quantum Rewinding for IOP-Based Succinct Arguments. Alessandro Chiesa, Marcel Dall'Agnol, Zijing Di, Ziyi Guan, and Nicholas Spooner.](https://eprint.iacr.org/2025/947)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -740,10 +740,15 @@ Add after the definition of $\mathsf{leadByte}$:
 > Define $\mathsf{H^{esk,Sapling}_{rseed}}(\_) = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}])\kern-0.1em\big)$.
 >
 > ($\mathsf{H^{esk,Sapling}}$ intentionally takes an argument that is unused.)
+>
+> Define $\mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte}) = \begin{cases}
+>   \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
+>   \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02}
+> \end{cases}$
 
 Replace the lines deriving $\mathsf{rcm}$ and $\mathsf{esk}$ with
 
-> Derive $\mathsf{rcm} = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big)$
+> Derive $\mathsf{rcm} = \mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte})$
 > 
 > Derive $\mathsf{esk} = \mathsf{H^{esk,Sapling}_{rseed}}(\bot)$
 
@@ -756,9 +761,10 @@ Add before "For each Action description":
 >
 > where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ})$.
 >
-> ($\mathsf{H^{rcm,Orchard}}$ is defined only for the $\mathsf{leadByte} = \mathtt{0x03}$ case; the existing
-> derivation $\mathsf{rcm} = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}}))$
-> from the protocol specification continues to apply when $\mathsf{leadByte} = \mathtt{0x02}$.)
+> Define $\mathsf{Derive\_rcm^{Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}) = \begin{cases}
+>   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
+>   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+> \end{cases}$
 >
 > Define $\mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 >
@@ -778,10 +784,7 @@ with
 
 > Derive $\mathsf{esk} = \mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}})$
 
-> Derive $\mathsf{rcm} = \begin{cases}
->   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
->   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
-> \end{cases}$
+> Derive $\mathsf{rcm} = \mathsf{Derive\_rcm^{Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ})$
 
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
@@ -789,7 +792,7 @@ with
 
 Replace the line deriving $\mathsf{rcm}$ with
 
-> Derive $\mathsf{rcm} = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big)$
+> Derive $\mathsf{rcm} = \mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte})$
 
 #### § 4.8.3 ‘Dummy Notes (Orchard)’
 
@@ -803,10 +806,7 @@ Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 > Let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$,
 > and $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$.
 >
-> Derive $\mathsf{rcm} = \begin{cases}
->   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
->   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
-> \end{cases}$
+> Derive $\mathsf{rcm} = \mathsf{Derive\_rcm^{Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ})$
 >
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
@@ -870,10 +870,8 @@ with
 > $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$ <br>
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
->                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Sapling} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x03}
+>                    \mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Sapling} \\
+>                    \mathsf{Derive\_rcm^{Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -881,7 +879,7 @@ The order of operations has to be altered because the derivation of
 $\mathsf{rcm}$ can depend on $\mathsf{g_d}$ and $\mathsf{pk_d}$.
 The definitions of $\mathsf{pre\_rcm}$ and $\mathsf{pre\_esk}$ are moved into
 § 4.7.2 ‘Sending Notes (Sapling)’ and § 4.7.3 ‘Sending Notes (Orchard)’ which
-define $\mathsf{H^{rcm,Orchard}}$.
+define $\mathsf{Derive\_rcm^{\{Sapling,Orchard\}}}$.
 
 For § 4.20.3, replace
 
@@ -898,10 +896,8 @@ with
 > $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$ <br>
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
->                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Sapling} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard} \text{ and } \mathsf{leadByte} = \mathtt{0x03}
+>                    \mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Sapling} \\
+>                    \mathsf{Derive\_rcm^{Orchard}_{rseed}}(\mathsf{leadByte}, \mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{protocol} = \mathsf{Orchard}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -1172,7 +1168,7 @@ instantiated using BLAKE2b, a conventional hash function not related to the
 Pallas curve.
 
 > The fact that $\mathsf{NoteCommit}$ has
-> $\text{ψ} = \mathsf{H}^{\text{ψ}}(\mathsf{rseed}, \text{ρ})$ as an
+> $\text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{rseed}}(\text{ρ})$ as an
 > input does not affect the analysis provided that $\mathsf{H^{rcm}}$ and
 > $\mathsf{H}^{\text{ψ}}$ can be treated as independent. In practice both
 > are defined in terms of $\mathsf{PRF^{expand}}$, but with strict domain

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -741,14 +741,14 @@ Add the following notes:
 
 Add after the definition of $\mathsf{leadByte}$:
 
-> Define $\mathsf{H^{esk,Sapling}_{rseed}}(\_) = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}])\kern-0.1em\big)$.
->
-> ($\mathsf{H^{esk,Sapling}}$ intentionally takes an argument that is unused.)
->
 > Define $\mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte}) = \begin{cases}
 >   \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
 >   \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}])\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02}
 > \end{cases}$
+>
+> Define $\mathsf{H^{esk,Sapling}_{rseed}}(\_) = \mathsf{ToScalar^{Sapling}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}])\kern-0.1em\big)$.
+>
+> ($\mathsf{H^{esk,Sapling}}$ intentionally takes an argument that is unused.)
 
 Replace the lines deriving $\mathsf{rcm}$ and $\mathsf{esk}$ with
 
@@ -794,6 +794,11 @@ with
 
 #### § 4.8.2 ‘Dummy Notes (Sapling)’
 
+Add
+
+> Let $\mathsf{Derive\_rcm^{Sapling}}$ be as defined in
+> § 4.7.2 ‘Sending Notes (Sapling)’.
+
 Replace the line deriving $\mathsf{rcm}$ with
 
 > Derive $\mathsf{rcm} = \mathsf{Derive\_rcm^{Sapling}_{rseed}}(\mathsf{leadByte})$
@@ -802,7 +807,7 @@ Replace the line deriving $\mathsf{rcm}$ with
 
 Insert before "The spend-related fields ...":
 
-> Let $\mathsf{H^{rcm,Orchard}}$ and $\mathsf{H^{\text{ψ},Orchard}}$ be
+> Let $\mathsf{Derive\_rcm^{Orchard}}$ and $\mathsf{H^{\text{ψ},Orchard}}$ be
 > as defined in § 4.7.3 ‘Sending Notes (Orchard)’.
 
 Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
@@ -821,9 +826,10 @@ in the inputs to $\mathsf{NoteCommit^{Orchard}}$.
 
 For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
 
-> Let $\mathsf{H^{esk,Sapling}}$ be as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
+> Let $\mathsf{Derive\_rcm^{Sapling}}$ and $\mathsf{H^{esk,Sapling}}$ be
+> as defined in § 4.7.2 ‘Sending Notes (Sapling)’.
 >
-> Let $\mathsf{H^{rcm,Orchard}}$, $\mathsf{H^{esk,Orchard}}$,
+> Let $\mathsf{Derive\_rcm^{Orchard}}$, $\mathsf{H^{esk,Orchard}}$,
 > and $\mathsf{H^{\text{ψ},Orchard}}$ be as defined in
 > § 4.7.3 ‘Sending Notes (Orchard)’.
 
@@ -1434,20 +1440,20 @@ $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3\, q_{\math
 
 *Algebraic setup.*
 By § 5.4.1.10 “Sinsemilla commitments”,
-$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) =
-\mathsf{Extract}_{\mathbb{P}}\big(M' + [\mathsf{rivk}]\, \mathcal{S}\big)$,
-where
-$\mathcal{S} := \mathsf{GroupHash}^{\mathbb{P}}(\texttt{“z.cash:Orchard-CommitIvk-r”}, \texttt{“”})$
-is the rivk-randomization base and
-$M' := \mathsf{SinsemillaHashToPoint}\big(\texttt{“z.cash:Orchard-CommitIvk-M”},\,
-\mathsf{LEBSP}(\mathsf{ak}) \,\Vert\, \mathsf{LEBSP}(\mathsf{nk})\big)$
-(see § 5.4.1.10 for the exact bit-sequence encoding).
+$$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) =
+\mathsf{Extract}_{\mathbb{P}}\big(M' + [\mathsf{rivk}]\, \mathcal{S}\big),$$
+where $\mathcal{S}$ is the rivk-randomization base
+$$\mathcal{S} := \mathsf{GroupHash}^{\mathbb{P}}(\texttt{“z.cash:Orchard-CommitIvk-r”}, \texttt{“”}),$$
+and
+$$M' := \mathsf{SinsemillaHashToPoint}\big(\texttt{“z.cash:Orchard-CommitIvk-M”},\;
+\mathsf{I2LEBSP}_{\ell^{\mathsf{Orchard}}_{\mathsf{base}}}(\mathsf{ak}) \,\Vert\,
+\mathsf{I2LEBSP}_{\ell^{\mathsf{Orchard}}_{\mathsf{base}}}(\mathsf{nk})\big).$$
 By expanding the Sinsemilla bases used inside $\mathsf{SinsemillaHashToPoint}$
 as scalar multiples of $\mathcal{S}$, without loss of generality we have
 $M' = [h(\mathsf{ak}, \mathsf{nk})]\, \mathcal{S}$ for a Pedersen-like
-deterministic scalar hash $h$. Therefore
-$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) =
-\mathsf{Extract}_{\mathbb{P}}\big([h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk}]\, \mathcal{S}\big)$.
+deterministic scalar hash $h$, so
+$$\mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) =
+\mathsf{Extract}_{\mathbb{P}}\big([h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk}]\, \mathcal{S}\big).$$
 Domain separation in
 the protocol's BLAKE2b instantiations ensures $h$ does not query
 $\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$,

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -272,7 +272,7 @@ graph BT
     ivk --> ivkmul
     rseed --> Hpsi[H<sup>ψ</sup>]:::func
     rho --> Hpsi
-    v([v, AssetBase]) ==> pre_rcm([pre_rcm])
+    v([#8239;v#8239;]) ==> pre_rcm([pre_rcm])
     pkd ====> pre_rcm
     gd ==> pre_rcm
     psi ===> pre_rcm
@@ -748,17 +748,12 @@ Replace the lines deriving $\mathsf{rcm}$ and $\mathsf{esk}$ with
 
 #### § 4.7.3 ‘Sending Notes (Orchard)’
 
-Add after the definition of $\mathsf{leadByte}$:
-
-> Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
-> § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
-
 Add before "For each Action description":
 
-> Define $\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star) =$
+> Define $\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}) =$
 >   $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
 >
-> where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star)$.
+> where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ})$.
 >
 > ($\mathsf{H^{rcm,Orchard}}$ is defined only for the $\mathsf{leadByte} = \mathtt{0x03}$ case; the existing
 > derivation $\mathsf{rcm} = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}}))$
@@ -773,8 +768,7 @@ The first-byte domain separator $\mathtt{0x0A}$ for $\mathsf{PRF^{expand}}$ is r
 Insert before the derivation of $\mathsf{esk}$:
 
 > Let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$,
-> $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$,
-> and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
+> and $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$.
 
 and use these in the inputs to $\mathsf{NoteCommit^{Orchard}}$.
 
@@ -785,7 +779,7 @@ with
 
 > Derive $\mathsf{rcm} = \begin{cases}
 >   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
->   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+>   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
 > \end{cases}$
 
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
@@ -803,11 +797,6 @@ Replace the line deriving $\mathsf{rcm}$ with
 
 #### § 4.8.3 ‘Dummy Notes (Orchard)’
 
-Add after the definition of $\mathsf{leadByte}$:
-
-> Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
-> § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
-
 Insert before "The spend-related fields ...":
 
 > Let $\mathsf{H^{rcm,Orchard}}$ and $\mathsf{H^{\text{ψ},Orchard}}$ be
@@ -816,26 +805,19 @@ Insert before "The spend-related fields ...":
 Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 
 > Let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$,
-> $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$,
-> and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
+> and $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$.
 >
 > Derive $\mathsf{rcm} = \begin{cases}
 >   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
->   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+>   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
 > \end{cases}$
 >
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
 and use $\mathsf{g}\star_{\mathsf{d}}$, $\mathsf{pk}\star_{\mathsf{d}}$,
-and $\mathsf{AssetBase}\kern0.05em\star$ in the inputs to
-$\mathsf{NoteCommit^{Orchard}}$.
+in the inputs to $\mathsf{NoteCommit^{Orchard}}$.
 
 #### § 4.20.2 and § 4.20.3 ‘Decryption using an Incoming/Full Viewing Key (Sapling and Orchard)’
-
-Add after the definition of $\mathsf{leadByte}$:
-
-> Let $\mathsf{AssetBase} = \mathcal{V}^{\mathsf{Orchard}}$ as defined in
-> § 5.4.8.3 ‘Homomorphic Pedersen commitments (Sapling and Orchard)’.
 
 For both § 4.20.2 and § 4.20.3, add before the decryption procedure:
 
@@ -890,13 +872,13 @@ with
 > $\hspace{2.5em}$     if $\mathsf{repr}_{\mathbb{G}}\big(\mathsf{KA.DerivePublic}(\mathsf{esk}, \mathsf{g_d})\kern-0.1em\big) \neq \mathtt{ephemeralKey}$, return $\bot$ <br>
 > 
 > $\hspace{1.0em}$ let $\mathsf{pk_d} = \mathsf{KA.DerivePublic}(\mathsf{ivk}, \mathsf{g_d})$ <br>
-> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
+> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$ <br>
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
 >                    \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot),&\!\!\!\text{if Sapling and } \mathsf{leadByte} = \mathtt{0x02} \\
 >                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
+>                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -918,13 +900,13 @@ For § 4.20.3, replace
 with
 
 > $\hspace{1.0em}$ let $\mathsf{g_d} = \mathsf{DiversifyHash}(\mathsf{d})$. if (for Sapling) $\mathsf{g_d} = \bot$, return $\bot$ <br>
-> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$, and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$ <br>
+> $\hspace{1.0em}$ let $\mathsf{g}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{g_d})$, $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$ <br>
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
 >                    \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot),&\!\!\!\text{if Sapling and } \mathsf{leadByte} = \mathtt{0x02} \\
 >                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x02} \\
->                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
+>                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -1000,10 +982,10 @@ Import this definition from ZIP 32 [^zip-0032-orchard-internal-key-derivation]:
 
 Import these definitions from § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend]:
 
-> Define $\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star) =$
+> Define $\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}) =$
 >   $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
 >
-> where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star)$.
+> where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ})$.
 >
 > Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x09}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 
@@ -1068,7 +1050,7 @@ $\begin{array}{l}
 \wedge\; \mathsf{ivk} \not\in \{0, \bot\} \vphantom{\Big(}\\
 \wedge\; \text{let } \mathsf{pk_d} = [\mathsf{ivk}]\, \mathsf{g_d} \vphantom{\big(}\\
 \wedge\; \text{let } \text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{r}\text{ψ}}(\underline{\text{ρ}}) \vphantom{\Big(}\\
-\wedge\; \text{let } \mathsf{noterepr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, {\mathsf{AssetBase}\kern0.05em\star}\big) \vphantom{\big(}\\
+\wedge\; \text{let } \mathsf{noterepr} = \big(\mathsf{repr}_{\mathbb{P}}(\mathsf{g_d}), \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d}), \mathsf{v}, \underline{\text{ρ}}, \text{ψ}\big) \vphantom{\big(}\\
 \wedge\; \text{let } \mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathtt{0x03}, \mathsf{noterepr}\big) \vphantom{\Big(}\\
 \wedge\; \text{let } \mathsf{cm} = \mathsf{NoteCommit^{Orchard}_{rcm}}(\mathsf{noterepr}) \vphantom{\big(}\\
 \wedge\; \mathsf{cm} \neq \bot \vphantom{\Big(}\\
@@ -1163,7 +1145,7 @@ Balance property.
 
 We prefer to fix this without changing $\mathsf{NoteCommit}$ itself.
 Instead we change how $\mathsf{rcm}$ is computed to be a hash of $\mathsf{rseed}$ and
-$\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)$,
+$\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ})$,
 as detailed in the [Specification] section.
 Specifically, when $\mathsf{leadByte} = \mathtt{0x03}$ we have:
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1156,6 +1156,11 @@ $\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{encode}(\maths
 
 ### Informal security argument for binding of note commitments
 
+For the formal versions of these arguments and their adaptation to the
+post-quantum setting, see the [key-binding](#thm-key-binding-rom) and
+[Spendability](#thm-spendability-collide) theorems below, and
+[§ Adaptation to the quantum setting](#adaptationtothequantumsetting).
+
 We can view the output of $\mathsf{NoteCommit_{rcm}}$ for
 $\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{noterepr})$
 as the point addition of a randomization term
@@ -1221,8 +1226,7 @@ note in the tree. As argued above, the distribution of $\mathsf{rcm}$ is
 indistinguishable from uniform-random on $\mathbb{F}_{r_\mathbb{P}}$. The
 success probability for each attempt in a classical search is therefore
 $2N/r_{\mathbb{P}}$ where $r_{\mathbb{P}}$ is the order of the Pallas curve,
-and that is negligible because $N \leq 2^{32} \ll r_{\mathbb{P}}$. This is
-also infeasible for a quantum adversary using a Grover search.
+and that is negligible because $N \leq 2^{32} \ll r_{\mathbb{P}}$.
 
 We're not finished yet because we also have to prove that the nullifier is
 computed deterministically for a given note.
@@ -1247,15 +1251,14 @@ uses (they can choose to attack either, or both simultaneously):
   is deterministic). <br>
   In particular, $\mathsf{ivk}$ is an essentially random function of
   $\mathsf{sk}$, and so we expect that an adversary has no better attack
-  than to search for values of $\mathsf{sk}$ (possibly using a Grover search)
+  than to search for values of $\mathsf{sk}$
   to find one that reproduces a given $\mathsf{ivk}$. Since $\mathsf{ivk}$
   must be an $x$-coordinate of a Pallas curve point (see the note at the end of
   [§ 4.2.3 Orchard Key Components](https://zips.z.cash/protocol/protocol.pdf#orchardkeycomponents)),
   it can take on $(r_{\mathbb{P}}-1)/2$ values. So if there are $T$ targets
   the success probability for each attempt in a classical search is
   $2T/(r_{\mathbb{P}}-1)$, which is negligible provided that
-  $T \ll r_{\mathbb{P}}$. This is also infeasible for a quantum adversary
-  using a Grover search for reasonable values of $T$.
+  $T \ll r_{\mathbb{P}}$.
 
 * Case $\mathsf{qk} \neq \bot$: This case is almost the same except that
   $\mathsf{ivk}$ is now an essentially random function of
@@ -1279,32 +1282,6 @@ computing Sinsemilla inside a circuit.") is not applicable when it is
 necessary to defend against a discrete-log-breaking or quantum adversary.
 Therefore, the post-quantum [Recovery Statement](#proposedrecoverystatement)
 will need to use complete curve additions to implement Sinsemilla.
-
-### Adaptation to the quantum setting
-
-In order to adapt this argument to the quantum setting, we need to consider
-*collapsing* hash functions as defined in [^Unruh2015] [^Unruh2016].
-
-$\mathsf{Extract}_{\mathbb{P}}$ does not interfere with the QROM lift:
-it is a deterministic 2-to-1 map on non-identity Pallas points
-(sending $P$ and $-P$ to the same $x$-coordinate) and does not query
-$\mathsf{H^{rcm}}$ or any other random oracle, so it composes with the
-underlying random oracle the same way classically and quantumly. The
-factor of 2 from the 2-to-1 reduction is already absorbed into the
-break-probability bound (each $\mathsf{cm}_x$ has exactly two valid
-$\mathsf{cm}$ values, hence exactly two valid $\mathsf{rcm}$ values, as
-stated above).
-
-By the argument in [^Bernstein2009], the best known *generic* quantum
-attack on a hash function is simply the classical attack of [^vOW1999].
-(In particular, the Brassard–Høyer–Tapp algorithm [^BHT1997] is entirely
-unimplementable for a 253-bit output size: to achieve the claimed speed-up,
-it would require running Grover's algorithm with a quantum circuit that
-does random accesses to a $2^{92.3}$-bit quantum memory.) Therefore, an
-output size of 253 bits does not exclude a hash function from being collapsing.
-
-TODO: discuss [^CBHSU2017] (sponge security), [^Unruh2015] [^Unruh2016]
-(collapse-binding property).
 
 ### Security argument for key binding
 
@@ -1782,12 +1759,82 @@ $q_{\mathsf{kb}}$ queries to the key-binding random oracles
 wins the Spendability-collision game with probability at most
 $\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} \;+\; \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
 
-TODO (QROM lift): The reduction is straight-line and does not adaptively
-reprogram $\mathsf{H^{rcm}}$ on inputs the adversary may have queried in
-superposition, so we expect a clean lift to the quantum random-oracle
-model via standard QROM techniques [^Unruh2015] [^Unruh2016] [^CMSZ2021]
-[^CDDGS2025], with at most a small loss factor. The technical conditions
-have not yet been verified.
+For the post-quantum lift of this bound and of the
+[key-binding bound](#thm-key-binding-rom) above, see the next section.
+
+## Adaptation to the quantum setting
+
+The classical-ROM proofs above (for [key binding](#thm-key-binding-rom)
+and [Spendability](#thm-spendability-collide)) rely on
+$\mathsf{H^{rcm}}$ and the various $\mathsf{rivk}$-derivation hashes
+being collision-resistant. The natural quantum analog is called the
+*collapsing* property, introduced by Unruh [^Unruh2015] [^Unruh2016].
+It says that even a quantum adversary holding a *superposition* over
+several preimages of a fixed output cannot tell —by any subsequent
+measurement— which preimage it now has. This is the right property
+for our reductions. Each proof above splits cases based on which oracle
+query produced the colliding output; that case analysis works the same
+classically and quantumly only if the underlying hash "collapses" the
+adversary's superposition to a single classical preimage.
+
+Subsequent work has analyzed whether standard hash-function
+constructions inherit collapsing from their compression function. Unruh
+[^Unruh2016] proved this for Merkle–Damgård (with a padding
+restriction); Czajkowski et al. [^CBHSU2017] for the *sponge*
+construction (the absorb-then-squeeze paradigm used by SHA-3 / Keccak),
+with [^ACMT2025] strengthening the sponge result via the related notion
+of quantum indifferentiability. Fehr [^Fehr2018] gave a unified
+algebraic framework that recovers these results and proves the
+collapsing property of HAIFA, a Merkle–Damgård variant with a
+per-iteration salt and counter. Gunsing and Mennink [^GM2022] extended
+this kind of analysis to tree-hash constructions, relevant for the
+Recovery Protocol's note-commitment tree.
+
+BLAKE2b uses HAIFA, so by Fehr's theorem modelling $\mathsf{H^{rcm}}$
+as collapsing reduces to modelling BLAKE2b's compression function as
+collapsing. The "iv-preimage resistance" side condition Fehr's theorem
+requires for arbitrary-length inputs is automatically satisfied if the
+compression function is modelled as a random oracle — which is also
+the modelling assumption underlying the classical-ROM analyses above.
+
+By the argument in [^Bernstein2009], the best known *generic* quantum
+attack on a hash function is simply the classical attack of [^vOW1999].
+(In particular, the Brassard–Høyer–Tapp algorithm [^BHT1997] is
+entirely unimplementable for a 253-bit output size: to achieve the
+claimed speed-up, it would require running Grover's algorithm with a
+quantum circuit that does random accesses to a $2^{92.3}$-bit quantum
+memory.) Therefore, an output size of 253 bits does not exclude a hash
+function from being collapsing.
+
+$\mathsf{Extract}_{\mathbb{P}}$ does not interfere with the QROM lift:
+it is a deterministic 2-to-1 map on non-identity Pallas points (sending
+$P$ and $-P$ to the same $x$-coordinate) and does not query
+$\mathsf{H^{rcm}}$ or any other random oracle, so it composes with the
+underlying random oracle the same way classically and quantumly. The
+factor of 2 from the 2-to-1 reduction is already absorbed into the
+break-probability bound (each $\mathsf{cm}_x$ has exactly two valid
+$\mathsf{cm}$ values, hence exactly two valid $\mathsf{rcm}$ values, as
+stated in the Spendability proof above).
+
+### QROM lift of the security arguments
+
+The classical-ROM reductions for both
+[Spendability](#thm-spendability-collide) and
+[key binding](#thm-key-binding-rom) satisfy the standard conditions for
+a "clean" lift to the quantum random-oracle model:
+
+* *Straight-line.* Neither reduction rewinds the adversary or measures
+  intermediate state; both inspect the adversary's classical output and
+  bound the probability over the random oracles' randomness.
+  Rewinding-based QROM techniques [^CMSZ2021] [^CDDGS2025] are therefore
+  not needed.
+* *No adaptive reprogramming.* Both reductions treat their random
+  oracles as fixed random functions throughout; neither reprograms
+  responses to adversary-queried inputs.
+
+Under the collapsing modelling, both classical-ROM bounds transfer to
+QROM with at most a polynomial loss factor in the number of oracle
+queries.
 
 ## Effects of discrete-log-breaking attacks before the switch to the Recovery Protocol
 
@@ -2034,7 +2081,11 @@ manipulate the note selection algorithm to some extent.
 
 [^CBHSU2017]: [Post-quantum security of the sponge construction. Jan Czajkowski, Leon Groot Bruinderink, Andreas Hülsing, Christian Schaffner, and Dominique Unruh.](https://eprint.iacr.org/2017/771)
 
+[^Fehr2018]: [Classical Proofs for the Quantum Collapsing Property of Classical Hash Functions. Serge Fehr.](https://eprint.iacr.org/2018/887)
+
 [^CMSZ2021]: [Post-Quantum Succinct Arguments: Breaking the Quantum Rewinding Barrier. Alessandro Chiesa, Fermi Ma, Nicholas Spooner, and Mark Zhandr.](https://eprint.iacr.org/2021/334)
+
+[^GM2022]: [Collapseability of Tree Hashes. Aldo Gunsing and Bart Mennink.](https://eprint.iacr.org/2022/248)
 
 [^CDDGS2025]: [Quantum Rewinding for IOP-Based Succinct Arguments. Alessandro Chiesa, Marcel Dall'Agnol, Zijing Di, Ziyi Guan, and Nicholas Spooner.](https://eprint.iacr.org/2025/947)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -243,7 +243,12 @@ graph BT
 The bold lines are changes introduced by this ZIP, which all take the form
 of additional inputs to derivation functions or alternative derivations.
 The derivations shown in the box labelled [Proposed Recovery Statement](#proposedrecoverystatement)
-are, roughly speaking, those enforced by the section of that name.
+are, roughly speaking, those enforced by the section of that name. The
+diagram shows the recoverable-note case ($\mathsf{leadByte} = \mathtt{0x03}$);
+for $\mathsf{leadByte} = \mathtt{0x02}$ the existing Orchard derivation
+$\mathsf{rcm} = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$
+applies, and the additional fields feeding into $\mathsf{pre\_rcm}$
+are absent.
 
 ```mermaid
 graph BT
@@ -271,8 +276,7 @@ graph BT
     ivk --> ivkmul
     rseed --> Hpsi[H<sup>ψ</sup>]:::func
     rho --> Hpsi
-    leadByte([leadByte]) ==> pre_rcm
-    v([v, AssetBase]) ===> pre_rcm([pre_rcm])
+    v([v, AssetBase]) ==> pre_rcm([pre_rcm])
     pkd ====> pre_rcm
     gd ==> pre_rcm
     psi ===> pre_rcm
@@ -285,8 +289,8 @@ graph BT
     Hpsi --> psi([#8239;ψ#8239;])
     gd --> NoteCommit:::func
     pkd --> NoteCommit
-    v --> NoteCommit
     psi --> NoteCommit
+    v --> NoteCommit
     rcm --> NoteCommit
     rho --> NoteCommit
     cm --> DeriveNullifier:::func
@@ -716,15 +720,14 @@ Add after the definition of $\mathsf{leadByte}$:
 
 Add before "For each Action description":
 
-> Define $\mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big) =$
+> Define $\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star) =$
 >   $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
 >
-> where $\mathsf{pre\_rcm} = \begin{cases}
->   [\mathtt{0x05}] \,||\, \underline{\text{ρ}},&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
->   [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \\
->   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \\
->   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
-> \end{cases}$
+> where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star)$.
+>
+> ($\mathsf{H^{rcm,Orchard}}$ is defined only for the $\mathsf{leadByte} = \mathtt{0x03}$ case; the existing
+> derivation $\mathsf{rcm} = \mathsf{ToScalar^{Orchard}}(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}}))$
+> from the protocol specification continues to apply when $\mathsf{leadByte} = \mathtt{0x02}$.)
 >
 > Define $\mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 >
@@ -745,7 +748,10 @@ with
 
 > Derive $\mathsf{esk} = \mathsf{H^{esk,Orchard}_{rseed}}(\underline{\text{ρ}})$
 
-> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big)$
+> Derive $\mathsf{rcm} = \begin{cases}
+>   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
+>   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+> \end{cases}$
 
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
@@ -778,7 +784,10 @@ Replace the lines deriving $\mathsf{rcm}$ and $\text{ψ}$ with
 > $\mathsf{pk}\star_{\mathsf{d}} = \mathsf{repr}_{\mathbb{P}}(\mathsf{pk_d})$,
 > and $\mathsf{AssetBase}\kern0.05em\star = \mathsf{repr}_{\mathbb{P}}(\mathsf{AssetBase})$.
 >
-> Derive $\mathsf{rcm} = \mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big)$
+> Derive $\mathsf{rcm} = \begin{cases}
+>   \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x02} \\
+>   \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
+> \end{cases}$
 >
 > Derive $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$
 
@@ -850,7 +859,9 @@ with
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{H^{rcm,protocol}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big),&\!\!\!\text{otherwise}
+>                    \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot),&\!\!\!\text{if Sapling and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -858,7 +869,7 @@ The order of operations has to be altered because the derivation of
 $\mathsf{rcm}$ can depend on $\mathsf{g_d}$ and $\mathsf{pk_d}$.
 The definitions of $\mathsf{pre\_rcm}$ and $\mathsf{pre\_esk}$ are moved into
 § 4.7.2 ‘Sending Notes (Sapling)’ and § 4.7.3 ‘Sending Notes (Orchard)’ which
-define $\mathsf{H^{rcm,protocol}}$.
+define $\mathsf{H^{rcm,Sapling}}$ and $\mathsf{H^{rcm,Orchard}}$ respectively.
 
 For § 4.20.3, replace
 
@@ -876,7 +887,9 @@ with
 > $\hspace{1.0em}$ let $\text{ψ} = \mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}})$ for Orchard or $\bot$ for Sapling <br>
 > $\hspace{1.0em}$ let $\mathsf{rcm} = \begin{cases}
 >                    \mathsf{LEOS2IP}_{256}(\mathsf{rseed}),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x01} \\
->                    \mathsf{H^{rcm,protocol}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big),&\!\!\!\text{otherwise}
+>                    \mathsf{H^{rcm,Sapling}_{rseed}}(\bot, \bot),&\!\!\!\text{if Sapling and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x05}] \,||\, \underline{\text{ρ}})\kern-0.1em\big),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x02} \\
+>                    \mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if Orchard and } \mathsf{leadByte} = \mathtt{0x03}
 >                  \end{cases}$ <br>
 > $\hspace{1.0em}$ if $\mathsf{rcm} \geq r_{\mathbb{G}}$, return $\bot$
 
@@ -950,17 +963,12 @@ Import this definition from ZIP 32 [^zip-0032-orchard-internal-key-derivation]:
 
 > $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rivk\_ext}}\big([\mathtt{0x83}] \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{ak}) \,||\, \mathsf{I2LEOSP}_{256}(\mathsf{nk})\kern-0.1em\big)\kern-0.15em\big)$
 
-Import these definitions from § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend], specialized to $\mathsf{leadByte} = \mathtt{0x03}$:
+Import these definitions from § 4.7.3 ‘Sending Notes (Orchard)’ [^protocol-orchardsend]:
 
-> Define $\mathsf{H^{rcm,Orchard}_{rseed}}\big(\mathsf{leadByte}, (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star)\kern-0.1em\big) =$
+> Define $\mathsf{H^{rcm,Orchard}_{rseed}}(\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}}, \mathsf{v}, \underline{\text{ρ}}, \text{ψ}, \mathsf{AssetBase}\kern0.05em\star) =$
 >   $\mathsf{ToScalar^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm})\kern-0.1em\big)$
 >
-> where $\mathsf{pre\_rcm} = \begin{cases}
->   \sout{[\mathtt{0x05}] \,||\, \underline{\text{ρ}},}&\!\!\!\sout{\text{if } \mathsf{leadByte} = \mathtt{0x02}} \\
->   [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \\
->   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \\
->   \hphantom{[\mathtt{0x0B}, \mathsf{leadByte}]} \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star),&\!\!\!\text{if } \mathsf{leadByte} = \mathtt{0x03}
-> \end{cases}$
+> where $\mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{g}\star_{\mathsf{d}}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{pk}\star_{\mathsf{d}}) \,||\, \mathsf{I2LEOSP}_{64}(\mathsf{v}) \,||\, \underline{\text{ρ}} \,||\, \mathsf{I2LEOSP}_{256}(\text{ψ}) \,||\, \mathsf{LEBS2OSP}_{256}(\mathsf{AssetBase}\kern0.05em\star)$.
 >
 > Define $\mathsf{H^{\text{ψ},Orchard}_{rseed}}(\underline{\text{ρ}}) = \mathsf{ToBase^{Orchard}}\big(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x09}] \,||\, \underline{\text{ρ}})\kern-0.1em\big)$.
 
@@ -1124,16 +1132,16 @@ $\mathsf{noterepr} = (\mathsf{g}\star_{\mathsf{d}}, \mathsf{pk}\star_{\mathsf{d}
 as detailed in the [Specification] section.
 Specifically, when $\mathsf{leadByte} = \mathtt{0x03}$ we have:
 
-$\hspace{2em}\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) = \mathsf{ToScalar}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm}))$
+$\hspace{2em}\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr}) = \mathsf{ToScalar}(\mathsf{PRF^{expand}_{rseed}}(\mathsf{pre\_rcm}))$
 
-$\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}, \mathsf{leadByte}] \,||\, \mathsf{encode}(\mathsf{noterepr})$
+$\text{where } \mathsf{pre\_rcm} = [\mathtt{0x0B}] \,||\, \mathsf{encode}(\mathsf{noterepr})$
 
 ### Informal security argument for binding of note commitments
 
 We can view the output of $\mathsf{NoteCommit_{rcm}}$ for
-$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{noterepr})$
 as the point addition of a randomization term
-$[\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}$,
+$[\mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr})]\, \mathcal{R}$,
 and some other function of $\mathsf{notetuple}$.
 
 Without loss of generality, we can write that function as
@@ -1143,7 +1151,7 @@ $\mathcal{C}_j = \mathcal{Q}(D) \text{ or } \mathcal{S}(j)$ used by
 [$\mathsf{HashToSinsimillaPoint}$](https://zips.z.cash/protocol/protocol.pdf#concretesinsemillahash)
 as $\mathcal{C}_j = [c_j]\, \mathcal{R}$ for some $c_j$. That is,
 the note commitment for $\mathsf{notetuple}$ is
-$$[\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{notetuple})]\, \mathcal{R}.$$
+$$[\mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr}) + \mathsf{f}(\mathsf{notetuple})]\, \mathcal{R}.$$
 
 We will model $\mathsf{H^{rcm}}$ as a random oracle independent of $\mathsf{f}$ with
 uniform output on $\mathbb{F}_{r_{\mathbb{P}}}.$ This is reasonable because
@@ -1168,11 +1176,11 @@ Pallas curve.
 > $r_{\mathbb{P}} \approx 2^{254}$ cannot introduce a problem.
 
 For each $\mathsf{H^{rcm}}$ oracle query the adversary chooses
-$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{noterepr})$
 and obtains a "random"
-$\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})$.
+$\mathsf{rcm} = \mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr})$.
 
-We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{notetuple})]\, \mathcal{R})$.
+We have $\mathsf{cm}_x = \mathsf{Extract}_{\mathbb{P}}([\mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr}) + \mathsf{f}(\mathsf{notetuple})]\, \mathcal{R})$.
 
 Over all Pallas curve points $P$, the number of outputs of
 $\mathsf{Extract}_{\mathbb{P}}(P)$ is $(\mathbb{F}_{r_\mathbb{P}} + 1)/2 \approx 2^{253}$ —
@@ -1241,7 +1249,7 @@ The above security argument means that provided we also check the uses of
 $\mathsf{H^{rcm}}$ and $\mathsf{H}^{\text{ψ}}$ in the post-quantum
 [Recovery Statement](#proposedrecoverystatement), Orchard note commitments
 can be considered binding on the note tuple
-$(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$.
+$(\mathsf{rseed}, \mathsf{noterepr})$.
 
 Note that the argument associated with
 [Theorem 5.4.4](https://zips.z.cash/protocol/protocol.pdf#thmsinsemillaex)
@@ -1416,7 +1424,7 @@ $\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$,
 $\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, or $\mathsf{H^{nk}}$:
 $h$ depends only on fixed Sinsemilla bases and on $(\mathsf{ak}, \mathsf{nk})$.
 
-By the same $y^2 = f(x)$ argument used in the Spendability proof
+By the same $y^2 = Y(x)$ argument used in the Spendability proof
 (using § 5.4.9.7 for the $\mathsf{Extract}_{\mathbb{P}}$-style
 $x$-coordinate convention), a key-binding break implies
 $$h(\mathsf{ak}, \mathsf{nk}) + \mathsf{rivk} \equiv \pm\big(h(\mathsf{ak}', \mathsf{nk}') + \mathsf{rivk}'\big) \pmod{r_{\mathbb{P}}}.$$
@@ -1549,8 +1557,8 @@ $$\mathsf{DeriveNullifier_{nk}}(\text{ρ}, \text{ψ}, \mathsf{cm}) :=
 
 Also recall from [Repairing note commitments] that we have
 
-$$\mathsf{cm} = [\mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr})
-     + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})]\, \mathcal{R}.$$
+$$\mathsf{cm} = [\mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr})
+     + \mathsf{f}(\mathsf{rseed}, \mathsf{noterepr})]\, \mathcal{R}.$$
 
 Let $K_{\kern-.08em\mathcal{R}}$ denote the discrete logarithm of
 $\mathcal{K}$ with respect to $\mathcal{R}$. This is well-defined and
@@ -1561,19 +1569,19 @@ respect to it; and $\mathcal{K}$ is non-identity by construction.
 Recall that $\text{ψ}$ is determined by $\mathsf{rseed}$ via
 $\text{ψ} = \mathsf{H}^{\text{ψ}}_{\mathsf{rseed}}(\text{ρ})$.
 The nullifier corresponding to
-$(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+$(\mathsf{nk}, \text{ρ}, \mathsf{rseed}, \mathsf{noterepr})$
 is then
 $$\mathsf{Extract}_{\mathbb{P}}\Big(
     \big[
       \big((\mathsf{PRF^{nf}_{nk}}(\text{ρ}) + \text{ψ}) \bmod q_{\mathbb{P}}\big) \cdot K_{\kern-.08em\mathcal{R}}
-      + \mathsf{H^{rcm}_{rseed}}(\mathsf{leadByte}, \mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})
+      + \mathsf{H^{rcm}_{rseed}}(\mathsf{noterepr}) + \mathsf{f}(\mathsf{rseed}, \mathsf{noterepr})
     \big]\, \mathcal{R}
   \Big).$$
 
 We model $\mathsf{H^{rcm}}$ as a random oracle with output uniform on
 $\mathbb{F}_{r_{\mathbb{P}}}$. The functions $\mathsf{f}$,
 $\mathsf{H}^{\text{ψ}}$, and $\mathsf{PRF^{nf}}$ are deterministic
-functions of $\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+functions of $\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{noterepr})$
 that **do not query $\mathsf{H^{rcm}}$**: $\mathsf{f}(\mathsf{notetuple})$
 is the Sinsemilla-base lift; $\mathsf{H}^{\text{ψ}}$ and $\mathsf{PRF^{nf}}$ are
 conventional hash functions.
@@ -1609,14 +1617,14 @@ The bound depends only on $q_{\mathsf{rcm}}$ and on
 $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$,
 not on running time.
 
-The components $\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr}$
+The components $\mathsf{rseed}, \mathsf{noterepr}$
 are fields of $\mathsf{notetuple}$ by definition; and $\text{ρ}$,
 $\mathsf{g_d}$, $\mathsf{pk_d}$, and $\text{ψ}$ are fields of
 $\mathsf{noterepr}$, hence of $\mathsf{notetuple}$.
 
 **$\mathsf{ivk}$-pinning lemma.** <a id="lemma-ivk-pinning"></a>
 For any valid Recovery Statement witness $w$ with
-$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$,
+$\mathsf{notetuple} = (\mathsf{rseed}, \mathsf{noterepr})$,
 the value $\mathsf{ivk} = \log_{\mathsf{g_d}}(\mathsf{pk_d})$ is
 well-defined, since $\mathsf{g_d} \neq \mathcal{O}_{\mathbb{P}}$ on the
 prime-order Pallas curve and
@@ -1635,7 +1643,7 @@ $\mathsf{notetuple}_i$ by the $\mathsf{ivk}$-pinning lemma; and
 $\text{ρ}_i$ is a field of $\mathsf{notetuple}_i$.
 
 The argument here covers nullifier-binding — it argues that $\mathsf{nf}$
-binds the note tuple $(\mathsf{rseed}, \mathsf{leadByte}, \mathsf{noterepr})$
+binds the note tuple $(\mathsf{rseed}, \mathsf{noterepr})$
 under $\mathsf{H^{rcm}}$ modelled as a random oracle
 and the [key-binding theorem](#thm-key-binding-rom).
 
@@ -1652,7 +1660,7 @@ satisfying:
 
 <a id="thm-spendability-distinct"></a>**Distinct note tuples**
 :   the $\mathsf{H^{rcm}}$-input tuples
-    $\mathsf{notetuple}_i := (\mathsf{rseed}_i, \mathsf{leadByte}_i, \mathsf{noterepr}_i)$
+    $\mathsf{notetuple}_i := (\mathsf{rseed}_i, \mathsf{noterepr}_i)$
     satisfy $\mathsf{notetuple}_1 \neq \mathsf{notetuple}_2$.
 
 <a id="thm-spendability-collide"></a>**Colliding nullifiers**
@@ -1706,7 +1714,7 @@ $F_i := \mathsf{F}(\mathsf{notetuple}_i)$ for $i \in \{1, 2\}$.
 $\mathsf{Extract}_{\mathbb{P}}$ (§ 5.4.9.7 'Coordinate Extractor for
 Pallas' [^protocol-concreteextractorpallas]) is the $x$-coordinate of
 its argument for non-identity points, with the identity mapping to $0$.
-Since Pallas has the form $y^2 = f(x)$ and no Pallas point has
+Since Pallas has the form $y^2 = Y(x)$ and no Pallas point has
 $x$-coordinate $0$, the collision $\mathsf{nf}_1 = \mathsf{nf}_2$
 holds iff $F_1 \equiv \pm F_2 \pmod{r_{\mathbb{P}}}$.
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -36,6 +36,10 @@ $\underline{\mathsf{underlined}}$ variable indicates a byte sequence,
 and a variable suffixed with $\star$ indicates a bit-sequence encoding of
 an elliptic curve point.
 
+The notation ${k \choose n}$ denotes the binomial coefficient — the
+number of ways of choosing $n$ items from a set of $k$, equal to
+$\frac{k!}{n!(k-n)!}$ for $0 \leq n \leq k$.
+
 For brevity, in the discussion sections of this ZIP we abbreviate
 $\mathsf{H^{rcm,Orchard}}$ as $\mathsf{H^{rcm}}$,
 $\mathsf{PRF^{nfOrchard}}$ as $\mathsf{PRF^{nf}}$,

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -120,8 +120,8 @@ Sapling [^zip-0032-sapling-child-key-derivation] [^zip-0032-sapling-internal-key
 and Orchard [^zip-0032-orchard-child-key-derivation] [^zip-0032-orchard-internal-key-derivation].)
 
 This proposal is implementable at low risk, and required changes to existing
-libraries and wallets are small. It can optionally be done at the same time
-as changes necessary to implement Memo Bundles [^zip-0231] and/or ZSAs [^zip-0226].
+libraries and wallets are small. It is compatible with Memo Bundles [^zip-0231]
+and/or ZSAs [^zip-0226].
 
 
 # Requirements
@@ -208,7 +208,7 @@ hardware-wallet use cases are described in
 [Usage with FROST](#usagewithfrost) and
 [Usage with hardware wallets](#usagewithhardwarewallets).
 
-## Flow diagram for the Orchard and OrchardZSA protocols
+## Flow diagram for the Orchard protocol
 
 This diagram shows, approximately, the derivation of Orchard keys,
 addresses, notes, note commitments, and nullifiers. All of the flow
@@ -967,8 +967,8 @@ changes to be adopted now are likely to be sufficient to securely support
 a Recovery Protocol.
 
 The proposed Recovery Protocol works, roughly speaking, by enforcing the
-derivations given in the [Flow diagram for the Orchard and OrchardZSA protocols],
-and we suggest having that diagram open in another window to refer to it.
+derivations given in the [Flow diagram for the Orchard protocol], and we
+suggest having that diagram open in another window to refer to it.
 
 ### Proposed Recovery Statement
 
@@ -1543,7 +1543,7 @@ $$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3 q_{\maths
 
 DeriveNullifier is based on a Pedersen hash. In the current Orchard
 protocol, the property that it is infeasible to find two distinct
-Orchard notes with the same nullifier (including possible nullfiers
+Orchard notes with the same nullifier (including possible nullifiers
 of split OrchardZSA notes), depends on the collision resistance of
 that hash, which would not hold against a discrete-log-breaking
 adversary.

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1832,9 +1832,32 @@ a "clean" lift to the quantum random-oracle model:
   oracles as fixed random functions throughout; neither reprograms
   responses to adversary-queried inputs.
 
-Under the collapsing modelling, both classical-ROM bounds transfer to
-QROM with at most a polynomial loss factor in the number of oracle
-queries.
+**Concrete QROM bounds.** By Zhandry's compressed-oracle technique
+[^Zhandry2018] (see also [^CFHL2021] for a classical-style derivation),
+the classical $q^2 / N$ collision probability
+transfers to $O(q^3 / N)$ in QROM: an adversary making at most $q$
+quantum queries to a random oracle with output space of size $N$
+finds a collision with probability $O(q^3 / N)$. Applied to our
+reductions:
+
+* $\varepsilon^{\mathsf{QROM}}_{\mathsf{Spendability}} \leq O\!\left(q_{\mathsf{rcm}}^3 / r_{\mathbb{P}}\right) + \varepsilon^{\mathsf{QROM}}_{\mathsf{kb}}.$
+* $\varepsilon^{\mathsf{QROM}}_{\mathsf{kb}} \leq O\!\left(q_{\mathsf{kb}}^3 / r_{\mathbb{P}}\right).$
+
+These are worst-case theoretical bounds. An adversary that saturates
+them would need to mount a BHT-style attack, which is unimplementable
+for a 253-bit output (as discussed above, the BHT algorithm would
+require a quantum circuit randomly accessing a $2^{92.3}$-bit quantum
+memory). In practice the achievable bound remains close to the
+classical $q^2 / r_{\mathbb{P}}$, since the best *known* generic
+quantum attack is the classical attack of [^vOW1999] — Bernstein
+[^Bernstein2009] is careful to flag this as best-known rather than
+provably best.
+
+For the parameters relevant to Zcash ($q_{\mathsf{rcm}},
+q_{\mathsf{kb}} \ll 2^{60}$ and $r_{\mathbb{P}} \approx 2^{254}$),
+the $O(q^3 / r_{\mathbb{P}})$ worst-case bound is at most
+$\sim 2^{-74}$, while the practically achievable
+$O(q^2 / r_{\mathbb{P}})$ bound stays closer to $\sim 2^{-134}$.
 
 ## Effects of discrete-log-breaking attacks before the switch to the Recovery Protocol
 
@@ -2082,6 +2105,10 @@ manipulate the note selection algorithm to some extent.
 [^CBHSU2017]: [Post-quantum security of the sponge construction. Jan Czajkowski, Leon Groot Bruinderink, Andreas Hülsing, Christian Schaffner, and Dominique Unruh.](https://eprint.iacr.org/2017/771)
 
 [^Fehr2018]: [Classical Proofs for the Quantum Collapsing Property of Classical Hash Functions. Serge Fehr.](https://eprint.iacr.org/2018/887)
+
+[^Zhandry2018]: [How to Record Quantum Queries, and Applications to Quantum Indifferentiability. Mark Zhandry.](https://eprint.iacr.org/2018/276)
+
+[^CFHL2021]: [On the Compressed-Oracle Technique, and Post-Quantum Security of Proofs of Sequential Work. Kai-Min Chung, Serge Fehr, Yu-Hsuan Huang, and Tai-Ning Liao.](https://eprint.iacr.org/2020/1305)
 
 [^CMSZ2021]: [Post-Quantum Succinct Arguments: Breaking the Quantum Rewinding Barrier. Alessandro Chiesa, Fermi Ma, Nicholas Spooner, and Mark Zhandr.](https://eprint.iacr.org/2021/334)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1300,9 +1300,10 @@ Orchard properties need different components of the key witness pinned:
   — the latter via the
   [$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning)):
   $\mathsf{nk}$ uniquely determined by $\mathsf{ivk}$.
-* **Spend Authorization**: $\mathsf{qk}$ uniquely determined by
-  $\mathsf{ivk}$ when $\mathsf{qk} \neq \bot$ (i.e., when
-  $\mathsf{use\_qsk} = \mathsf{true}$).
+* **Spend Authorization**: $\mathsf{ak}$ (up to $y$-sign of
+  $\mathsf{ak}^{\mathbb{P}}$) uniquely determined by $\mathsf{ivk}$;
+  and $\mathsf{qk}$ uniquely determined by $\mathsf{ivk}$ when
+  $\mathsf{qk} \neq \bot$ (i.e., when $\mathsf{use\_qsk} = \mathsf{true}$).
 
 The formal key-binding condition stated below covers both of these
 uniformly: a key-binding break is a pair of distinct witnesses sharing

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1820,6 +1820,14 @@ break-probability bound (each $\mathsf{cm}_x$ has exactly two valid
 $\mathsf{cm}$ values, hence exactly two valid $\mathsf{rcm}$ values, as
 stated in the Spendability proof above).
 
+This factor-of-2 absorption relies on the
+[fibres](https://en.wikipedia.org/wiki/Fiber_%28mathematics%29) $\{P, -P\}$
+of $\mathsf{Extract}_{\mathbb{P}}$ forming a *uniform* partition of the
+non-identity points of $\mathbb{P}$ — the free $\mathbb{Z}/2$ negation action
+gives every fibre for non-identity points exactly size 2 — which is what lets
+birthday-style bounds substitute $r_{\mathbb{P}} \to r_{\mathbb{P}}/2$ cleanly.
+A non-uniform mapping would not admit such a substitution.
+
 ### QROM lift of the security arguments
 
 The classical-ROM reductions for both

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1791,8 +1791,107 @@ have not yet been verified.
 
 ## Effects of discrete-log-breaking attacks before the switch to the Recovery Protocol
 
-TBD: explain that such attacks can break Balance and Spendability, including
-Spendability for transactions after switching to the Recovery Protocol.
+A practical discrete-log-breaking attack —either by a sufficiently large quantum
+computer running Shor's algorithm, or a major advance in classical cryptanalysis
+of the discrete logarithm or Diffie–Hellman problems— would compromise the
+cryptographic primitives underlying Zcash's shielded protocols.
+
+Note and value commitments in Orchard[ZSA] and Sapling are Pedersen-style and
+lose binding; the proof systems used in the shielded protocols (Halo 2 over
+Vesta in Orchard[ZSA], Groth16 over BLS12-381 in Sapling or Sprout) lose
+soundness; and the RedDSA binding and spend authorization signatures in
+Orchard[ZSA] and Sapling can be forged. Sprout's note commitments are
+SHA-256-based and survive a discrete log break, but the broken proof system is
+sufficient to forge JoinSplit statements, and the Ed25519 spend authorization
+and JoinSplit signatures can be forged. In addition, the ECDSA signatures used
+for transparent spend authentication can be forged.
+
+The combined effect is severe. An adversary can:
+
+* break Balance for the Sapling or Orchard pools by forging value-commitment
+  openings or binding signatures;
+* break Balance for the Sprout, Sapling, or Orchard pools by forging Groth16 or
+  Halo 2 proofs of balanced transactions;
+* break Spend authentication (i.e. steal funds, independently of a Balance break)
+  for the Sprout, Sapling, or Orchard pools by forging alternative note witnesses
+  for any commitment on chain, or by forging Groth16 or Halo 2 proofs of valid
+  spends;
+* break Spend authentication for the Sapling or Orchard pools by forging RedJubjub
+  or RedPallas spend authorization signatures, or for the transparent pool by
+  forging ECDSA-over-secp256k1 signatures used in scripts;
+* break Spendability via roadblock or Faerie Gold attacks, preventing users from
+  spending their own funds;
+* break Privacy of note plaintexts by finding the $\mathsf{ivk}$ for a known
+  Sapling or Orchard address, or the $\mathsf{sk_{enc}}$ for a known Sprout
+  address, or by breaking the Diffie–Hellman-based note encryption (again only
+  for a known recipient address).
+
+Attacks on transparent spend authentication are not addressed by this proposal.
+[^Google2025] discusses these attacks in the context of Bitcoin. For Zcash, we
+should note that P2PK and legacy P2MS (non-P2SH) scripts have never been
+supported by Zcash wallets, but Zcash is vulnerable to "on-spend" attacks in a
+similar way to Bitcoin, with the additional consideration that some Zcash
+wallets might be more likely to reuse transparent addresses. The discussion of
+Segwit is not relevant to Zcash.
+
+## Effects of discrete-log-breaking attacks after the switch to the Recovery Protocol
+
+We assume for this section that the legacy Orchard, OrchardZSA (if deployed),
+Sapling, and Sprout protocols will be switched off. Any remaining funds in
+the Sapling and Sprout pools, as well as funds in non-recoverable Orchard notes,
+would be rendered permanently unspendable.
+
+The Balance, Spend authentication, and Spendability attacks are possible only
+*before* the switch to the Recovery Protocol — that is, while legacy Orchard,
+Sapling, and (if ZIP 2003 is not deployed first [^zip-2003]) Sprout spends are
+still accepted by the consensus rules.
+
+If a balance violation occurred in any pool before its protocol was switched
+off, it would not necessarily be detected. The only constraint on such attacks
+is the ZIP 209 turnstile mechanism [^zip-0209]. If there were evidence of
+balance violation having occurred, confidence in Zcash as a whole could
+potentially be undermined despite the turnstile constraints (especially if the
+violation was in the largest pool, currently Orchard). Therefore, it will be
+essential to ensure that the pre-quantum protocols are switched off well in
+advance of the potential availability of cryptographically relevant quantum
+computers.
+
+If the transparent protocol is not switched off, then the situation with respect
+to transparent spend authentication is unchanged. Balance for the transparent
+protocol cannot be violated directly by a discrete-log break (but funds created
+by a balance violation in a shielded pool can be moved into the transparent pool
+up to that shielded pool's turnstile limit).
+
+The changes made by ZIP 2005 are only intended to address Balance preservation,
+Spend authentication, and Spendability for recoverable Orchard[ZSA] notes. The
+situation with respect to Privacy is unchanged for any pool.
+
+In particular, the note encryption for Orchard[ZSA], Sapling, and Sprout pools
+is subject to "Harvest Now, Decrypt Later" attacks: that is, a
+discrete-log-breaking attack can be performed as long as an adversary has both
+the ciphertext (which is published on the block chain) and the recipient
+address. Other protocol changes are under consideration to mitigate this risk
+for future transfers.
+
+Due to the zero-knowledge property, Groth16 and Halo 2 proofs do not leak
+further information relevant to Privacy when addresses are unknown. The same is
+true of Sapling or Orchard[ZSA] spend authentication signatures, due to key
+rerandomization.
+
+## Attacks addressed by the Recovery Protocol
+
+The Recovery Statement's $\mathsf{BindKeys}$ constraint pins the key witness via
+$\mathsf{PRF^{expand}}$ (modelled as collapsing), not via discrete-log hardness.
+So (if no mistakes are made in the design or instantiation), fresh Balance,
+Spend authentication, or Spendability attacks against the Recovery Protocol
+should require breaking post-quantum binding rather than just discrete logs.
+Funds in recoverable Orchard notes can therefore be spent through the Recovery
+Protocol after the switch. However, if the adversary attacked either
+Spendability (e.g. via a roadblock attack) or Spend authorization before the
+switch to the Recovery Protocol, then it could affect the legitimate holder's
+ability to spend the funds afterward. The window between
+$\mathsf{ZIP2005ActivationHeight}$ and the switch is the critical exposure
+period for recoverable Orchard funds.
 
 Note that we can precisely identify the set of note commitments for recoverable
 Orchard notes in v6 transactions, even if we cannot decrypt them, since only
@@ -1804,8 +1903,8 @@ We cannot identify the precise set of nullifiers for recoverable notes: an
 Orchard action in a v6 transaction could be spending either a recoverable or
 non-recoverable note, and their nullifier sets are indistinguishable.
 
-On the other hand, within the Recovery Statement we know that the
-note being spent is recoverable.
+On the other hand, within the Recovery Statement we know that the note being
+spent is recoverable.
 
 # Deployment
 
@@ -1895,6 +1994,8 @@ manipulate the note selection algorithm to some extent.
 
 [^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
 
+[^zip-0209]: [ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances](zip-0209.rst)
+
 [^zip-0226]: [ZIP 226: Transfer and Burn of Zcash Shielded Assets](zip-0226.rst)
 
 [^zip-0226-split-notes]: [ZIP 226: Transfer and Burn of Zcash Shielded Assets — Split Notes](zip-0226.rst#split-notes)
@@ -1912,6 +2013,8 @@ manipulate the note selection algorithm to some extent.
 [^zip-0312-key-generation]: [ZIP 312: FROST for Spend Authorization Multisignatures — Key Generation](zip-0312.rst#key-generation)
 
 [^zip-0312-threat-model]: [ZIP 312: FROST for Spend Authorization Multisignatures — Threat Model](zip-0312.rst#threat-model)
+
+[^zip-2003]: [ZIP 2003: Disallow version 4 transactions](zip-2003.rst)
 
 [^zcash-security]: Understanding Zcash Security ([video](https://www.youtube.com/watch?v=f6UToqiIdeY), [slides](https://raw.githubusercontent.com/daira/zcash-security/main/zcash-security.pdf)). Presentation by Daira-Emma Hopwood at Zcon3.
 
@@ -1938,3 +2041,5 @@ manipulate the note selection algorithm to some extent.
 [^CDDGS2025]: [Quantum Rewinding for IOP-Based Succinct Arguments. Alessandro Chiesa, Marcel Dall'Agnol, Zijing Di, Ziyi Guan, and Nicholas Spooner.](https://eprint.iacr.org/2025/947)
 
 [^ACMT2025]: [The Sponge is Quantum Indifferentiable. Gorjan Alagic, Joseph Carolan, Christian Majenz, and Saliha Tokat.](https://eprint.iacr.org/2025/731)
+
+[^Google2025]: [Securing Elliptic Curve Cryptocurrencies against Quantum Vulnerabilities: Resource Estimates and Mitigations. Ryan Babbush, Adam Zalcman, Craig Gidney, Michael Broughton, Tanuj Khattar, Hartmut Neven, Thiago Bergamaschi, Justin Drake, and Dan Boneh](https://quantumai.google/static/site-assets/downloads/cryptocurrency-whitepaper.pdf)

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -133,9 +133,9 @@ as changes necessary to implement Memo Bundles [^zip-0231] and/or ZSAs [^zip-022
   discrete-log-breaking and quantum adversaries.
 * No particular choice of post-quantum proving system or commitment
   tree hash should be assumed for that alternate protocol.
-* The proposed scheme should be fully compatible with FROST
-  multisignatures [^zip-0312], hardware wallets, and the combination
-  of both.
+* The proposed scheme should be fully compatible with FROST threshold
+  multisignatures [^zip-0312], hardware wallets, and the combination of
+  both.
 * The proposed scheme should not require regeneration of existing
   non-multisignature keys or addresses.
 * The changes made to the pre-quantum protocol should not cause a
@@ -143,8 +143,8 @@ as changes necessary to implement Memo Bundles [^zip-0231] and/or ZSAs [^zip-022
   against any given adversary class, or require significant re-analysis
   of that protocol's pre-quantum security.
 * The Recovery Protocol should ensure no loss of security against
-  pre-quantum adversaries — including when FROST multisignatures and/or
-  hardware wallets are used.
+  pre-quantum adversaries — including when FROST threshold multisignatures
+  and/or hardware wallets are used.
 * Recovery of funds from hardware wallets that support this protocol
   should not require exposing the pre-quantum spend authorizing key
   $\mathsf{ask}$ to theft.
@@ -384,8 +384,8 @@ Note that a quantum adversary may be able to steal the funds with only
 access to $\mathsf{qsk}$, which is held by every participant (see below
 for more detail on [Key storage options](#keystorageoptionsandanalysis)).
 Therefore, it is RECOMMENDED that as soon as a fully post-quantum protocol
-that supports multisignatures is available, all funds held under FROST keys
-be transferred into that protocol's shielded pool.
+that supports threshold multisignatures is available, all funds held under
+FROST keys be transferred into that protocol's shielded pool.
 
 ## Usage with hardware wallets
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -4,12 +4,16 @@
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
             Jack Grigg <thestr4d@gmail.com>
     Credits: Sean Bowe
+             Dev Ojha
+             Kris Nuttycombe
     Status: Draft
     Category: Consensus
     Created: 2025-03-31
     License: MIT
     Discussions-To: <https://github.com/zcash/zips/issues/1135>
     Pull-Request: <https://github.com/zcash/zips/pull/1126>
+                  <https://github.com/zcash/zips/pull/1184>
+                  <https://github.com/zcash/zips/pull/1275>
 
 
 # Terminology

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1541,7 +1541,7 @@ Treating the five rivk-derivation random oracles
 $\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, $\mathsf{H^{nk}}$) as a
 single combined uniform random oracle on the joint query domain (each
 RO contributes its outputs independently of the others), and
-union-bounding over the at most $\binom{q_{\mathsf{kb}}}{2}$ pairs
+union-bounding over the at most ${q_{\mathsf{kb}} \choose 2}$ pairs
 of distinct witnesses,
 $$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3 q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2 r_{\mathbb{P}}}.$$
 
@@ -1756,7 +1756,7 @@ $F_1$ and $F_2$ are independent uniform on $\mathbb{F}_{r_{\mathbb{P}}}$.
 The win condition $F_1 \equiv \pm F_2$ is a linear constraint on a
 pair of independent uniform variables, satisfied with probability at
 most $2/r_{\mathbb{P}}$ (one per sign). Union-bounding over the at
-most $\binom{q_{\mathsf{rcm}}}{2}$ pairs of distinct
+most ${q_{\mathsf{rcm}} \choose 2}$ pairs of distinct
 $\mathsf{H^{rcm}}$ queries:
 $$\Pr[\text{win} \mid \neg\,\text{break}] \leq \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}}.$$
 Decomposing on whether a key-binding break occurs and applying

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1897,7 +1897,7 @@ manipulate the note selection algorithm to some extent.
 
 [^Bernstein2009]: [Cost analysis of hash collisions: Will quantum computers make SHARCS obsolete? Daniel J. Bernstein.](https://cr.yp.to/hash/collisioncost-20090517.pdf)
 
-[^BLAKE3]: [BLAKE3: One Function, Fast Everywhere. Jack O'Connor, Jean-Philippe Aumasson, Samuel Neves, and Zooko Wilcox-O'Hearn, 2020.](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) See § 2.1.2 for the `derive_key` mode.
+[^BLAKE3]: [BLAKE3: One Function, Fast Everywhere. Jack O'Connor, Jean-Philippe Aumasson, Samuel Neves, and Zooko Wilcox, 2020.](https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf) See § 2.1.2 for the `derive_key` mode.
 
 [^Maurer2002]: [Indistinguishability of Random Systems. Ueli Maurer.](https://crypto.ethz.ch/publications/files/Maurer02.pdf) Advances in Cryptology — EUROCRYPT 2002, LNCS vol. 2332, pp. 110–132.
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -2002,9 +2002,7 @@ manipulate the note selection algorithm to some extent.
 
 [^zip-0227]: [ZIP 227: Issuance of Zcash Shielded Assets](zip-0227.rst)
 
-[^zip-0230]: [ZIP 230: Version 6 Transaction Format](zip-0230.rst)
-
-[^zip-0231]: [ZIP 231: Memo Bundles](zip-0231.rst)
+[^zip-0231]: [ZIP 231: Memo Bundles](zip-0231.md)
 
 [^zip-0248]: [ZIP 248: Extensible Transaction Format (PR: zcash/zips#1156)](https://github.com/zcash/zips/pull/1156)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -303,6 +303,18 @@ graph BT
 
 # Specification
 
+## Proactive movement of funds to recoverable notes
+
+Once this proposal is deployed, wallets SHOULD move all of the funds they
+control (including transparent, Sprout, and Sapling funds) into recoverable
+Orchard notes as soon as practically possible. This does not depend on support
+from other wallets for receiving recoverable notes, because wallet-internal
+addresses can be used.
+
+Non-recoverable funds may be received after existing funds have been made
+recoverable. Wallets SHOULD therefore treat the movement of funds to
+recoverable notes as an ongoing process.
+
 ## Usage with FROST
 
 When generating Orchard keys for FROST, $\mathsf{ak}$ will be derived jointly


### PR DESCRIPTION
Follow-up to merged PR #1264. This branch makes the following changes:

## Security argument

- Use note-tuple terminology consistently in the Spendability arguments, correcting pre-existing imprecisions in the $\mathsf{notetuple}$ framing.
- Drop $\mathsf{leadByte}$ from the input to $\mathsf{H^{rcm,Orchard}}$. $\mathsf{leadByte}$ versions the *note plaintext*, not the *note*. The previous design created a layering violation between the handling of note plaintexts vs notes. The $\mathsf{leadByte} = \mathtt{0x02}$ case retains the existing protocol-spec derivation; the $\mathsf{leadByte} = \mathtt{0x03}$ case uses the new $\mathsf{H^{rcm,Orchard}}$ directly.
- ZIP 2005 is now specified to activate without ZSAs, so drop $\mathsf{AssetBase}$ from the input to $\mathsf{H^{rcm,Orchard}}$.
- Inline $\mathsf{H^{rcm,Sapling}}$ (it was a wrapper around $\mathsf{ToScalar^{Sapling}}(\mathsf{PRF^{expand}_{rseed}}([\mathtt{0x04}]))$ with unused args); reduce the signature of $\mathsf{H^{esk,Sapling}}$ from `(_, _)` to `(_)` matching its Canopy-onward call shape; replace `if Sapling and leadByte = ...` / `if Orchard and leadByte = ...` with the explicit `if protocol = Sapling and ...` / `if protocol = Orchard and ...` form in the prose dispatches.
- Define `Derive_rcm^{Sapling,Orchard}` helpers that bundle the $\mathsf{leadByte}$ case-split for $\mathsf{rcm}$ derivation. Call sites in §4.7.2 / §4.7.3 / §4.8.2 / §4.8.3 / §4.20.2 / §4.20.3 invoke these helpers instead of dispatching inline. The §4.20.2 / §4.20.3 decryption $\mathsf{rcm}$ derivation collapses from a 4-case case-split to a 2-case protocol-conditional call.
- Pin $\mathsf{ak}$ (up to $y$-sign of $\mathsf{ak}^{\mathbb{P}}$) for Spend Authorization key-binding, in addition to $\mathsf{qk}$. The spend-authorization verification key is randomized from $\mathsf{ak}^{\mathbb{P}}$; the previous motivation enumeration listed only $\mathsf{qk}$. The formal key-binding predicate already pinned $\mathsf{ak}$ via $\mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk})$; the enumeration was incomplete.
- Make the key-binding algebraic setup explicit per §5.4.1.10 'Sinsemilla commitments': exhibit $\mathcal{S}$ as the rivk-randomization base, $M'$ as $\mathsf{SinsemillaHashToPoint}$ over the encoded $(\mathsf{ak}, \mathsf{nk})$, and the WLOG scalar-lift $M' = [h(\mathsf{ak}, \mathsf{nk})]\, \mathcal{S}$ for a Pedersen-like deterministic $h$. Resolves two duplicate TODOs.

## Post-quantum analysis

- Restructure the "Adaptation to the quantum setting" section: promote from `###` (inside Security analysis) to `##` (top-level, after the formal Spendability argument), so that all quantum analysis follows all classical analysis rather than being sandwiched between the informal and formal arguments. Trim the informal binding argument's quantum mentions and add a forward reference.
- Define the *collapsing* property as the quantum analog of collision-resistance; survey collapsing for standard hash-function constructions (Unruh on Merkle–Damgård, Czajkowski et al. on sponge, ACMT 2025 on quantum-indifferentiability, Fehr 2018 on HAIFA, Gunsing and Mennink 2022 on tree hashes). Apply Fehr's theorem: modelling $\mathsf{H^{rcm}}$ as collapsing reduces to modelling BLAKE2b's compression function as collapsing.
- State concrete QROM bounds (Zhandry's compressed-oracle technique, with CFHL 2021's classical-style derivation as a co-citation): the classical $q^2 / r_{\mathbb{P}}$ collision probability becomes $O(q^3 / r_{\mathbb{P}})$ in QROM. For Zcash-relevant parameters the worst-case QROM bound is $\sim 2^{-74}$; the practically achievable bound stays closer to the classical $\sim 2^{-134}$ since BHT-style attacks would need the $2^{92.3}$-bit quantum memory shown to be infeasible.
- Resolve three prior TODOs in the security argument: $\mathsf{Extract}_{\mathbb{P}}$ / QROM composition, CBHSU2017 / Unruh literature discussion, and the QROM-lift technical conditions.

## Threat analysis

- Draft the "Effects of discrete-log-breaking attacks" sections (before / after the switch, and "Attacks addressed by the Recovery Protocol") — covering the threat across all of Zcash's primitives, what becomes permanently unspendable post-switch (Sapling, Sprout, and non-recoverable Orchard), the out-of-scope status of transparent funds, and the limits of the Recovery Protocol. Replaces a prior TBD; adds ZIP 209, ZIP 2003, and a 2025 Google paper on ECC-cryptocurrency quantum recovery to the references.

## Deployment

- Commit to deployment option 1 (deploy in v5 transactions before the next NU, with a $\mathsf{ZIP2005ActivationHeight}$); restructure $\mathsf{allowedLeadBytes}$ accordingly.
- Add a "Proactive movement of funds to recoverable notes" section: wallets SHOULD sweep all non-recoverable funds they control into recoverable Orchard notes once this proposal is deployed. Wallet-internal sends use $\mathtt{0x03}$ immediately; external sends use $\mathtt{0x02}$ until there is wider support for receiving $\mathtt{0x03}$.
- Decouple ZIP 2005 from OrchardZSA in framing prose.

## Terminology and housekeeping

- `FROST multisignatures` → `FROST threshold multisignatures` (a multisignature scheme is not necessarily a threshold scheme).
- Update Credits and Pull-Request fields.

## Bibliography

- Annotate eprint citations with "Also published in …" when the paper also appears at a conference / in a journal, signalling that the linked revision may differ from the named published version. Applied to eleven entries (Unruh 2015/2016, CBHSU 2017, Fehr 2018, Zhandry 2018, CFHL 2021, CMSZ 2021, GM 2022, BHT 1997, Bernstein 2009, Maurer 2002).
- New references introduced by the post-quantum analysis: Fehr 2018 (HAIFA collapsing), Zhandry 2018 (compressed-oracle technique), CFHL 2021 (classical-style derivation), Gunsing and Mennink 2022 (tree-hash collapsing).
- Update the BLAKE3 reference to cite Zooko Wilcox's current name.

## Cross-ZIP

- ZIPs 226 / 230 / 231: replace explicit `0x03` references with placeholders (`{{ZSALEADBYTE}}` / `{{LEADBYTE}}` / `{{MBLEADBYTE}}`) since 0x03 is now reserved for ZIP 2005.
- Withdraw ZIP 230 (obsoleted by ZIP 248).

## Suggested checks

- [ ] Spot-check that `Derive_rcm^{Sapling}` and `Derive_rcm^{Orchard}` dispatch correctly and cover the relevant leadByte values.
- [ ] The $\mathsf{allowedLeadBytes}$ matrix covers all valid (protocol, height, txVersion) combinations.
- [ ] The key-binding algebraic-setup paragraph matches §5.4.1.10 'Sinsemilla commitments' (domain strings, encoding).

🤖 Filed with [Claude Code](https://claude.com/claude-code)


