### PR TITLE
[ZIP 416] Repurpose for documenting zcashd key generation.

### DIFF
--- a/zips/zip-0416.rst
+++ b/zips/zip-0416.rst
@@ -1,10 +1,10 @@
 ::
 
   ZIP: 416
-  Title: Support for Unified Addresses in zcashd
+  Title: Spending Key Derivation in the `zcashd` wallet
   Owners: Daira-Emma Hopwood <daira@jacaranda.org>
           Jack Grigg <thestr4d@gmail.com>
           Kris Nuttycombe <kris@nutty.land>
   Status: Reserved
   Category: RPC / Wallet
-  Discussions-To: <https://github.com/zcash/zips/issues/503>
+  Discussions-To: <https://github.com/zcash/zips/issues/1175>


### PR DESCRIPTION
ZIP 416 was reserved for specifying unified address support for the zcashd wallet, but with the upcoming deprecation of `zcashd` that is no longer a useful task; instead, we need to fully document the historic schemes used for key generation by the zcashd wallet, for the purpose of future recoverability. This updates the reserved ZIP to serve that purpose.