### PR TITLE
ZIP 143, ZIP 243: Note that test vectors are randomly generated.

### DIFF
--- a/zips/zip-0143.rst
+++ b/zips/zip-0143.rst
@@ -303,6 +303,10 @@ the ZIP 143 test vectors [#test-vectors]_. The first two test vectors are broken
 that 32-byte values below are exactly as the hash function returns, and are not reversed. Further examples can
 be found in the SignatureHash test data [#sighash-tests]_.
 
+The sample transactions below and in [#sighash-tests]_ are randomly generated and are intended only for
+testing implementations of the transaction digest algorithm; they are not necessarily valid Zcash
+transactions and do not necessarily pass full validation.
+
 The test vectors below should be verified with the Overwinter consensus branch ID (0x5ba81b19) [#zip-0201]_.
 
 Test vector 1

--- a/zips/zip-0243.rst
+++ b/zips/zip-0243.rst
@@ -273,8 +273,9 @@ the ZIP 243 test vectors [#test-vectors]_. The first two test vectors are broken
 that 32-byte values below are exactly as the hash function returns, and are not reversed. Further examples can
 be found in the SignatureHash test data [#sighash-tests]_.
 
-The sample transactions below and in [#sighash-tests]_ are intended only for testing implementations of the
-transaction digest algorithm; they do not necessarily pass full validation.
+The sample transactions below and in [#sighash-tests]_ are randomly generated and are intended only for
+testing implementations of the transaction digest algorithm; they are not necessarily valid Zcash
+transactions and do not necessarily pass full validation.
 
 
 Test vector 1


### PR DESCRIPTION
Closes #356.

Clarifies (in the Example sections of both ZIPs) that the sample
transactions used to exercise the sighash algorithm are randomly
generated and are not necessarily valid Zcash transactions; their
purpose is to verify the transaction digest algorithm rather than to
pass full validation. The note added to ZIP 143 mirrors the (now
slightly extended) note that ZIP 243 already carried.

Filed with Claude Code assistance.