### PR TITLE
ZIP 317: Clarify that tx_in/out_total_size exclude tx_in/out_count.

### DIFF
--- a/zips/zip-0317.rst
+++ b/zips/zip-0317.rst
@@ -163,6 +163,13 @@ Input                                         Units  Description
 :math:`\mathit{nMemoChunks}`                  number the number of memo chunks
 ============================================= ====== ====================================================================
 
+Here, :math:`\mathit{tx\_in\_total\_size}` is the sum of the sizes in bytes of the
+serialized ``tx_in`` entries, and :math:`\mathit{tx\_out\_total\_size}` is the sum of
+the sizes in bytes of the serialized ``tx_out`` entries, as defined by the Bitcoin-style
+transaction format referenced in [#protocol-txnencoding]_. These totals do not include
+the size of the ``tx_in_count`` or ``tx_out_count`` CompactSize prefixes that precede
+the ``tx_in`` and ``tx_out`` arrays in the encoded transaction.
+
 It is not a consensus requirement that fees follow this formula; however,
 wallets SHOULD create transactions that pay this fee, in order to reduce
 information leakage, unless overridden by the user.


### PR DESCRIPTION
Closes #683.

The definitions of \`tx_in_total_size\` and \`tx_out_total_size\` were
ambiguous about whether the CompactSize \`tx_in_count\` and
\`tx_out_count\` prefixes that precede the \`tx_in\` and \`tx_out\` arrays
in the encoded transaction are included. A careful reading of the
protocol specification implies they are not, but the ZIP did not say
so explicitly. This ambiguity led to a bug in an initial
implementation attempt (see zcash/zcash#6524, discussion \`r1162854449\`).
This PR adds an explicit paragraph after the inputs table making the
exclusion unambiguous.

Filed with Claude Code assistance.