### PR TITLE
ZIP 321: Add Deployment section.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,6 @@ written.
     <tr> <td>312</td> <td class="left"><a href="zips/zip-0312.rst">FROST for Spend Authorization Multisignatures</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/382">zips#382</a></td>
     <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zips/zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/434">zips#434</a></td>
     <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/447">zips#447</a></td>
-    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zips/zip-0318.rst">Associated Payload Encryption</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/633">zips#633</a></td>
     <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zips/zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/635">zips#635</a></td>
     <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zips/zip-0322.rst">Generic Signed Message Format</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/429">zips#429</a></td>
     <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zips/zip-0323.rst">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/405">zips#405</a></td>
@@ -355,7 +354,6 @@ Index of ZIPs
     <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
     <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>[Revision 0] Active, [Revision 1] Withdrawn, [Revision 2] Draft</td>
     <tr> <td>317</td> <td class="left"><a href="zips/zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>Active</td>
-    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zips/zip-0318.rst">Associated Payload Encryption</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zips/zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
     <tr> <td>320</td> <td class="left"><a href="zips/zip-0320.rst">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Active</td>
     <tr> <td>321</td> <td class="left"><a href="zips/zip-0321.rst">Payment Request URIs</a></td> <td>Active</td>

--- a/zips/zip-0321.rst
+++ b/zips/zip-0321.rst
@@ -449,6 +449,23 @@ query parameter rather than in the ``hier-part`` of the URI. They may also
 not support the ``memo`` parameter, or may not treat it as base64url-encoded.
 
 
+Deployment
+==========
+
+ZIP 321 payment request URIs are widely deployed in the Zcash ecosystem.
+A reference implementation of parsing and construction of ZIP 321 URIs (for
+the ZEC-only subset of the format, excluding the ``req-asset`` extension) is
+provided by the ``zip321`` crate in the ``librustzcash`` repository
+[#librustzcash-zip321]_, and is used by wallets built on the
+``zcash_client_backend`` library. Support for ZIP 321 URIs has shipped in
+production wallets including Zashi, Nighthawk Wallet, Edge, Unstoppable
+Wallet, YWallet, and (historically) ZecWallet Lite, among others, and is
+commonly relied upon for generating QR codes and clickable payment links.
+
+The ``req-asset`` extension for Custom Asset payments described in this ZIP
+is not yet deployed, pending the activation of ZIP 227 [#zip-0227]_.
+
+
 References
 ==========
 
@@ -463,6 +480,7 @@ References
 .. [#zip-0173] `ZIP 173: Bech32 Format <zip-0173.rst>`_
 .. [#zip-0211] `ZIP 211: Disabling Addition of New Value to the Sprout Value Pool <zip-0211.rst>`_
 .. [#zip-0227] `ZIP 227: Issuance of Zcash Shielded Assets <zip-0227.rst>`_
+.. [#librustzcash-zip321] `librustzcash: zip321 crate <https://github.com/zcash/librustzcash/tree/main/components/zip321>`_
 .. [#zip-0227-asset-identifier] `ZIP 227: Issuance of Zcash Shielded Assets — Asset Identifier <zip-0227.rst#asset-identifier>`_
 .. [#zip-0316] `ZIP 316: Unified Addresses and Unified Viewing Keys <zip-0316.rst>`_
 .. [#protocol-networks] `Zcash Protocol Specification, Version 2023.4.0. Section 3.11: Mainnet and Testnet <protocol/protocol.pdf#networks>`_


### PR DESCRIPTION
Closes #937.

ZIP 321 has been Active since its initial publication; this PR adds an
explicit Deployment section describing its existing deployment in
production wallets and noting that the \`req-asset\` extension is not
yet deployed pending ZIP 227 activation.

### Reviewer notes (please verify before un-drafting)

The Deployment section's factual claims were drafted from general
ecosystem knowledge rather than direct repository inspection, and
should be sanity-checked:

1. **Wallet list.** Named wallets — Zashi, Nighthawk Wallet, Edge,
   Unstoppable Wallet, YWallet, and (historically) ZecWallet Lite — may
   need correction or trimming. Some notable wallets may also be missing.
2. **\`librustzcash\` zip321 crate path.** The referenced path
   (\`components/zip321\` vs. \`zip321\` at the repo root) was not
   verified against the live \`librustzcash\` tree from the worktree
   used to draft this PR.
3. **\`req-asset\` deployment status.** Claim that it is pending ZIP 227
   activation should be confirmed against current ZSA work.

Filed with Claude Code assistance.