### PR TITLE
ZIP 244, ZIP 246: Disambiguate scope of BLAKE2b-256 over per-input data.

### DIFF
--- a/zips/zip-0244.rst
+++ b/zips/zip-0244.rst
@@ -688,8 +688,8 @@ The personalization field of this hash is set to::
 A.1: transparent_scripts_digest
 ```````````````````````````````
 In the case that the transaction contains transparent inputs, this is a BLAKE2b-256 hash
-of the field encoding of the concatenated values of the Bitcoin script values associated
-with each transparent input belonging to the transaction.
+of the concatenation of the field encoding of the Bitcoin script value associated with
+each transparent input belonging to the transaction, in transaction order.
 
 The personalization field of this hash is set to::
 
@@ -702,11 +702,13 @@ In the case that the transaction has no transparent inputs, ``transparent_script
 A.2: sapling_auth_digest
 ````````````````````````
 In the case that Sapling Spends or Sapling Outputs are present, this is a BLAKE2b-256 hash
-of the field encoding of the Sapling ``zkproof`` value of each Sapling Spend Description,
-followed by the field encoding of the ``spend_auth_sig`` value of each Sapling Spend
-Description belonging to the transaction, followed by the field encoding of the
-``zkproof`` field of each Sapling Output Description belonging to the transaction,
-followed by the field encoding of the binding signature::
+of the concatenation of the field encoding of the Sapling ``zkproof`` value for each
+Sapling Spend Description belonging to the transaction in transaction order, followed by
+the concatenation of the field encoding of the ``spend_auth_sig`` value for each Sapling
+Spend Description belonging to the transaction in transaction order, followed by the
+concatenation of the field encoding of the ``zkproof`` field for each Sapling Output
+Description belonging to the transaction in transaction order, followed by the field
+encoding of the binding signature::
 
    A.2a: spend_zkproofs           (field encoding bytes)
    A.2b: spend_auth_sigs          (field encoding bytes)

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -529,7 +529,7 @@ Note that while the structure of ``sapling_auth_digest`` remains the same as in 
 A.1: transparent_auth_digest
 ````````````````````````````
 
-In the case that the transaction contains transparent inputs, this is a BLAKE2b-256 hash of the following values for each transparent input::
+In the case that the transaction contains transparent inputs, this is a BLAKE2b-256 hash of the concatenation of the field encoding of the ``TransparentSighashInfo`` value for each transparent input in transaction order, followed by the concatenation of the field encoding of the Bitcoin ``scriptSig`` value for each transparent input in transaction order::
 
    A.1a: TransparentSighashInfo    (field encoding bytes)
    A.1b: scriptSig                 (field encoding bytes)


### PR DESCRIPTION
Closes #1082.

In \`transparent_auth_digest\` (ZIP 246), \`sapling_auth_digest\` and
\`transparent_scripts_digest\` (ZIP 244), the existing wording
"BLAKE2b-256 hash of <X> for each <Y>" was ambiguous: it could be read
as either a single hash over the concatenation of all <X> values, or as
the concatenation of per-<Y> hashes. The intended reading (consistent
with the existing empty-case definition \`BLAKE2b-256(..., [])\` which
yields a single 32-byte output) is a single hash over the concatenation.
Each site is rephrased to make the concatenation explicit and to
specify transaction-order iteration.

The "For each X, the following elements are included in the hash"
pattern (T.3a.ii, T.3b.i/ii/iii, T.4a/b/c, T.5a, etc.) was left
untouched: that wording references a previously-named single hash and
is materially less ambiguous; broader cleanup of that pattern is a
separate concern.

Filed with Claude Code assistance.