### PR TITLE
[Protocol spec] Fix minor rendering issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,7 +208,7 @@ written.
     <tr> <td>400</td> <td class="left"><a href="zips/zip-0400.rst">Wallet.dat format</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zips/zip-0402.rst">New Wallet Database Format</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/365">zips#365</a></td>
     <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zips/zip-0403.rst">Verification Behaviour of zcashd</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/404">zips#404</a></td>
-    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zips/zip-0416.rst">Support for Unified Addresses in zcashd</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/503">zips#503</a></td>
+    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zips/zip-0416.rst">Spending Key Derivation in the `zcashd` wallet</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1175">zips#1175</a></td>
     <tr> <td>2002</td> <td class="left"><a href="zips/zip-2002.rst">Explicit Fees</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/803">zips#803</a></td>
     <tr> <td>2003</td> <td class="left"><a href="zips/zip-2003.rst">Disallow version 4 transactions</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/825">zips#825</a></td>
     <tr> <td>2004</td> <td class="left"><a href="zips/zip-2004.rst">Remove the dependency of consensus on note encryption</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/917">zips#917</a></td>
@@ -368,7 +368,7 @@ Index of ZIPs
     <tr> <td>401</td> <td class="left"><a href="zips/zip-0401.rst">Addressing Mempool Denial-of-Service</a></td> <td>Active</td>
     <tr> <td><span class="reserved">402</span></td> <td class="left"><a class="reserved" href="zips/zip-0402.rst">New Wallet Database Format</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">403</span></td> <td class="left"><a class="reserved" href="zips/zip-0403.rst">Verification Behaviour of zcashd</a></td> <td>Reserved</td>
-    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zips/zip-0416.rst">Support for Unified Addresses in zcashd</a></td> <td>Reserved</td>
+    <tr> <td><span class="reserved">416</span></td> <td class="left"><a class="reserved" href="zips/zip-0416.rst">Spending Key Derivation in the `zcashd` wallet</a></td> <td>Reserved</td>
     <tr> <td><strike>1001</strike></td> <td class="left"><strike><a href="zips/zip-1001.rst">Keep the Block Distribution as Initially Defined — 90% to Miners</a></strike></td> <td>Obsolete</td>
     <tr> <td><strike>1002</strike></td> <td class="left"><strike><a href="zips/zip-1002.rst">Opt-in Donation Feature</a></strike></td> <td>Obsolete</td>
     <tr> <td><strike>1003</strike></td> <td class="left"><strike><a href="zips/zip-1003.rst">20% Split Evenly Between the ECC and the Zcash Foundation, and a Voting System Mandate</a></strike></td> <td>Obsolete</td>

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -268,7 +268,7 @@
 \setlist[itemize]{itemsep=0.3ex,topsep=0.2ex,before=\vspace{-0.8ex},after=\vspace{1.5ex}}
 
 \newlist{compactitemize}{itemize}{3}
-\setlist[compactitemize]{itemsep=-1ex,topsep=0ex,before=\vspace{-0.2ex},leftmargin=1.2em,label=$\cdot$,after=\vspace{-3.3ex}}
+\setlist[compactitemize]{nosep,leftmargin=1.2em,label=$\cdot$}
 
 \newlist{formulae}{itemize}{3}
 \setlist[formulae]{itemsep=0.2ex,topsep=0ex,leftmargin=1.5em,label=,after=\vspace{1.5ex}}
@@ -785,6 +785,12 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 % The method of linking to the index is inspired by <https://tex.stackexchange.com/a/399776/78411>.
 % \texorpdfstring doesn't actually work here other than to cause an error if we would end up with a
 % link in a heading, rather than a hang.
+%
+% Caveat: if the rendered term (#1) line-breaks across a page boundary, pdfTeX/hyperref emits the
+% continuation /Link annotation on the second page with an uninitialised /Rect covering the whole
+% MediaBox, causing the entire page to highlight on hover in PDF.js. Workarounds: reword to avoid
+% the break at that site, or wrap the specific use in \mbox{...}. Wrapping the \hyperlink here
+% in \mbox would fix it globally but at the cost of paragraph fill quality for long terms.
 \newcommand{\indexlink}[3]{\texorpdfstring{\hypersetup{pdfborderstyle=/W 0}\hyperlink{index:#2}{#1}%
 \hypersetup{pdfborderstyle={/S/U/W 0.7}}\index{#2@{\protect\hypertarget{index:#2}{}\linkstrut\smash{#3}}|\indextype}}{}\xspace}
 
@@ -1402,7 +1408,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\zerobytes}[1]{[\hexint{00}]^{#1}}
 \newcommand{\ones}[1]{[1]^{#1}}
 \newcommand{\bit}{\mathbb{B}}
-\newcommand{\byte}{\mathbb{B}\kern -0.1em\raisebox{0.55ex}{\overlap{0.0001em}{\scalebox{0.7}{$\mathbb{Y}$}}}}
+\newcommand{\byte}{\mathbb{B}\kern -0.1em\raisebox{0.45ex}{\overlap{0.0001em}{\scalebox{0.7}{$\mathbb{Y}$}}}}
 \newcommand{\Nat}{\mathbb{N}}
 \newcommand{\PosInt}{\mathbb{N}^+}
 \newcommand{\Int}{\mathbb{Z}}
@@ -4090,9 +4096,8 @@ keep in mind at one time, in order to apprehend the connections of that piece to
 The work could be to extend or maintain the system, to understand its security or other properties,
 or to explain it to others.
 
-In this specification, we make use wherever possible of abstractions that have been developed by
-the cryptography community to model cryptographic primitives: \pseudoRandomFunctions, \commitmentSchemes,
-\signatureSchemes, etc.
+In this specification, we make use wherever possible of abstractions developed by the cryptography
+community to model cryptographic primitives: \pseudoRandomFunctions, \commitmentSchemes, \signatureSchemes, etc.
 Each abstract primitive has associated syntax (its interface as used by the rest of the system) and
 security properties, as documented in this part. Their instantiations are documented in part
 \crossref{concreteprotocol}.
@@ -5365,24 +5370,23 @@ Let $\GroupP$, $\reprP$, $\ellP$, $\ParamP{q}$, and $\ParamP{r}$ be as defined i
 \vspace{-0.2ex}
 Let $\ExtractP$ be as defined in \crossref{concreteextractorpallas}.
 
-\vspace{-0.3ex}
+\vspace{-0.2ex}
 Let $\GroupPHash$ be as defined in \crossref{concretegrouphashpallasandvesta}.
 
 \vspace{-0.2ex}
 Let $\PRFexpand{}$ and $\PRFock{Orchard}{}$ be as defined in \crossref{concreteprfs}.
 
-\vspace{-0.4ex}
+\vspace{-0.2ex}
 Let $\DeriveInternalFVKOrchard$ be as defined in \cite[Orchard internal key derivation]{ZIP-32}.
 
-\vspace{-0.2ex}
 Let $\PRPd{} \typecolon \DiversifierKeyType \times \DiversifierType \rightarrow \DiversifierType$
 be as defined in \crossref{concreteprps}.
 
-\vspace{-0.3ex}
+\vspace{-0.2ex}
 Let $\KA{Orchard}$, instantiated in \crossref{concreteorchardkeyagreement},
 be a \keyAgreementScheme.
 
-\vspace{-0.3ex}
+\vspace{-0.2ex}
 Let $\CommitIvk{}$, instantiated in \crossref{concretesinsemillacommit},
 be a \commitmentScheme.
 
@@ -5396,12 +5400,13 @@ be a \rerandomizableSignatureScheme.
 \vspace{-0.2ex}
 Let $\ItoLEBSP{}$, $\ItoLEOSP{}$, and $\LEOStoIP{}$ be as defined in \crossref{endian}.
 
-\vspace{0.4ex}
+\vspace{0.8ex}
 Define $\ToBase{Orchard}(x \typecolon \PRFOutputExpand) := \LEOStoIPOf{\PRFOutputLengthExpand}{x} \pmod{\ParamP{q}}$.
 
-\vspace{-1.3ex}
+\vspace{-1ex}
 Define $\ToScalar{Orchard}(x \typecolon \PRFOutputExpand) := \LEOStoIPOf{\PRFOutputLengthExpand}{x} \pmod{\ParamP{r}}$.
 
+\introlist
 Define $\DeriveDkAndOvkOrchard(\CommitIvkRand \typecolon \CommitIvkRandType, \AuthSignPublic \typecolon \AuthSignPublicTypeOrchard, \NullifierKey \typecolon \NullifierKeyTypeOrchard)$
 as follows:
 
@@ -5445,7 +5450,7 @@ the \outgoingViewingKey $\OutViewingKey \typecolon \OutViewingKeyType$, and corr
   \item let $\AuthSignPublic = \ExtractP(\AuthSignPublicPoint)$
         \vspace{-0.4ex}
   \item let $\InViewingKey = \CommitIvk{\CommitIvkRand}\big(\AuthSignPublic, \NullifierKey\big)$
-        \vspace{-0.3ex}
+        \vspace{-0.2ex}
   \item if $\InViewingKey \in \setof{0, \bot}$, discard this key and repeat with a new $\SpendingKey$.
         \vspace{-0.2ex}
   \item let $(\DiversifierKey, \OutViewingKey) = \DeriveDkAndOvkOrchard(\CommitIvkRand, \AuthSignPublic, \NullifierKey)$
@@ -13782,7 +13787,8 @@ derived from the \blockHeader and a nonce.
 \end{bytefield}
 \end{lrbox}
 
-Let $\powheader := \Justthebox[-7.5ex]{\powheaderbox}$
+\vspace{0.5ex}
+Let $\powheader := \Justthebox[-5.2ex]{\powheaderbox}$
 
 \vspace{1ex}
 For $i \in \range{1}{N}$, let $X_i = \EquihashGen{n, k}(\powheader, i)$.


### PR DESCRIPTION
This fixes overlaps in the transaction encoding tables, and a link target rendering bug on page 24 that caused the whole page to highlight on mouseover. It also regenerates README.rst after the reassignment of ZIP number 416.