### PR TITLE
Update ZIP 2004 deployment to NU6.3

### DIFF
--- a/zips/zip-2004.rst
+++ b/zips/zip-2004.rst
@@ -3,7 +3,7 @@
   ZIP: 2004
   Title: Remove the dependency of consensus on note encryption
   Owners: Daira-Emma Hopwood <daira@jacaranda.org>
-  Status: Draft
+  Status: Proposed
   Category: Consensus
   Created: 2024-10-22
   License: MIT
@@ -36,9 +36,9 @@ of note encryption. This has unnecessarily complicated the specification and
 implementation of consensus rules.
 
 This proposal disentangles note encryption from consensus, by instead requiring
-coinbase outputs for v6 and later transaction versions to be unencrypted. The
-disentanglement will be complete once earlier transaction versions are no longer
-allowed on the network, which is likely to happen in some later upgrade.
+coinbase outputs from NU6.3 onward to be unencrypted. The disentanglement will
+be complete once earlier transaction versions are no longer allowed on the
+network, which is likely to happen in some later upgrade.
 
 
 Motivation
@@ -69,9 +69,9 @@ This ZIP restores the originally intended design property.
 Requirements
 ============
 
-The consensus rule change specified in this ZIP must, from transaction version 6
-onward, make the implementation and specification of shielded coinbase outputs
-independent of note encryption.
+The consensus rule change specified in this ZIP must, from NU6.3 onward, make
+the implementation and specification of shielded coinbase outputs independent
+of note encryption.
 
 
 Specification
@@ -110,11 +110,11 @@ to
   let $\mathsf{NoteSym}$ and $\mathsf{NullSym}$ be as
   instantiated in § 5.4.3 'Symmetric Encryption'.
   
-  [Pre-NU7] let $\mathsf{Sym}$ be $\mathsf{NoteSym}$.
+  [Pre-NU6.3] let $\mathsf{Sym}$ be $\mathsf{NoteSym}$.
 
-  [NU7 onward] if the note to be decrypted is in an output of a version 6
-  or later coinbase transaction, let $\mathsf{Sym}$ be
-  $\mathsf{NullSym}$, otherwise let it be $\mathsf{NoteSym}$.
+  [NU6.3 onward] if the note to be decrypted is in an output of a coinbase
+  transaction, let $\mathsf{Sym}$ be $\mathsf{NullSym}$, otherwise let it be
+  $\mathsf{NoteSym}$.
 
 These changes apply identically to Mainnet and Testnet.
 
@@ -124,8 +124,7 @@ TODO: specify the handling of the ``ephemeralKey`` field.
 Deployment
 ==========
 
-This ZIP is proposed to be deployed with the next transaction version change,
-which is assumed to be v6. [#zip-0230]_
+This ZIP is proposed to be deployed with NU6.3.
 
 
 Reference implementation


### PR DESCRIPTION
## Summary
- promote ZIP 2004 from Draft to Proposed
- change the deployment trigger from v6 transaction format / NU7 wording to NU6.3 onward
- remove the version-6 coinbase transaction qualifier from the proposed decryption rule

## Verification
- git diff --check
- ./render.sh --rst zips/zip-2004.rst rendered/zip-2004.html fails locally because rst2html5 is not installed in this shell