### PR TITLE
Replace production rendering pipeline with `nix build` flow.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,40 +63,67 @@
           # Tests require additional fixtures not included in the PyPI tarball
           doCheck = false;
         };
+
+        buildInputs = [
+          # Core dependencies for render.sh
+          rst2html5 # rst2html5 2.0.1 (PyPI)
+          pkgs.python3Packages.pygments # syntax highlighting for code blocks
+          pkgs.pandoc # pandoc markdown renderer
+          mmd # multimarkdown renderer (zcash fork)
+          pkgs.perl # perl for text processing
+
+          # Build system dependencies
+          pkgs.gnumake # make command for building
+          pkgs.git # required by Makefile for safe.directory
+
+          # LaTeX dependencies for protocol PDF generation
+          (pkgs.texlive.combine { inherit (pkgs.texlive) scheme-full; })
+
+          # Python dependencies for links_and_dests.py
+          pkgs.python3
+          pkgs.python3Packages.beautifulsoup4
+          pkgs.python3Packages.html5lib
+          pkgs.python3Packages.certifi
+
+          # Standard utilities (usually available, but ensuring they're present)
+          pkgs.coreutils
+          pkgs.bash
+          pkgs.gnused
+          pkgs.gnugrep
+          pkgs.diffutils
+          pkgs.findutils
+        ];
+
+        all = pkgs.stdenv.mkDerivation {
+          pname = "zcash-zips-rendered-all";
+          version = "0.0.1";
+          src = ./.;
+
+          inherit buildInputs;
+
+          buildPhase = ''
+            # Subprocess for bash set flags scope, especially -x so that we
+            # don't see very verbose nix cleanup traces on errors:
+            (
+              set -efuxo pipefail
+              # Ewww... looks like `kpathsea` mutates the user's home.
+              # Create a fake home dir inside the buildir:
+              fake_home='./messy-fake-home'
+              mkdir "$fake_home"
+              HOME="$fake_home" make all
+            )
+          '';
+        };
       in
       {
+        packages = {
+          inherit all;
+
+          default = all;
+        };
+
         devShells.default = pkgs.mkShell {
-          buildInputs = [
-            # Core dependencies for render.sh
-            rst2html5 # rst2html5 2.0.1 (PyPI)
-            pkgs.python3Packages.pygments # syntax highlighting for code blocks
-            pkgs.pandoc # pandoc markdown renderer
-            mmd # multimarkdown renderer (zcash fork)
-            pkgs.perl # perl for text processing
-
-            # Build system dependencies
-            pkgs.gnumake # make command for building
-            pkgs.git # required by Makefile for safe.directory
-
-            # LaTeX dependencies for protocol PDF generation
-            (pkgs.texlive.combine {
-              inherit (pkgs.texlive) scheme-full;
-            })
-
-            # Python dependencies for links_and_dests.py
-            pkgs.python3
-            pkgs.python3Packages.beautifulsoup4
-            pkgs.python3Packages.html5lib
-            pkgs.python3Packages.certifi
-
-            # Standard utilities (usually available, but ensuring they're present)
-            pkgs.coreutils
-            pkgs.bash
-            pkgs.gnused
-            pkgs.gnugrep
-            pkgs.diffutils
-            pkgs.findutils
-          ];
+          inherit buildInputs;
 
           shellHook = ''
             echo "ZIP documentation rendering environment"


### PR DESCRIPTION
The goal of this PR is to replace the production rendering pipeline to use `nix build`.

**Motivation:** As a nix-supremacy conspirator, I view all software as on a continuum where the desired end-point is that it is packaged so that `nix build` with the default target gives me everything I'd ever want to automatically derive about that software package, without needing to know anything about how that derivation happens (so passing commands/args to `nix develop --command` fails to meet the extreme of this continuum). The other end of the continuum is "not yet packaged sufficiently in `nix`", which is just a transient state our future selves will call the dark ages of software supply chains.

The only kind of snag I'm aware of that may exist is if the [`nix develop --command ...`](https://github.com/ShieldedLabs/zips/blob/59d4ecf24caeab6ad6cb5b71ec3ad52675b4b613/.github/actions/render/action.yml#L22) rendering is doing something funky with caching or non-explicit config via `/tmp/dev-profile`.

blocked by #1300