### PR TITLE
Assign ZIP 229 to v6 transaction format

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,7 +70,6 @@ The following ZIPs are under consideration for deployment in NU7:
 - `ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation <zips/zip-0233.md>`__
 - `ZIP 234: Network Sustainability Mechanism: Issuance Smoothing <zips/zip-0234.md>`__
 - `ZIP 235: Network Sustainability Mechanism: Remove 60% of Transaction Fees From Circulation <zips/zip-0235.md>`__
-- `ZIP 246: Digests for the Version 6 Transaction Format <zips/zip-0246.rst>`__
 - `ZIP 2002: Explicit Fees <zips/zip-2002.rst>`__
 - `ZIP 2003: Disallow version 4 transactions <zips/zip-2003.rst>`__
 
@@ -178,13 +177,13 @@ written.
     <tr> <td>226</td> <td class="left"><a href="zips/zip-0226.rst">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/618">zips#618</a></td>
     <tr> <td>227</td> <td class="left"><a href="zips/zip-0227.rst">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/618">zips#618</a></td>
     <tr> <td><span class="reserved">228</span></td> <td class="left"><a class="reserved" href="zips/zip-0228.rst">Asset Swaps for Zcash Shielded Assets</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/776">zips#776</a></td>
+    <tr> <td>229</td> <td class="left"><a href="zips/zip-0229.md">Version 6 Transaction Format</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td>231</td> <td class="left"><a href="zips/zip-0231.md">Memo Bundles</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/627">zips#627</a></td>
     <tr> <td>233</td> <td class="left"><a href="zips/zip-0233.md">Network Sustainability Mechanism: Removing Funds From Circulation</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/922">zips#922</a></td>
     <tr> <td>234</td> <td class="left"><a href="zips/zip-0234.md">Network Sustainability Mechanism: Issuance Smoothing</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/923">zips#923</a></td>
     <tr> <td>235</td> <td class="left"><a href="zips/zip-0235.md">Remove 60% of Transaction Fees From Circulation</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/924">zips#924</a></td>
     <tr> <td><span class="reserved">240</span></td> <td class="left"><a class="reserved" href="zips/zip-0240.md">Standard Transaction Rules</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/648">zips#648</a></td>
     <tr> <td>245</td> <td class="left"><a href="zips/zip-0245.rst">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/384">zips#384</a></td>
-    <tr> <td>246</td> <td class="left"><a href="zips/zip-0246.rst">Digests for the Version 6 Transaction Format</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td>258</td> <td class="left"><a href="zips/zip-0258.md">Deployment of the NU6.3 Network Upgrade</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1304">zips#1304</a></td>
     <tr> <td><span class="reserved">260</span></td> <td class="left"><a class="reserved" href="zips/zip-0260.md">Extending Block Messages with Additional Authentication Data</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/522">zips#522</a></td>
     <tr> <td><span class="reserved">270</span></td> <td class="left"><a class="reserved" href="zips/zip-0270.md">Key Rotation for Tracked Signing Keys</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1047">zips#1047</a></td>
@@ -236,7 +235,6 @@ be deleted.
     <tr> <td class="left">draft-ecc-authenticated-reply-addrs</td> <td class="left"><a href="zips/draft-ecc-authenticated-reply-addrs.md">Authenticated Reply Addresses</a></td> <td class="left"><a href="https://github.com/zcash/zips/issues/1230">zips#1230</a></td>
     <tr> <td class="left">draft-ecc-onchain-accountable-voting</td> <td class="left"><a href="zips/draft-ecc-onchain-accountable-voting.md">On-chain Accountable Voting</a></td> <td class="left"></td>
     <tr> <td class="left">draft-str4d-orchard-balance-proof</td> <td class="left"><a href="zips/draft-str4d-orchard-balance-proof.md">Air drops, Proof-of-Balance, and Stake-weighted Polling</a></td> <td class="left"><a href="https://github.com/zcash/zips/issues/1229">zips#1229</a></td>
-    <tr> <td class="left">draft-zodl-valargroup-ironwood-txformat</td> <td class="left"><a href="zips/draft-zodl-valargroup-ironwood-txformat.md">Version 6 Transaction Format</a></td> <td class="left"></td>
   </table></embed>
 
 Withdrawn, Rejected, or Obsolete ZIPs
@@ -251,6 +249,7 @@ Withdrawn, Rejected, or Obsolete ZIPs
     <tr> <td><strike>210</strike></td> <td class="left"><strike><a href="zips/zip-0210.rst">Sapling Anchor Deduplication within Transactions</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>220</strike></td> <td class="left"><strike><a href="zips/zip-0220.rst">Zcash Shielded Assets</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>230</strike></td> <td class="left"><strike><a href="zips/zip-0230.rst">Withdrawn Version 6 Transaction Format</a></strike></td> <td>Withdrawn</td>
+    <tr> <td><strike>246</strike></td> <td class="left"><strike><a href="zips/zip-0246.rst">Digests for the Version 6 Transaction Format</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>254</strike></td> <td class="left"><strike><a href="zips/zip-0254.md">Deployment of the NU7 Network Upgrade (Withdrawn)</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>303</strike></td> <td class="left"><strike><a href="zips/zip-0303.rst">Sprout Payment Disclosure</a></strike></td> <td>Withdrawn</td>
     <tr> <td><strike>313</strike></td> <td class="left"><strike><a href="zips/zip-0313.rst">Reduce Conventional Transaction Fee to 1000 zatoshis</a></strike></td> <td>Obsolete</td>
@@ -318,6 +317,7 @@ Index of ZIPs
     <tr> <td>226</td> <td class="left"><a href="zips/zip-0226.rst">Transfer and Burn of Zcash Shielded Assets</a></td> <td>Draft</td>
     <tr> <td>227</td> <td class="left"><a href="zips/zip-0227.rst">Issuance of Zcash Shielded Assets</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">228</span></td> <td class="left"><a class="reserved" href="zips/zip-0228.rst">Asset Swaps for Zcash Shielded Assets</a></td> <td>Reserved</td>
+    <tr> <td>229</td> <td class="left"><a href="zips/zip-0229.md">Version 6 Transaction Format</a></td> <td>Draft</td>
     <tr> <td><strike>230</strike></td> <td class="left"><strike><a href="zips/zip-0230.rst">Withdrawn Version 6 Transaction Format</a></strike></td> <td>Withdrawn</td>
     <tr> <td>231</td> <td class="left"><a href="zips/zip-0231.md">Memo Bundles</a></td> <td>Draft</td>
     <tr> <td>233</td> <td class="left"><a href="zips/zip-0233.md">Network Sustainability Mechanism: Removing Funds From Circulation</a></td> <td>Draft</td>
@@ -329,7 +329,7 @@ Index of ZIPs
     <tr> <td>243</td> <td class="left"><a href="zips/zip-0243.rst">Transaction Signature Validation for Sapling</a></td> <td>Final</td>
     <tr> <td>244</td> <td class="left"><a href="zips/zip-0244.rst">Transaction Identifier Non-Malleability</a></td> <td>Final</td>
     <tr> <td>245</td> <td class="left"><a href="zips/zip-0245.rst">Transaction Identifier Digests & Signature Validation for Transparent Zcash Extensions</a></td> <td>Draft</td>
-    <tr> <td>246</td> <td class="left"><a href="zips/zip-0246.rst">Digests for the Version 6 Transaction Format</a></td> <td>Draft</td>
+    <tr> <td><strike>246</strike></td> <td class="left"><strike><a href="zips/zip-0246.rst">Digests for the Version 6 Transaction Format</a></strike></td> <td>Withdrawn</td>
     <tr> <td>250</td> <td class="left"><a href="zips/zip-0250.rst">Deployment of the Heartwood Network Upgrade</a></td> <td>Final</td>
     <tr> <td>251</td> <td class="left"><a href="zips/zip-0251.rst">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
     <tr> <td>252</td> <td class="left"><a href="zips/zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>

--- a/zips/zip-0229.md
+++ b/zips/zip-0229.md
@@ -1,7 +1,9 @@
-    ZIP: XXX
+    ZIP: 229
     Title: Version 6 Transaction Format
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
-            ‹other ZODL / Valar Group authors›
+            Kris Nuttycombe <kris@nutty.land>
+            Dev Ojha <dev@valargroup.dev>
+            Sean Bowe <sean@bowe.tech>
     Status: Draft
     Category: Consensus
     Created: 2026-06-13

--- a/zips/zip-0246.rst
+++ b/zips/zip-0246.rst
@@ -7,7 +7,7 @@
           Daira-Emma Hopwood <daira@jacaranda.org>
           Jack Grigg <thestr4d@gmail.com>
           Kris Nuttycombe <kris@nutty.land>
-  Status: Draft
+  Status: Withdrawn
   Category: Consensus
   Created: 2025-02-12
   License: MIT
@@ -34,6 +34,11 @@ Abstract
 
 This ZIP defines the sighash algorithms associated with the v6 transaction
 format.
+
+.. warning::
+    This ZIP has been withdrawn. Version 6 transaction identifiers, authorizing
+    data commitments, and signature digests are now specified by ZIP 229
+    [#zip-0229]_.
 
 This proposal also defines the new concept of "sighash algorithm versioning":
 where previously each transaction version had a single associated sighash
@@ -642,6 +647,7 @@ References
 .. [#protocol-actiondesc] `Zcash Protocol Specification, Version 2025.6.2 [NU6.1]. Section 4.6: Action Descriptions <protocol/protocol.pdf#actiondesc>`_
 .. [#protocol-txnencoding] `Zcash Protocol Specification, Version 2022.3.8. Section 7.1: Transaction Encoding and Consensus <protocol/protocol.pdf#txnencoding>`_
 .. [#zip-0200] `ZIP 200: Network Upgrade Mechanism <zip-0200.rst>`_
+.. [#zip-0229] `ZIP 229: Version 6 Transaction Format <zip-0229.md>`_
 .. [#zip-0230-transaction-format] `ZIP 230: Version 6 Transaction Format — Specification: Transaction Format <zip-0230.rst#transaction-format>`_
 .. [#zip-0230-orchardzsa-action-group-description] `ZIP 230: Version 6 Transaction Format — Specification: OrchardZSA Action Group Description  <zip-0230.rst#orchardzsa-action-group-description>`_
 .. [#zip-0230-orchardzsa-action-description-orchardzsaaction] `ZIP 230: Version 6 Transaction Format — Specification: OrchardZSA Action Description <zip-0230.rst#orchardzsa-action-description-orchardzsaaction>`_

--- a/zips/zip-0258.md
+++ b/zips/zip-0258.md
@@ -25,14 +25,14 @@ The terms "Mainnet" and "Testnet" are to be interpreted as described in § 3.12
 
 The terms "Orchard protocol", "*Orchard pool*", "*Ironwood pool*", "*Orchard-pool* Action", and
 "version 6 transaction" are to be interpreted as described in
-[^draft-zodl-valargroup-ironwood-txformat].
+[^zip-0229].
 
 
 # Abstract
 
 This proposal defines the deployment of the NU6.3 network upgrade, which introduces the
 Ironwood shielded pool. The consensus changes for NU6.3 are specified across the version 6
-transaction format [^draft-zodl-valargroup-ironwood-txformat], the Orchard Action circuit
+transaction format [^zip-0229], the Orchard Action circuit
 update [^draft-zodl-valargroup-action-circuit-update], ZIP 2005 [^zip-2005], and this ZIP,
 which fixes the activation parameters and the consensus rules that gate on NU6.3 activation
 regardless of transaction version.
@@ -46,7 +46,7 @@ The primary sources of information about NU6.3 consensus protocol changes are:
 
 * The Zcash Protocol Specification [^protocol].
 * ZIP 200: Network Upgrade Mechanism [^zip-0200].
-* The version 6 transaction format [^draft-zodl-valargroup-ironwood-txformat], the Orchard
+* The version 6 transaction format [^zip-0229], the Orchard
   Action circuit update [^draft-zodl-valargroup-action-circuit-update], and ZIP 2005
   [^zip-2005].
 
@@ -66,7 +66,7 @@ MIN_NETWORK_PROTOCOL_VERSION (NU6.3)
 : Testnet: TBD
 : Mainnet: TBD
 
-The version group ID for version 6 transactions [^draft-zodl-valargroup-ironwood-txformat] is:
+The version group ID for version 6 transactions [^zip-0229] is:
 
 TX_VERSION_GROUP_ID (v6)
 : TBD
@@ -181,6 +181,6 @@ lower protocol versions.
 
 [^zip-2005]: [ZIP 2005: Ironwood Quantum Recoverability](zip-2005.md)
 
-[^draft-zodl-valargroup-ironwood-txformat]: [Version 6 Transaction Format (draft)](draft-zodl-valargroup-ironwood-txformat.md)
+[^zip-0229]: [ZIP 229: Version 6 Transaction Format](zip-0229.md)
 
 [^draft-zodl-valargroup-action-circuit-update]: [NU6.2 and NU6.3 updates to the Orchard Circuit (draft)](draft-zodl-valargroup-action-circuit-update.md)

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -48,7 +48,7 @@ and similarly for other Orchard-specific hash function names. The changes
 to the protocol specification and to other ZIPs use the full forms.
 
 The terms "*Ironwood pool*" and "*Orchard pool*" are to be interpreted as
-described in [^draft-zodl-valargroup-ironwood-txformat]. Following the
+described in [^zip-0229]. Following the
 convention in the protocol specification, we use *slanted text* to refer
 to pool names, in order to more clearly distinguish them from shielded
 protocols.
@@ -69,7 +69,7 @@ the Orchard protocol [^zip-0226] [^zip-0227] if that were deployed.
 # Abstract
 
 This ZIP proposes a change to the construction of notes, to be deployed for the
-*Ironwood pool* [^draft-zodl-valargroup-ironwood-txformat], designed to improve
+*Ironwood pool* [^zip-0229], designed to improve
 Zcash's long-term resilience against a significant potential threat to its security
 from quantum computers. It does not by itself make the protocol secure against
 quantum adversaries, but is intended to support a smoother transition to future
@@ -1974,11 +1974,11 @@ recoverable Orchard funds.
 Note that we can precisely identify the set of note commitments for recoverable
 notes, even though we cannot decrypt them: the recoverable notes are exactly the
 *Ironwood-pool* notes, so their commitments are exactly those in the
-*Ironwood pool*'s note commitment tree [^draft-zodl-valargroup-ironwood-txformat].
+*Ironwood pool*'s note commitment tree [^zip-0229].
 
 We can likewise identify the precise set of nullifiers for recoverable notes:
 they are exactly the *Ironwood-pool* nullifiers, which form a nullifier set
-separate from that of the *Orchard pool* [^draft-zodl-valargroup-ironwood-txformat].
+separate from that of the *Orchard pool* [^zip-0229].
 
 Within the Recovery Statement we also know that the note being spent is
 recoverable.
@@ -2025,7 +2025,7 @@ that NU6.3 provides.
 
 This change is enforced from NU6.3: every *Ironwood-pool* output note is a
 recoverable note, and no *Orchard-pool* output note is
-[^draft-zodl-valargroup-ironwood-txformat].
+[^zip-0229].
 
 When a compliant wallet receives an Orchard note with lead byte
 $\mathtt{0x02}$, the associated funds are not recoverable and need to be
@@ -2130,6 +2130,6 @@ manipulate the note selection algorithm to some extent.
 
 [^Google2025]: [Securing Elliptic Curve Cryptocurrencies against Quantum Vulnerabilities: Resource Estimates and Mitigations. Ryan Babbush, Adam Zalcman, Craig Gidney, Michael Broughton, Tanuj Khattar, Hartmut Neven, Thiago Bergamaschi, Justin Drake, and Dan Boneh](https://quantumai.google/static/site-assets/downloads/cryptocurrency-whitepaper.pdf)
 
-[^draft-zodl-valargroup-ironwood-txformat]: [Version 6 Transaction Format (draft)](draft-zodl-valargroup-ironwood-txformat.md)
+[^zip-0229]: [ZIP 229: Version 6 Transaction Format](zip-0229.md)
 
 [^draft-zodl-valargroup-deploy-nu6.3]: [Deployment of the NU6.3 Network Upgrade (draft)](draft-zodl-valargroup-deploy-nu6.3.md)


### PR DESCRIPTION
Rename the Ironwood v6 transaction format draft to ZIP 229, update references, and withdraw the superseded ZIP 246 digest draft.