### PR TITLE
Protocol Specification version 2026.7.0 and ZIP 257 (NU6.2)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,15 +46,26 @@ See `here <protocol/README.rst>`__ for the project dependencies.
 Settled Mainnet Network Upgrade
 -------------------------------
 
-The most recent [settled](https://zips.z.cash/protocol/protocol.pdf#blockchain) Network Upgrade
-on Mainnet is NU6.1, which activated at Mainnet block height 3146400 on November 24, 2025, at
-19:56 UTC.
+The most recent `settled <https://zips.z.cash/protocol/protocol.pdf#blockchain>`__ Network Upgrade on Mainnet is NU6.2,
+which activated at Mainnet block height 3364600 on June 3, 2026, at 04:03 UTC.
 
-NU6.1 is described in `ZIP 255: Deployment of the NU6.1 Network Upgrade <zips/zip-0255.md>`__.
-It deployed the following ZIPs:
+NU6.2 is described in `ZIP 257: Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade <zips/zip-0257.md>`__.
 
-- `ZIP 1016: Community and Coinholder Funding Model <zips/zip-1016.md>`__
-- `ZIP 271: Deferred Dev Fund Lockbox Disbursement <zips/zip-0271.md>`__
+
+NU6.3 Candidate ZIPs
+--------------------
+
+NU6.3 is described in `ZIP 258: Deployment of the NU6.3 Network Upgrade <zips/zip-0258.md>`__
+and the following additional ZIPs:
+
+- `ZIP 229: Version 6 Transaction Format <zips/zip-0229.md>`__
+- `ZIP 2005: Ironwood Quantum Recoverability <zips/zip-2005.rst>`__
+- `ZIP 2006: Restricting Transfers to the Orchard Pool <zips/zip-2006.rst>`__
+- `ZIP 318: Orchard to Ironwood Migration <zips/zip-0318.rst>`__
+- `ZIP 326: NU6.3 Consequences for Wallets <zips/zip-0326.rst>`__
+
+`ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances <zips/zip-0209.rst>`__
+and `ZIP 317: Proportional Transfer Fee Mechanism <zips/zip-0317.rst>`__ will be updated.
 
 
 NU7 Candidate ZIPs
@@ -63,8 +74,6 @@ NU7 Candidate ZIPs
 The following ZIPs are under consideration for deployment in NU7:
 
 - `ZIP 218: 25-second Block Target Spacing <zips/zip-0218.md>`__
-- `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zips/zip-0226.rst>`__
-- `ZIP 227: Issuance of Zcash Shielded Assets <zips/zip-0227.rst>`__
 - `ZIP 230: Version 6 Transaction Format <zips/zip-0230.rst>`__
 - `ZIP 231: Memo Bundles <zips/zip-0231.md>`__
 - `ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation <zips/zip-0233.md>`__
@@ -129,9 +138,9 @@ Released ZIPs
     <tr> <td>251</td> <td class="left"><a href="zips/zip-0251.rst">Deployment of the Canopy Network Upgrade</a></td> <td>Final</td>
     <tr> <td>252</td> <td class="left"><a href="zips/zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
     <tr> <td>253</td> <td class="left"><a href="zips/zip-0253.md">Deployment of the NU6 Network Upgrade</a></td> <td>Final</td>
-    <tr> <td>255</td> <td class="left"><a href="zips/zip-0255.md">Deployment of the NU6.1 Network Upgrade</a></td> <td>Proposed</td>
-    <tr> <td>256</td> <td class="left"><a href="zips/zip-0256.md">Deployment of Consensus Bug Fixes Between NU6.1 and NU6.2</a></td> <td>Proposed</td>
-    <tr> <td>257</td> <td class="left"><a href="zips/zip-0257.md">Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade</a></td> <td>Proposed</td>
+    <tr> <td>255</td> <td class="left"><a href="zips/zip-0255.md">Deployment of the NU6.1 Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>256</td> <td class="left"><a href="zips/zip-0256.md">Deployment of Consensus Bug Fixes Between NU6.1 and NU6.2</a></td> <td>Final</td>
+    <tr> <td>257</td> <td class="left"><a href="zips/zip-0257.md">Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade</a></td> <td>Final</td>
     <tr> <td>271</td> <td class="left"><a href="zips/zip-0271.md">Dev Fund Extension and One-Time Disbursement</a></td> <td>Proposed</td>
     <tr> <td>300</td> <td class="left"><a href="zips/zip-0300.rst">Cross-chain Atomic Transactions</a></td> <td>Proposed</td>
     <tr> <td>301</td> <td class="left"><a href="zips/zip-0301.rst">Zcash Stratum Protocol</a></td> <td>Active</td>
@@ -200,11 +209,13 @@ written.
     <tr> <td>312</td> <td class="left"><a href="zips/zip-0312.rst">FROST for Spend Authorization Multisignatures</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/382">zips#382</a></td>
     <tr> <td><span class="reserved">314</span></td> <td class="left"><a class="reserved" href="zips/zip-0314.rst">Privacy upgrades to the Zcash light client protocol</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/434">zips#434</a></td>
     <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/447">zips#447</a></td>
+    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zips/zip-0318.rst">Orchard to Ironwood Migration</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1315">zips#1315</a></td>
     <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zips/zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/635">zips#635</a></td>
     <tr> <td><span class="reserved">322</span></td> <td class="left"><a class="reserved" href="zips/zip-0322.rst">Generic Signed Message Format</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/429">zips#429</a></td>
     <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zips/zip-0323.rst">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/405">zips#405</a></td>
     <tr> <td>324</td> <td class="left"><a href="zips/zip-0324.rst">URI-Encapsulated Payments</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/421">zips#421</a></td>
     <tr> <td>325</td> <td class="left"><a href="zips/zip-0325.md">Account Metadata Keys</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1233">zips#1233</a></td>
+    <tr> <td><span class="reserved">326</span></td> <td class="left"><a class="reserved" href="zips/zip-0326.rst">NU6.3 Consequences for Wallets</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1318">zips#1318</a></td>
     <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zips/zip-0332.rst">Wallet Recovery from zcashd HD Seeds</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/675">zips#675</a></td>
     <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zips/zip-0339.rst">Wallet Recovery Words</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/364">zips#364</a></td>
     <tr> <td><span class="reserved">350</span></td> <td class="left"><a class="reserved" href="zips/zip-0350.md">Bech32m</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/484">zips#484</a></td>
@@ -215,6 +226,7 @@ written.
     <tr> <td>2002</td> <td class="left"><a href="zips/zip-2002.rst">Explicit Fees</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/803">zips#803</a></td>
     <tr> <td>2003</td> <td class="left"><a href="zips/zip-2003.rst">Disallow version 4 transactions</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/825">zips#825</a></td>
     <tr> <td>2004</td> <td class="left"><a href="zips/zip-2004.rst">Remove the dependency of consensus on note encryption</a></td> <td>Draft</td> <td class="left"><a href="https://github.com/zcash/zips/issues/917">zips#917</a></td>
+    <tr> <td><span class="reserved">2006</span></td> <td class="left"><a class="reserved" href="zips/zip-2006.rst">Restricting Transfers to the Orchard Pool</a></td> <td>Reserved</td> <td class="left"><a href="https://github.com/zcash/zips/issues/1305">zips#1305</a></td>
     <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td> <td class="left"></td>
     <tr> <td>template</td> <td class="left"><a href="zips/zip-template.md">{Template for new ZIPs}</a></td> <td>Draft</td> <td class="left"></td>
@@ -337,9 +349,9 @@ Index of ZIPs
     <tr> <td>252</td> <td class="left"><a href="zips/zip-0252.rst">Deployment of the NU5 Network Upgrade</a></td> <td>Final</td>
     <tr> <td>253</td> <td class="left"><a href="zips/zip-0253.md">Deployment of the NU6 Network Upgrade</a></td> <td>Final</td>
     <tr> <td><strike>254</strike></td> <td class="left"><strike><a href="zips/zip-0254.md">Deployment of the NU7 Network Upgrade (Withdrawn)</a></strike></td> <td>Withdrawn</td>
-    <tr> <td>255</td> <td class="left"><a href="zips/zip-0255.md">Deployment of the NU6.1 Network Upgrade</a></td> <td>Proposed</td>
-    <tr> <td>256</td> <td class="left"><a href="zips/zip-0256.md">Deployment of Consensus Bug Fixes Between NU6.1 and NU6.2</a></td> <td>Proposed</td>
-    <tr> <td>257</td> <td class="left"><a href="zips/zip-0257.md">Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade</a></td> <td>Proposed</td>
+    <tr> <td>255</td> <td class="left"><a href="zips/zip-0255.md">Deployment of the NU6.1 Network Upgrade</a></td> <td>Final</td>
+    <tr> <td>256</td> <td class="left"><a href="zips/zip-0256.md">Deployment of Consensus Bug Fixes Between NU6.1 and NU6.2</a></td> <td>Final</td>
+    <tr> <td>257</td> <td class="left"><a href="zips/zip-0257.md">Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade</a></td> <td>Final</td>
     <tr> <td>258</td> <td class="left"><a href="zips/zip-0258.md">Deployment of the NU6.3 Network Upgrade</a></td> <td>Draft</td>
     <tr> <td><span class="reserved">260</span></td> <td class="left"><a class="reserved" href="zips/zip-0260.md">Extending Block Messages with Additional Authentication Data</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">270</span></td> <td class="left"><a class="reserved" href="zips/zip-0270.md">Key Rotation for Tracked Signing Keys</a></td> <td>Reserved</td>
@@ -362,6 +374,7 @@ Index of ZIPs
     <tr> <td>315</td> <td class="left"><a href="zips/zip-0315.rst">Best Practices for Wallet Implementations</a></td> <td>Draft</td>
     <tr> <td>316</td> <td class="left"><a href="zips/zip-0316.rst">Unified Addresses and Unified Viewing Keys</a></td> <td>[Revision 0] Active, [Revision 1] Withdrawn, [Revision 2] Draft</td>
     <tr> <td>317</td> <td class="left"><a href="zips/zip-0317.rst">Proportional Transfer Fee Mechanism</a></td> <td>[Revision 0] Active, [Revision 1: NU6.3] Draft, [Revision 2] Draft</td>
+    <tr> <td><span class="reserved">318</span></td> <td class="left"><a class="reserved" href="zips/zip-0318.rst">Orchard to Ironwood Migration</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">319</span></td> <td class="left"><a class="reserved" href="zips/zip-0319.rst">Options for Shielded Pool Retirement</a></td> <td>Reserved</td>
     <tr> <td>320</td> <td class="left"><a href="zips/zip-0320.rst">Defining an Address Type to which funds can only be sent from Transparent Addresses</a></td> <td>Active</td>
     <tr> <td>321</td> <td class="left"><a href="zips/zip-0321.rst">Payment Request URIs</a></td> <td>Active</td>
@@ -369,6 +382,7 @@ Index of ZIPs
     <tr> <td><span class="reserved">323</span></td> <td class="left"><a class="reserved" href="zips/zip-0323.rst">Specification of getblocktemplate for Zcash</a></td> <td>Reserved</td>
     <tr> <td>324</td> <td class="left"><a href="zips/zip-0324.rst">URI-Encapsulated Payments</a></td> <td>Draft</td>
     <tr> <td>325</td> <td class="left"><a href="zips/zip-0325.md">Account Metadata Keys</a></td> <td>Draft</td>
+    <tr> <td><span class="reserved">326</span></td> <td class="left"><a class="reserved" href="zips/zip-0326.rst">NU6.3 Consequences for Wallets</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">332</span></td> <td class="left"><a class="reserved" href="zips/zip-0332.rst">Wallet Recovery from zcashd HD Seeds</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">339</span></td> <td class="left"><a class="reserved" href="zips/zip-0339.rst">Wallet Recovery Words</a></td> <td>Reserved</td>
     <tr> <td><span class="reserved">350</span></td> <td class="left"><a class="reserved" href="zips/zip-0350.md">Bech32m</a></td> <td>Reserved</td>
@@ -399,6 +413,7 @@ Index of ZIPs
     <tr> <td>2003</td> <td class="left"><a href="zips/zip-2003.rst">Disallow version 4 transactions</a></td> <td>Draft</td>
     <tr> <td>2004</td> <td class="left"><a href="zips/zip-2004.rst">Remove the dependency of consensus on note encryption</a></td> <td>Draft</td>
     <tr> <td>2005</td> <td class="left"><a href="zips/zip-2005.md">Ironwood Quantum Recoverability</a></td> <td>Proposed</td>
+    <tr> <td><span class="reserved">2006</span></td> <td class="left"><a class="reserved" href="zips/zip-2006.rst">Restricting Transfers to the Orchard Pool</a></td> <td>Reserved</td>
     <tr> <td>guide-markdown</td> <td class="left"><a href="zips/zip-guide-markdown.md">{Something Short and To the Point}</a></td> <td>Draft</td>
     <tr> <td>guide</td> <td class="left"><a href="zips/zip-guide.rst">{Something Short and To the Point}</a></td> <td>Draft</td>
     <tr> <td>template</td> <td class="left"><a href="zips/zip-template.md">{Template for new ZIPs}</a></td> <td>Draft</td>

--- a/README.template
+++ b/README.template
@@ -52,14 +52,28 @@ which activated at Mainnet block height 3364600 on June 3, 2026, at 04:03 UTC.
 NU6.2 is described in `ZIP 257: Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade <zips/zip-0257.md>`__.
 
 
+NU6.3 Candidate ZIPs
+--------------------
+
+NU6.3 is described in `ZIP 258: Deployment of the NU6.3 Network Upgrade <zips/zip-0258.md>`__
+and the following additional ZIPs:
+
+- `ZIP 229: Version 6 Transaction Format <zips/zip-0229.md>`__
+- `ZIP 2005: Ironwood Quantum Recoverability <zips/zip-2005.rst>`__
+- `ZIP 2006: Restricting Transfers to the Orchard Pool <zips/zip-2006.rst>`__
+- `ZIP 318: Orchard to Ironwood Migration <zips/zip-0318.rst>`__
+- `ZIP 326: NU6.3 Consequences for Wallets <zips/zip-0326.rst>`__
+
+`ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances <zips/zip-0209.rst>`__
+and `ZIP 317: Proportional Transfer Fee Mechanism <zips/zip-0317.rst>`__ will be updated.
+
+
 NU7 Candidate ZIPs
 ------------------
 
 The following ZIPs are under consideration for deployment in NU7:
 
 - `ZIP 218: 25-second Block Target Spacing <zips/zip-0218.md>`__
-- `ZIP 226: Transfer and Burn of Zcash Shielded Assets <zips/zip-0226.rst>`__
-- `ZIP 227: Issuance of Zcash Shielded Assets <zips/zip-0227.rst>`__
 - `ZIP 230: Version 6 Transaction Format <zips/zip-0230.rst>`__
 - `ZIP 231: Memo Bundles <zips/zip-0231.md>`__
 - `ZIP 233: Network Sustainability Mechanism: Removing Funds From Circulation <zips/zip-0233.md>`__

--- a/README.template
+++ b/README.template
@@ -46,15 +46,10 @@ See `here <protocol/README.rst>`__ for the project dependencies.
 Settled Mainnet Network Upgrade
 -------------------------------
 
-The most recent [settled](https://zips.z.cash/protocol/protocol.pdf#blockchain) Network Upgrade
-on Mainnet is NU6.1, which activated at Mainnet block height 3146400 on November 24, 2025, at
-19:56 UTC.
+The most recent `settled <https://zips.z.cash/protocol/protocol.pdf#blockchain>`__ Network Upgrade on Mainnet is NU6.2,
+which activated at Mainnet block height 3364600 on June 3, 2026, at 04:03 UTC.
 
-NU6.1 is described in `ZIP 255: Deployment of the NU6.1 Network Upgrade <zips/zip-0255.md>`__.
-It deployed the following ZIPs:
-
-- `ZIP 1016: Community and Coinholder Funding Model <zips/zip-1016.md>`__
-- `ZIP 271: Deferred Dev Fund Lockbox Disbursement <zips/zip-0271.md>`__
+NU6.2 is described in `ZIP 257: Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade <zips/zip-0257.md>`__.
 
 
 NU7 Candidate ZIPs

--- a/protocol/Makefile
+++ b/protocol/Makefile
@@ -55,10 +55,10 @@ protocol: $(PDFDIR)/protocol.pdf
 protocol-dark: $(PDFDIR)/protocol-dark.pdf
 
 all-pdfs: .Makefile.uptodate
-	$(MAKE) $(PDFDIR)/protocol.pdf $(PDFDIR)/protocol-dark.pdf $(PDFDIR)/nu6.pdf $(PDFDIR)/nu5.pdf $(PDFDIR)/canopy.pdf $(PDFDIR)/heartwood.pdf $(PDFDIR)/blossom.pdf $(PDFDIR)/sapling.pdf
+	$(MAKE) $(PDFDIR)/protocol.pdf $(PDFDIR)/protocol-dark.pdf $(PDFDIR)/nu6_1.pdf $(PDFDIR)/nu6.pdf $(PDFDIR)/nu5.pdf $(PDFDIR)/canopy.pdf $(PDFDIR)/heartwood.pdf $(PDFDIR)/blossom.pdf $(PDFDIR)/sapling.pdf
 
 all-specs: .Makefile.uptodate
-	$(MAKE) nu6_1 nu6_1-dark nu6 nu5 canopy heartwood blossom sapling
+	$(MAKE) nu6_2 nu6_2-dark nu6_1 nu6 nu5 canopy heartwood blossom sapling
 
 discard:
 	git checkout -- "$(PDFDIR)/*.pdf"
@@ -85,11 +85,14 @@ $(PDFDIR)/nu5.pdf: protocol.tex zcash.bib jubjub.png key_components_sapling.png 
 $(PDFDIR)/nu6.pdf: protocol.tex zcash.bib jubjub.png key_components_sapling.png key_components_orchard.png incremental_merkle.png
 	$(MAKE) nu6
 
-$(PDFDIR)/protocol.pdf: protocol.tex zcash.bib jubjub.png key_components_sapling.png key_components_orchard.png incremental_merkle.png
+$(PDFDIR)/nu6_1.pdf: protocol.tex zcash.bib jubjub.png key_components_sapling.png key_components_orchard.png incremental_merkle.png
 	$(MAKE) nu6_1
 
+$(PDFDIR)/protocol.pdf: protocol.tex zcash.bib jubjub.png key_components_sapling.png key_components_orchard.png incremental_merkle.png
+	$(MAKE) nu6_2
+
 $(PDFDIR)/protocol-dark.pdf: protocol.tex zcash.bib jubjub.png key_components_sapling.png key_components_orchard_dark.png incremental_merkle_dark.png
-	$(MAKE) nu6_1-dark
+	$(MAKE) nu6_2-dark
 
 .PHONY: auxsapling sapling
 auxsapling:
@@ -180,20 +183,33 @@ auxnu6_1:
 nu6_1:
 	$(MAKE) auxnu6_1
 	mkdir -p $(PDFDIR)
-	mv -f aux/nu6_1.pdf $(PDFDIR)/protocol.pdf
+	mv -f aux/nu6_1.pdf $(PDFDIR)
 
-.PHONY: auxnu6_1-dark nu6_1-dark
-auxnu6_1-dark:
-	printf '\\toggletrue{darkmode}\\toggletrue{isnusixone}\n\\renewcommand{\\docversion}{Version %s [\\NUSixOneSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
+.PHONY: auxnu6_2 nu6_2
+auxnu6_2:
+	printf '\\toggletrue{isnusixtwo}\n\\renewcommand{\\docversion}{Version %s [\\NUSixTwoSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
 	mkdir -p aux
-	rm -f aux/nu6_1-dark.*
+	rm -f aux/nu6_2.*
 	cp mymakeindex.sh aux
-	$(LATEXMK) -jobname=nu6_1-dark -auxdir=aux -outdir=aux $(EXTRAOPT) protocol $(NOCRUFT)
+	$(LATEXMK) -jobname=nu6_2 -auxdir=aux -outdir=aux $(EXTRAOPT) protocol $(NOCRUFT)
 
-nu6_1-dark:
-	$(MAKE) auxnu6_1-dark
+nu6_2:
+	$(MAKE) auxnu6_2
 	mkdir -p $(PDFDIR)
-	mv -f aux/nu6_1-dark.pdf $(PDFDIR)/protocol-dark.pdf
+	mv -f aux/nu6_2.pdf $(PDFDIR)/protocol.pdf
+
+.PHONY: auxnu6_2-dark nu6_2-dark
+auxnu6_2-dark:
+	printf '\\toggletrue{darkmode}\\toggletrue{isnusixtwo}\n\\renewcommand{\\docversion}{Version %s [\\NUSixTwoSpec]}\n' "$$(git describe --tags --abbrev=6 |sed 's/-1-g.*//;s/-auto//')" |tee protocol.ver
+	mkdir -p aux
+	rm -f aux/nu6_2-dark.*
+	cp mymakeindex.sh aux
+	$(LATEXMK) -jobname=nu6_2-dark -auxdir=aux -outdir=aux $(EXTRAOPT) protocol $(NOCRUFT)
+
+nu6_2-dark:
+	$(MAKE) auxnu6_2-dark
+	mkdir -p $(PDFDIR)
+	mv -f aux/nu6_2-dark.pdf $(PDFDIR)/protocol-dark.pdf
 
 .PHONY: clean
 clean:

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -13863,17 +13863,30 @@ $\EphemeralPrivate$, hence the entire \notePlaintext. \\ \hline
 The $\ephemeralKey$, $\encCiphertext$, and $\outCiphertext$ fields together form the
 \noteCiphertextOrchard, which is computed as described in \crossref{saplinginband}.
 
-\vspace{-1ex}
-\consensusrule{$\LEOStoIPOf{256}{\cmxField}$ \MUST be less than $\ParamP{q}$.}
+\begin{consensusrules}
+    \item $\LEOStoIPOf{256}{\cmxField}$ \MUST be less than $\ParamP{q}$.
+    \nusixtwoonwarditem{The $\proofsOrchard$ field \MUST have the canonical length of
+          $2720 + 2272 \cdot \nActionsOrchard$ bytes.}
+\end{consensusrules}
 
 Other consensus rules applying to an \actionDescription are given in \crossref{actiondesc}.
 
-\vspace{-1ex}
-\nnote{An \Orchard \actionDescription with $\ephemeralKey$ encoding the zero point, or any other 32-byte
-string that does not encode a valid \pallasCurve point, was accepted by \zcashd but rejected by \zebra as
-required by \crossref{actiondesc}, a potential consensus split. \zcashd now requires $\ephemeralKey$ to decode
-to a valid non-zero \pallasCurve point. This was partially fixed in \zcashdref{v6.12.1} (rejecting the zero
-\pallasCurve point encoding), and extended to all invalid encodings in \zcashdref{v6.12.2}.}
+\notbeforenusixtwo{\begin{nnotes}}
+\nusixtwo{
+    \item Before \NUSixTwo, the length of the $\proofsOrchard$ field was not enforced as a
+          consensus rule. The canonical length is determined by the circuit, and is the same
+          for the pre-\NUSixTwo and post-\NUSixTwo circuits. See \crossref{halo2encoding},
+          where a \HaloTwo proof is encoded as the proof byte sequence itself.
+} %nusixtwo
+\notbeforenusixtwo{\item} \notnusixtwo{\nnote}{
+          An \Orchard \actionDescription with $\ephemeralKey$ encoding the zero point, or
+          any other 32-byte string that does not encode a valid \pallasCurve point, was
+          accepted by \zcashd but rejected by \zebra as required by \crossref{actiondesc},
+          a potential consensus split. \zcashd now requires $\ephemeralKey$ to decode to a
+          valid non-zero \pallasCurve point. This was partially fixed in \zcashdref{v6.12.1}
+          (rejecting the zero \pallasCurve point encoding), and extended to all invalid
+          encodings in \zcashdref{v6.12.2}.}
+\notbeforenusixtwo{\end{nnotes}}
 } %nufive
 
 
@@ -15638,7 +15651,8 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \begin{itemize}
 \nufive{
     \item Apply the changes described in \cite{ZIP-257} to specify the mitigation of
-          the soundness bug in the pre-\NUSixTwo \Orchard Action circuit:
+          the soundness bug in the pre-\NUSixTwo \Orchard Action circuit, and a
+          non-canonical proof length issue:
           \vspace{0.5ex}
           \begin{itemize}
               \item Add a vulnerability disclosure in \crossref{actionstatement} for
@@ -15651,6 +15665,8 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
                     circuit has been deployed.
               \item Remove the note in \crossref{abstractzk} saying that these subscripts
                     are dropped.
+              \nusixtwoonwarditem{Add a consensus rule in \crossref{actionencodingandconsensus}
+                    that the $\proofsOrchard$ field \MUST be of the canonical length.}
           \end{itemize}
           \vspace{-1.5ex}
 } %nufive

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -2846,6 +2846,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\prenufiveitem}[1]{\item \prenufive{#1}}
 \newcommand{\nufiveonlyitem}[1]{\nufive{\item {[\NUFive only\notbeforenusix{, pre-\NUSix}]}\, {#1}}}
 \newcommand{\nufiveonwarditem}[1]{\nufive{\item {[\NUFive onward]}\, {#1}}}
+\newcommand{\nufiveprenusixtwoitem}[1]{\nufive{\item {[\NUFive \notnusixtwo{onward}\notbeforenusixtwo{ to \NUSixOne inclusive, pre-\NUSixTwo}]}\, {#1}}}
 \newcommand{\precanopyitem}[1]{\item \precanopy{#1}}
 \newcommand{\canopyonlyitem}[1]{\canopy{\item {[\NUCanopy only\notbeforenufive{, pre-\NUFive}]}\, {#1}}}
 \newcommand{\canopyonwarditem}[1]{\canopy{\item {[\NUCanopy onward]}\, {#1}}}
@@ -5425,7 +5426,8 @@ them to be the relevant \Groth \provingKeys and
 \verifyingKeys defined in \crossref{grothparameters}.
 
 \nufive{
-We also omit subscripts on $\ActionProve$ and $\ActionVerify$.
+Subscripts are not omitted on $\ActionProve$ and $\ActionVerify$, since
+more than one version of the $\OrchardProto$ circuit has been deployed.
 For \HaloTwo, parameters for a given circuit implementation are
 generated on the fly by the \halotwo library, and do not require
 parameter files.
@@ -6062,6 +6064,9 @@ Let $\Sym$ be as defined in \crossref{abstractsym}.
 
 Let $\Action$ be as defined in \crossref{abstractzk}.
 
+Let $\vk$ be the \HaloTwo \verifyingKey identified by the \Orchard circuit version, as specified
+in the consensus rules below.
+
 \vspace{0.5ex}
 \introsection
 An \actionDescription comprises $(\cvNet{}\kern-0.2em, \rt{\OrchardPoolId}\kern-0.2em, \nf, \AuthSignRandomizedPublic, \spendAuthSig,
@@ -6126,9 +6131,15 @@ $\Proof{}$ is aggregated with other Action proofs and encoded in the $\proofsOrc
         As specified in \crossref{concretereddsa}, validation of the $\RedDSAReprR{}$ component
         of the signature prohibits \nonCanonicalPoint encodings.
         \vspace{-0.25ex}
-  \item The proof $\Proof{}$ \MUST be valid given a \primaryInput
+  \nufiveprenusixtwoitem{$\vk$ \MUST be the \verifyingKey identified by
+        \texttt{OrchardCircuitVersion::}\linebreak[2]\texttt{InsecurePreNU6\_2}.}
+        \vspace{-0.25ex}
+  \nusixtwoonwarditem{$\vk$ \MUST be the \verifyingKey identified by
+        \texttt{OrchardCircuitVersion::FixedPostNU6\_2}.}
+        \vspace{-0.25ex}
+  \item The proof $\Proof{}$ \MUST be valid for \verifyingKey $\vk$ given a \primaryInput
         $(\cv, \rt{\OrchardPoolId}, \nf, \AuthSignRandomizedPublic, \cmX, \enableSpends,$ $\enableOutputs)$ ---
-        i.e.\ $\ActionVerify\big(\kern-0.1em(\cv, \rt{\OrchardPoolId}, \nf, \AuthSignRandomizedPublic, \cmX, \enableSpends, \enableOutputs), \Proof{}\big) = 1$.
+        i.e.\ ${\ActionVerify}_{\vk}\big(\kern-0.1em(\cv, \rt{\OrchardPoolId}, \nf, \AuthSignRandomizedPublic, \cmX, \enableSpends, \enableOutputs), \Proof{}\big) = 1$.
         \vspace{-0.25ex}
   \item $\AuthSignRandomizedPublic$ \MUSTNOT be the identity point $\ZeroP$.
 \end{consensusrules}
@@ -7918,6 +7929,17 @@ $\vNew{} = 0$ or $\enableOutputs = 1$.
 
 \vspace{2ex}
 For details of the form and encoding of \actionStatement proofs, see \crossref{halo2}.
+
+\vuln{
+The pre-\NUSixTwo \Orchard Action circuit had a soundness bug in its \nh{variable-base} scalar
+multiplication gadget \cite{GHSA-circuit}, which could have allowed balance violation. The bug is
+in the circuit implementation only; the \actionStatement specified above is as intended. The
+corrected circuit deployed at \NUSixTwo has a different \verifyingKey, so pre-\NUSixTwo \Orchard
+Action proofs verify only under the insecure pre-\NUSixTwo key, and \NUSixTwo-onward proofs only
+under the corrected one. The two circuits differ only in the additional copy constraints added to
+ensure soundness \cite{halo2-commit}. The consensus rule specifying which key is used for
+verification is in \crossref{actiondesc}.
+}
 
 \begin{pnotes}
   \item The \primaryInputs are encoded as the following sequence of type $\typeexp{\GF{\ParamP{q}}}{9}$: \\
@@ -15614,12 +15636,30 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \historyentry{\docversion}{}
 
 \begin{itemize}
+\nufive{
+    \item Apply the changes described in \cite{ZIP-257} to specify the mitigation of
+          the soundness bug in the pre-\NUSixTwo \Orchard Action circuit:
+          \vspace{0.5ex}
+          \begin{itemize}
+              \item Add a vulnerability disclosure in \crossref{actionstatement} for
+                    the soundness bug.
+              \item Add\notnusixtwo{ a consensus rule}\nusixtwo{ consensus rules}
+                    in \crossref{actiondesc} specifying which \verifyingKey is used
+                    before\nusixtwo{ and after} \NUSixTwo.
+              \item Use subscripts to indicate the verifying key for $\ActionProve$ and
+                    $\ActionVerify$, since more than one version of the $\OrchardProto$
+                    circuit has been deployed.
+              \item Remove the note in \crossref{abstractzk} saying that these subscripts
+                    are dropped.
+          \end{itemize}
+          \vspace{-1.5ex}
+} %nufive
 \nusixtwo{
     \item Add boilerplate support for \NUSixTwo.
 } %nusixtwo
-\notnusixtwo{
-    \item No changes before \NUSixTwo.
-} %notnusixtwo
+\notnufive{
+    \item No changes before \NUFive.
+} %notnufive
 \end{itemize}
 
 

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -15649,7 +15649,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \intropart
 \lsection{Change History}{changehistory}
 
-\historyentry{\docversion}{}
+\historyentry{2026.7.0}{2026-07-05}
 
 \begin{itemize}
 \nufive{

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -82,6 +82,8 @@
 \newcommand{\NUFiveSpec}{NU5}
 \newcommand{\NUSixSpec}{NU6}
 \newcommand{\NUSixOneSpec}{NU6.1}
+\newcommand{\NUSixTwoSpec}{NU6.2}
+\newcommand{\NUSixThreeSpec}{NU6.3 proposal}
 \newtoggle{issapling}
 \togglefalse{issapling}
 \newtoggle{isblossom}
@@ -96,6 +98,12 @@
 \togglefalse{isnusix}
 \newtoggle{isnusixone}
 \togglefalse{isnusixone}
+\newtoggle{isnusixtwo}
+\togglefalse{isnusixtwo}
+\newtoggle{isnusixthree}
+\togglefalse{isnusixthree}
+\newtoggle{isnuseven}
+\togglefalse{isnuseven}
 \newtoggle{darkmode}
 \togglefalse{darkmode}
 \InputIfFileExists{protocol.ver}{}{}
@@ -679,14 +687,55 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\nusixcolorname}{\nusixcolor}
 \newcommand{\nusixonecolor}{burgundy}
 \newcommand{\nusixonecolorname}{\nusixonecolor}
+\newcommand{\nusixtwocolor}{brown}
+\newcommand{\nusixtwocolorname}{\nusixtwocolor}
+\newcommand{\nusixthreecolor}{blue}
+\newcommand{\nusixthreecolorname}{bright blue}
 \newcommand{\labelcolor}{cream}
 
-\iftoggle{isnusixone}{
+\iftoggle{isnuseven}{
+  \errmessage{NU7 is not defined yet}
+} {
+  \newcommand{\setnuseven}{}
+  \newcommand{\nuseven}[1]{}
+  \newcommand{\notnuseven}[1]{#1}
+  \newcommand{\notbeforenuseven}[1]{}
+}
+
+\iftoggle{isnusixthree}{
+  \providecommand{\baseurl}{https://zips.z.cash/protocol/nu6_3.pdf}
+  \toggletrue{isnusixtwo}
+  \newcommand{\setnusixthree}{\color{\nusixthreecolor}}
+  \newcommand{\nusixthree}[1]{\texorpdfstring{{\setnusixthree{#1}}}{#1}}
+  \newcommand{\notnusixthree}[1]{}
+  \newcommand{\notbeforenusixthree}[1]{#1}
+} {
+  \newcommand{\setnusixthree}{}
+  \newcommand{\nusixthree}[1]{}
+  \newcommand{\notnusixthree}[1]{#1}
+  \newcommand{\notbeforenusixthree}[1]{}
+}
+
+\iftoggle{isnusixtwo}{
   \iftoggle{darkmode}{
     \providecommand{\baseurl}{https://zips.z.cash/protocol/protocol-dark.pdf}
   }{
     \providecommand{\baseurl}{https://zips.z.cash/protocol/protocol.pdf}
   }
+  \toggletrue{isnusixone}
+  \newcommand{\setnusixtwo}{\color{\nusixtwocolor}}
+  \newcommand{\nusixtwo}[1]{\texorpdfstring{{\setnusixtwo{#1}}}{#1}}
+  \newcommand{\notnusixtwo}[1]{}
+  \newcommand{\notbeforenusixtwo}[1]{#1}
+} {
+  \newcommand{\setnusixtwo}{}
+  \newcommand{\nusixtwo}[1]{}
+  \newcommand{\notnusixtwo}[1]{#1}
+  \newcommand{\notbeforenusixtwo}[1]{}
+}
+
+\iftoggle{isnusixone}{
+  \providecommand{\baseurl}{https://zips.z.cash/protocol/nu6_1.pdf}
   \toggletrue{isnusix}
   \newcommand{\setnusixone}{\color{\nusixonecolor}}
   \newcommand{\nusixone}[1]{\texorpdfstring{{\setnusixone{#1}}}{#1}}
@@ -932,6 +981,10 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\NUSixOne}{\readasunicode{004e200b0055200b0036002e0031}{\termandindexx{\upgradetype{NU6.1}}{NU6.1 (Network Upgrade 6.1)}}\xspace}
 % "N<zwsp>U<zwsp>6.2"
 \newcommand{\NUSixTwo}{\readasunicode{004e200b0055200b0036002e0032}{\termandindexx{\upgradetype{NU6.2}}{NU6.2 (Network Upgrade 6.2)}}\xspace}
+% "N<zwsp>U<zwsp>6.3"
+\newcommand{\NUSixThree}{\readasunicode{004e200b0055200b0036002e0033}{\termandindexx{\upgradetype{NU6.3}}{NU6.3 (Network Upgrade 6.3)}}\xspace}
+% "N<zwsp>U<zwsp>7"
+\newcommand{\NUSeven}{\readasunicode{004e200b0055200b0037}{\termandindexx{\upgradetype{NU7}}{NU7 (Network Upgrade 7)}}\xspace}
 
 % Protocol-name math identifiers. The protocol analogue of the pool ids (\<P>PoolId); used for
 % math superscripts and as the rendering of the protocol terms and headings below, so protocol
@@ -2775,8 +2828,17 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\consensusrule}[1]{\needspace{4ex}\vspace{2ex}\callout{}{Consensus rule:}{#1}}
 \newenvironment{consensusrules}{\introlist\callout{}{Consensus rules:}\begin{itemize}}{\end{itemize}}
 
+\newcommand{\prenusevenitem}[1]{\item \prenuseven{#1}}
+\newcommand{\nusevenonlyitem}[1]{\nuseven{\item {[\NUSeven only]}\, {#1}}}
+\newcommand{\nusevenonwarditem}[1]{\nuseven{\item {[\NUSeven onward]}\, {#1}}}
+\newcommand{\prenusixthreeitem}[1]{\item \prenusixthree{#1}}
+\newcommand{\nusixthreeonlyitem}[1]{\nusixthree{\item {[\NUSixThree only\notbeforenuseven{, pre-\NUSeven}]}\, {#1}}}
+\newcommand{\nusixthreeonwarditem}[1]{\nusixthree{\item {[\NUSixThree onward]}\, {#1}}}
+\newcommand{\prenusixtwoitem}[1]{\item \prenusixtwo{#1}}
+\newcommand{\nusixtwoonlyitem}[1]{\nusixtwo{\item {[\NUSixTwo only\notbeforenusixthree{, pre-\NUSixThree}]}\, {#1}}}
+\newcommand{\nusixtwoonwarditem}[1]{\nusixtwo{\item {[\NUSixTwo onward]}\, {#1}}}
 \newcommand{\prenusixoneitem}[1]{\item \prenusixone{#1}}
-\newcommand{\nusixoneonlyitem}[1]{\nusixone{\item {[\NUSixOne only]}\, {#1}}}
+\newcommand{\nusixoneonlyitem}[1]{\nusixone{\item {[\NUSixOne only\notbeforenusixtwo{, pre-\NUSixTwo}]}\, {#1}}}
 \newcommand{\nusixoneonwarditem}[1]{\nusixone{\item {[\NUSixOne onward]}\, {#1}}}
 \newcommand{\prenusixitem}[1]{\item \prenusix{#1}}
 \newcommand{\nusixonlyitem}[1]{\nusix{\item {[\NUSix only\notbeforenusixone{, pre-\NUSixOne}]}\, {#1}}}
@@ -2805,6 +2867,15 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\overwinterprenufiveitem}[1]{\overwinter{\item \overwinterprenufive{#1}}}
 \newcommand{\sproutspecificitem}[1]{\item \sproutspecific{#1}}
 
+\newcommand{\prenuseven}[1]{\notbeforenuseven{\nuseven{[Pre-\NUSeven\!]\,}} {#1}}
+\newcommand{\nusevenonly}[1]{\nuseven{[\NUSeven only]\, {#1}}}
+\newcommand{\nusevenonward}[1]{\nuseven{[\NUSeven onward]\, {#1}}}
+\newcommand{\prenusixthree}[1]{\notbeforenusixthree{\nusixthree{[Pre-\NUSixThree\!]\,}} {#1}}
+\newcommand{\nusixthreeonly}[1]{\nusixthree{[\NUSixThree only]\, {#1}}}
+\newcommand{\nusixthreeonward}[1]{\nusixthree{[\NUSixThree onward]\, {#1}}}
+\newcommand{\prenusixtwo}[1]{\notbeforenusixtwo{\nusixtwo{[Pre-\NUSixTwo\!]\,}} {#1}}
+\newcommand{\nusixtwoonly}[1]{\nusixtwo{[\NUSixTwo only]\, {#1}}}
+\newcommand{\nusixtwoonward}[1]{\nusixtwo{[\NUSixTwo onward]\, {#1}}}
 \newcommand{\prenusixone}[1]{\notbeforenusixone{\nusixone{[Pre-\NUSixOne\!]\,}} {#1}}
 \newcommand{\nusixoneonly}[1]{\nusixone{[\NUSixOne only]\, {#1}}}
 \newcommand{\nusixoneonward}[1]{\nusixone{[\NUSixOne onward]\, {#1}}}
@@ -2843,6 +2914,12 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\nnote}[1]{\needspace{4ex}\vspace{2ex}\callout{}{Non-normative note:}{#1}}
 \newenvironment{nnotes}{\introlist\callout{}{Non-normative notes:}\begin{itemize}}{\end{itemize}}
 
+\newcommand{\nusevenonwardnnote}[1]{\nuseven{\callout{[\NUSeven onward]\,\,}{Non-normative note:}{#1}}}
+\newcommand{\nusevenonwardpnote}[1]{\nuseven{\callout{[\NUSeven onward]\,\,}{Note:}{#1}}}
+\newcommand{\nusixthreeonwardnnote}[1]{\nusixthree{\callout{[\NUSixThree onward]\,\,}{Non-normative note:}{#1}}}
+\newcommand{\nusixthreeonwardpnote}[1]{\nusixthree{\callout{[\NUSixThree onward]\,\,}{Note:}{#1}}}
+\newcommand{\nusixtwoonwardnnote}[1]{\nusixtwo{\callout{[\NUSixTwo onward]\,\,}{Non-normative note:}{#1}}}
+\newcommand{\nusixtwoonwardpnote}[1]{\nusixtwo{\callout{[\NUSixTwo onward]\,\,}{Note:}{#1}}}
 \newcommand{\nusixoneonwardnnote}[1]{\nusixone{\callout{[\NUSixOne onward]\,\,}{Non-normative note:}{#1}}}
 \newcommand{\nusixoneonwardpnote}[1]{\nusixone{\callout{[\NUSixOne onward]\,\,}{Note:}{#1}}}
 \newcommand{\nusixonwardnnote}[1]{\nusix{\callout{[\NUSix onward]\,\,}{Non-normative note:}{#1}}}
@@ -2902,7 +2979,9 @@ memory-hard \proofOfWork algorithm.
 \notnufive{\canopy{\thisspecdefines{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, and \NUCanopy}}}%
 \notnusix{\nufive{\thisspecdefines{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, and \NUFive}}}%
 \notnusixone{\nusix{\thisspecdefines{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, and \NUSix}}}%
-\nusixone{\thisspecdefines{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, \NUSix, and \NUSixOne}}%
+\notnusixtwo{\nusixone{\thisspecdefines{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, \NUSix, and \NUSixOne}}}%
+\notnusixthree{\nusixtwo{\thisspecdefines{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, \NUSix, \NUSixOne, and \NUSixTwo}}}%
+\nusixthree{\thisspecdefinesandproposes{\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, \NUSix, \NUSixOne, \NUSixTwo}{\NUSixThree}}%
 It is a work in progress. Protocol differences from \Zerocash and \Bitcoin are also explained.
 
 \vspace{2ex}
@@ -2977,6 +3056,9 @@ are highlighted in \nusix{\nusixcolorname}.}
 
 \notbeforenusixone{Changes specific to the \NUSixOne upgrade following \NUSix
 are highlighted in \nusixone{\nusixonecolorname}.}
+
+\notbeforenusixtwo{Changes specific to the \NUSixTwo upgrade following \NUSixOne
+are highlighted in \nusixtwo{\nusixtwocolorname}.}
 
 All of these are also changes from \Zerocash.
 
@@ -6708,6 +6790,8 @@ identifiers, and \MAY be used for that reason whether or not \actionTransfers ar
         as defined in \cite{ZIP-253}.}
   \nusixoneonlyitem{All \transactions \MUST use the \NUSixOne \consensusBranchID \hexint{4DEC4DF0}
         as defined in \cite{ZIP-255}.}
+  \nusixtwoonlyitem{All \transactions \MUST use the \NUSixTwo \consensusBranchID \hexint{5437F330}
+        as defined in \cite{ZIP-257}.}
 \end{consensusrules}
 
 
@@ -12968,17 +13052,22 @@ Its specifications are described in this document, \cite{ZIP-253}, \cite{ZIP-236
 \cite{ZIP-2001}, with updates to \cite{ZIP-207} and \cite{ZIP-214}.
 Additional information and rationale is given in \cite{ZIP-1015}.}
 
-\nusixone{This draft specification describes the set of changes proposed for the \NUSixOne
-\networkUpgrade \cite{Zcash-Nu6.1}, for which the \Mainnet activation \blockHeight has not
-yet been set. Its specifications are described in this document,
+\nusixone{An eighth upgrade, called \defining{\NUSixOne}, activated on \Mainnet on 24~November, 2025
+at \blockHeight $3146400$ \cite{Zcash-Nu6.1}. Its specifications are described in this document,
 \cite{ZIP-255}, and \cite{ZIP-271}, with updates to \cite{ZIP-214}.
 Additional information and rationale is given in \cite{ZIP-1016}.}
+
+\nusixtwo{A ninth upgrade, called \defining{\NUSixTwo}, activated on \Mainnet on 3~June, 2026
+at \blockHeight $3364600$ \cite{Zcash-Nu6.2} \cite{GHSA-zcashd}. It was necessary in order to
+re-enable the \OrchardPool, after it had been temporarily disabled in order to mitigate a soundness
+vulnerability \cite{GHSA-circuit} \cite{ZIP-257}. Its specifications are described in this document
+and \cite{ZIP-257}.}
 
 \introlist
 \vspace{1.5ex}
 This section summarizes the strategy for upgrading from the Sprout epoch to subsequent epochs
-of the protocol (\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, \NUSix, and \NUSixOne),
-and for future upgrades.
+of the protocol (\NUOverwinter, \NUSapling, \NUBlossom, \NUHeartwood, \NUCanopy, \NUFive, \NUSix,
+\NUSixOne, and \NUSixTwo), and for future upgrades.
 
 \defining{The \networkUpgrade mechanism is described in \cite{ZIP-200}.}
 
@@ -15521,6 +15610,18 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 
 \intropart
 \lsection{Change History}{changehistory}
+
+\historyentry{\docversion}{}
+
+\begin{itemize}
+\nusixtwo{
+    \item Add boilerplate support for \NUSixTwo.
+} %nusixtwo
+\notnusixtwo{
+    \item No changes before \NUSixTwo.
+} %notnusixtwo
+\end{itemize}
+
 
 \historyentry{2026.6.4}{2026-07-05}
 

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -3962,7 +3962,7 @@ consensus that it has activated with a given \activationBlock hash. A \fullValid
 that potentially risks \Mainnet funds or displays \Mainnet \transaction information
 to a user \MUST do so only for a \blockChain that includes the \activationBlock of
 the most recent \settled \networkUpgrade, with the corresponding \activationBlock hash.
-Currently, there is social consensus that \NUSixOne has activated on the \Zcash \Mainnet
+Currently, there is social consensus that \NUSixTwo has activated on the \Zcash \Mainnet
 and \Testnet with the \activationBlock hashes given in \crossref{networks}.
 
 A \fullValidator \MAY impose a limit on the number of \blocks it will ``roll back'' when
@@ -4321,18 +4321,18 @@ relative to the normal order for a $\SHAFull$ hash).}
 
 \Mainnet \genesisBlock: $\mathtt{00040fe8ec8471911baa1db1266ea15dd06b4a8a5c453883c000b031973dce08}$
 
-\Mainnet \NUSixOne \activationBlock: $\mathtt{0000000000b98a7d8f390793fa113bf6755935f0c14ea817af07d2c16f2c3ef4}$
+\Mainnet \NUSixTwo \activationBlock: $\mathtt{0000000000806344c408a4cfdf472f4132c632edbdc24cf2f3f672061da8b865}$
 
 \introlist
 There is also a public test \network called \defining{\Testnet}. It supports a \TAZ token which is
-intended to have no monetary value. By convention, \Testnet activates \networkUpgrades (as described
+intended to have no monetary value. By convention, \Testnet normally activates \networkUpgrades (as described
 in \crossref{networkupgrades}) before \Mainnet, in order to allow for errors or ambiguities in
 their specification and implementation to be discovered. The \Testnet \blockChain is subject to
 being rolled back to a prior \block at any time.
 
 \Testnet \genesisBlock: $\mathtt{05a60a92d99d85997cce3b87616c089f6124d7342af37106edc76126334a2c38}$
 
-\Testnet \NUSixOne \activationBlock: $\mathtt{01b947c7556b23040dc6840e9d3e4c6d9478c67a87b9737a83be848729d6e0af}$
+\Testnet \NUSixTwo \activationBlock: $\mathtt{0010cb912b0188da5bc055ee67e3f77d30cd27611369d865974a5bf0b1ec2912}$
 
 We call the smallest units of currency (on either \network) \zatoshi.\footnote{\definingquotedterm{tazoshi}
 may be used for the smallest units of currency on Testnet, but it is usually more convenient to use a
@@ -15678,6 +15678,10 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 } %nufive
 \nusixtwo{
     \item Add boilerplate support for \NUSixTwo.
+    \item Specify in \crossref{blockchain} that \NUSixTwo is the most recent \settled \networkUpgrade
+          on \Testnet and \Mainnet.
+    \item Note in \crossref{networks} that \Testnet does not always activate \networkUpgrades
+          before \Mainnet; \NUSixTwo activated on \Testnet after \Mainnet.
 } %nusixtwo
 \notnufive{
     \item No changes before \NUFive.

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -13409,6 +13409,9 @@ in \cite{ZIP-239}.
         $(\nActionsOrchard > 0$ and $\enableOutputsOrchard = 1)$.}
   \nufiveonwarditem{If $\effectiveVersion \geq 5$ and $\nActionsOrchard > 0$, then at least one of
         $\enableSpendsOrchard$ and $\enableOutputsOrchard$ \MUST be $1$.}
+  \nufive{\prenusixtwoitem{From \blockHeight $3363426$ (\Mainnet) or $4048500$ (\Testnet)
+        onward, until the activation of \NUSixTwo on each \network, if $\effectiveVersion \geq 5$ then
+        the \transaction \MUSTNOT contain any \Orchard \actionDescriptions, i.e.\ $\nActionsOrchard = 0$.}}
   \item A \transaction with one or more \transparentInputs from \coinbaseTransactions \MUST have no
         \transparentOutputs (i.e.\ \txOutCount{} \MUST be $0$). Inputs from
         \coinbaseTransactions include \foundersReward outputs\canopy{ and \fundingStream outputs}.
@@ -15657,6 +15660,9 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           \begin{itemize}
               \item Add a vulnerability disclosure in \crossref{actionstatement} for
                     the soundness bug.
+              \item Add a consensus rule in \crossref{txnconsensus} temporarily prohibiting
+                    \Orchard \actionDescriptions, from a specified \blockHeight on each
+                    \network until the activation of \NUSixTwo.
               \item Add\notnusixtwo{ a consensus rule}\nusixtwo{ consensus rules}
                     in \crossref{actiondesc} specifying which \verifyingKey is used
                     before\nusixtwo{ and after} \NUSixTwo.

--- a/protocol/zcash.bib
+++ b/protocol/zcash.bib
@@ -1876,6 +1876,14 @@ generic composition paradigm},
    urldate={2026-06-20}
 }
 
+@misc{halo2-commit,
+   presort={halo2-commit},
+   author={Daira\nbh{}Emma Hopwood},
+   title={{zcash/halo2} {PR}~888, commit d8e48ef. {halo2\_gadgets}: Anchor variable-base scalar-mul incomplete-addition base},
+   url={https://github.com/zcash/halo2/pull/888/changes/d8e48efddbe4746d76eb2c8a843a6ddc2b9a727a},
+   urldate={2026-06-20}
+}
+
 @misc{GHSA-zcashd,
    presort={GHSA-zcashd},
    author={Kris Nuttycombe},

--- a/protocol/zcash.bib
+++ b/protocol/zcash.bib
@@ -1516,6 +1516,14 @@ Last revised February~5, 2018.}
    urldate={2026-06-16}
 }
 
+@misc{ZIP-257,
+   presort={ZIP-0257},
+   author={Daira\nbh{}Emma Hopwood},
+   title={Deployment of the {O}rchard Temporary Vulnerability Mitigation and {NU6.2} Network Upgrade},
+   howpublished={Zcash Improvement Proposal 257. Created June~9, 2026.},
+   url={https://zips.z.cash/zip-0257},
+   urldate={2026-06-16}
+}
 @misc{ZIP-271,
    presort={ZIP-0271},
    author={Daira\nbh{}Emma Hopwood and Kris Nuttycombe and Jack Grigg},
@@ -1845,9 +1853,36 @@ generic composition paradigm},
    presort={Zcash-Nu6.1},
    author={Electric Coin Company},
    title={Network Upgrade 6.1},
-   date={2025-08-20},
+   date={2025-11-24},
    url={https://z.cash/upgrade/nu6.1/},
-   urldate={2025-08-20}
+   urldate={2026-06-20}
+}
+
+@misc{Zcash-Nu6.2,
+   presort={Zcash-Nu6.2},
+   author={Zcash Open Development Lab},
+   title={Orchard Vulnerability Successfully Remediated},
+   date={2026-06-02},
+   url={https://zodl.com/orchard-vulnerability-successfully-remediated/},
+   urldate={2025-06-20}
+}
+
+@misc{GHSA-circuit,
+   presort={GHSA-circuit},
+   author={DC},
+   title={GitHub Security Advisory ww9q-8r59-xv46: Missing copy constraint in halo2\_gadgets variable-base scalar multiplication allows under-constrained base, breaking Orchard Action circuit soundness},
+   date={2026-06-15},
+   url={https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-ww9q-8r59-xv46},
+   urldate={2026-06-20}
+}
+
+@misc{GHSA-zcashd,
+   presort={GHSA-zcashd},
+   author={Kris Nuttycombe},
+   title={GitHub Security Advisory ghc3-g8w4-whf9: Urgent Zcash hotfixes v6.12.4 and v6.20.0},
+   date={2026-06-01},
+   url={https://github.com/zcash/zcash/security/advisories/GHSA-ghc3-g8w4-whf9},
+   urldate={2026-06-20}
 }
 
 @misc{WCBTV2015,

--- a/zips/zip-0255.md
+++ b/zips/zip-0255.md
@@ -3,7 +3,7 @@
     Title: Deployment of the NU6.1 Network Upgrade
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
     Credits: Arya
-    Status: Proposed
+    Status: Final
     Category: Consensus / Network
     Created: 2025-05-06
     License: MIT

--- a/zips/zip-0256.md
+++ b/zips/zip-0256.md
@@ -2,7 +2,7 @@
     ZIP: 256
     Title: Deployment of Consensus Bug Fixes Between NU6.1 and NU6.2
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
-    Status: Proposed
+    Status: Final
     Category: Consensus / Network
     Created: 2026-06-09
     License: MIT

--- a/zips/zip-0257.md
+++ b/zips/zip-0257.md
@@ -1,0 +1,162 @@
+
+    ZIP: 257
+    Title: Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade
+    Owners: Daira-Emma Hopwood <daira@jacaranda.org>
+    Status: Proposed
+    Category: Consensus / Network
+    Created: 2026-06-09
+    License: MIT
+    Discussions-To: <https://github.com/zcash/zips/issues/1293>
+
+
+# Terminology
+
+The key words "MUST" and "MUST NOT" in this document are to be interpreted as
+described in BCP 14 [^BCP14] when, and only when, they appear in all capitals.
+
+The term "network upgrade" in this document is to be interpreted as described
+in ZIP 200. [^zip-0200]
+
+The character § is used when referring to sections of the Zcash Protocol
+Specification. [^protocol]
+
+The terms "Mainnet" and "Testnet" are to be interpreted as described in
+§ 3.12 ‘Mainnet and Testnet’. [^protocol-networks]
+
+
+# Abstract
+
+This ZIP retrospectively documents the deployment of the Orchard temporary
+vulnerability mitigation, and the NU6.2 network upgrade.
+
+
+# Motivation
+
+On 2026-05-29, security researcher Taylor Hornby, who had been tasked with an
+AI-assisted security audit of the Orchard shielded protocol, reported a
+soundness vulnerability in the
+[Orchard Action circuit implementation](https://github.com/zcash/orchard).
+Details of the vulnerability are described in Taylor's work log [^Hornby2026]
+and in GHSA-ww9q-8r59-xv46. [^GHSA-halo2]
+
+This vulnerability could have allowed balance violation and theft of funds.
+Therefore, it was imperative to immediately disable use of Orchard, until a
+corrected Orchard Action circuit could be deployed in the NU6.2 network
+upgrade. (Disabling the vulnerable circuit and enabling the new one at the
+same time was ruled out due to the risk of revealing the vulnerability
+before it had been mitigated, and in order to close the vulnerability window
+more quickly, while the fix was still being prepared and reviewed.)
+
+
+# Specification
+
+## Orchard temporary vulnerability mitigation
+
+Consensus rule: From block height 3363426 (Mainnet) or 4048500 (Testnet)
+onward, until the activation of NU6.2 on each network, v5 and later transactions
+MUST NOT contain any Orchard Action descriptions, i.e. $\mathsf{nActionsOrchard} = 0$.
+
+The Mainnet mitigation was deployed as an emergency hotfix in zcashd v6.12.5
+and zebra v4.5.3. [^GHSA-zcash-hotfix] [^GHSA-zebra-hotfix] These releases did
+not have the "until the activation of NU6.2" restriction; i.e. they disabled
+Orchard until deployment of the subsequent releases. Note that zcashd v6.12.4
+also deployed other security fixes described in ZIP 256 [^zip-0256].
+
+zcashd v6.12.4 had used a Mainnet activation height of 3363366, 60 blocks
+earlier. Some mining pools failed to upgrade in time, so the activation was
+re-attempted successfully at the height given above.
+
+These emergency hotfixes enabled the soft fork on Mainnet only, leaving the
+Testnet mitigation height unset. On Testnet, the soft fork instead took effect
+through zcashd v6.20.0 and zebra v5.0.0, which set the Testnet mitigation height
+to 4048500 and added support for NU6.2. Those releases had been published before
+Testnet reached height 4048500. The disabling of Orchard, and the subsequent
+re-enabling at NU6.2 (height 4052000), therefore occurred on Testnet as an
+ordinary scheduled activation rather than an emergency response.
+
+## NU6.2 deployment
+
+The NU6.2 network upgrade re-enables the Orchard shielded protocol, with two
+consensus changes relative to the original Orchard rules:
+
+- The Orchard Action circuit's variable-base scalar multiplication gadget is
+  corrected, fixing the soundness vulnerability. This changes the Orchard
+  verifying key. Pre-NU6.2 Action proofs verify only under the historical
+  (insecure) verifying key, and NU6.2-onward proofs only under the corrected
+  one. The fix was published in halo2_gadgets v0.5.0 [^halo2-0.5.0] and
+  orchard v0.14.0. [^orchard-0.14.0]
+
+- From the activation of NU6.2, an Orchard Action proof MUST have the canonical
+  length for the corrected circuit. Before NU6.2, this length was not enforced
+  as a consensus rule. [^GHSA-zebra-hotfix]
+
+From the activation of NU6.2, the temporary mitigation no longer applies.
+Transactions containing Orchard Action descriptions MUST again be accepted,
+with proofs subject to verification under the corrected circuit and the
+canonical-length rule. NU6.2 was deployed in zcashd v6.20.0 and zebra v5.0.0.
+
+The primary sources of information about NU6.2 consensus protocol changes are
+the Zcash Protocol Specification [^protocol] and this ZIP.
+
+The network handshake and peer management mechanisms defined in ZIP 201
+[^zip-0201] also apply to this upgrade.
+
+The following network upgrade constants [^zip-0200] are defined for the
+NU6.2 upgrade:
+
+CONSENSUS_BRANCH_ID
+: `0x5437F330`
+
+ACTIVATION_HEIGHT (NU6.2)
+: Testnet: 4052000
+: Mainnet: 3364600
+
+MIN_NETWORK_PROTOCOL_VERSION (NU6.2)
+: Testnet: `170150`
+: Mainnet: `170150`
+
+For each network (Testnet and Mainnet), nodes compatible with NU6.2 activation
+on that network MUST advertise a network protocol version that is greater
+than or equal to the MIN_NETWORK_PROTOCOL_VERSION (NU6.2) for that activation.
+
+## Zcash Protocol Specification changes
+
+TODO follow similar pattern to ZIP 2005
+
+## Backward compatibility
+
+Prior to the network upgrade activating on each network, NU6.2 and pre-NU6.2
+nodes are compatible and can connect to each other. However, NU6.2 nodes will
+have a preference for connecting to other NU6.2 nodes, so pre-NU6.2 nodes will
+be disconnected in the run up to activation.
+
+Once the network upgrades, even though pre-NU6.2 nodes can still accept the
+numerically larger protocol version used by NU6.2 as being valid, NU6.2 nodes
+will always disconnect peers using lower protocol versions.
+
+
+# References
+
+[^BCP14]: [Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
+
+[^protocol]: [Zcash Protocol Specification, Version 2025.6.3 or later](protocol/protocol.pdf)
+
+[^protocol-networks]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
+
+[^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
+
+[^zip-0201]: [ZIP 201: Network Peer Management for Overwinter](zip-0201.rst)
+
+[^zip-0256]: [ZIP 256: Deployment of Consensus Bug Fixes Between NU6.1 and NU6.2](zip-0256.rst)
+
+[^orchard-0.14.0]: [orchard v0.14.0 release (zcash/orchard#500)](https://github.com/zcash/orchard/pull/500)
+
+[^halo2-0.5.0]: [halo2_gadgets v0.5.0 release (zcash/halo2#888)](https://github.com/zcash/halo2/pull/888)
+
+[^Hornby2026]: [Taylor Hornby — work log for the Orchard counterfeiting vulnerability](https://drive.google.com/file/d/1SVK41y-ip3Vw9eB69E9QRy-Qn3idTOwV/view)
+
+[^GHSA-halo2]: [Missing copy constraint in halo2_gadgets variable-base scalar multiplication allows under-constrained base, breaking Orchard Action circuit soundness (fixed in zcashd v6.20.0 and zebra v5.0.0)](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-ww9q-8r59-xv46)
+
+[^GHSA-zcash-hotfix]: [Urgent Zcash hotfixes v6.12.4 & v6.20.0 (zcashd, affected v5.0.0–v6.13.0)](https://github.com/zcash/zcash/security/advisories/GHSA-ghc3-g8w4-whf9)
+
+[^GHSA-zebra-hotfix]: [‹GHSA-jfw5-j458-pfv6 title — fill from GitHub once published› (zebrad; soft-fork disable in v4.5.3, NU6.2 proof-size rule in v5.0.0)](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-jfw5-j458-pfv6)

--- a/zips/zip-0257.md
+++ b/zips/zip-0257.md
@@ -128,7 +128,9 @@ TODO follow similar pattern to ZIP 2005
 Prior to the network upgrade activating on each network, NU6.2 and pre-NU6.2
 nodes are compatible and can connect to each other. However, NU6.2 nodes will
 have a preference for connecting to other NU6.2 nodes, so pre-NU6.2 nodes will
-be disconnected in the run up to activation.
+be disconnected in the run up to activation. (In practice, this was limited by
+the fix only initially being distributed to a subset of nodes before the
+activation, due to time constraints.)
 
 Once the network upgrades, even though pre-NU6.2 nodes can still accept the
 numerically larger protocol version used by NU6.2 as being valid, NU6.2 nodes

--- a/zips/zip-0257.md
+++ b/zips/zip-0257.md
@@ -18,7 +18,7 @@ The term "network upgrade" in this document is to be interpreted as described
 in ZIP 200. [^zip-0200]
 
 The character § is used when referring to sections of the Zcash Protocol
-Specification. [^protocol]
+Specification. [^protocol-2026.7.0]
 
 The terms "Mainnet" and "Testnet" are to be interpreted as described in
 § 3.12 ‘Mainnet and Testnet’. [^protocol-networks]
@@ -96,7 +96,7 @@ with proofs subject to verification under the corrected circuit and the
 canonical-length rule. NU6.2 was deployed in zcashd v6.20.0 and zebra v5.0.0.
 
 The primary sources of information about NU6.2 consensus protocol changes are
-the Zcash Protocol Specification [^protocol] and this ZIP.
+the Zcash Protocol Specification [^protocol-2026.7.0] and this ZIP.
 
 The network handshake and peer management mechanisms defined in ZIP 201
 [^zip-0201] also apply to this upgrade.
@@ -121,7 +121,80 @@ than or equal to the MIN_NETWORK_PROTOCOL_VERSION (NU6.2) for that activation.
 
 ## Zcash Protocol Specification changes
 
-TODO follow similar pattern to ZIP 2005
+The changes below to the Zcash Protocol Specification correspond to the two NU6.2
+consensus changes described above. They are relative to version 2026.6.4 of the
+specification [^protocol-2026.6.4], and are applied in version 2026.7.0 [^protocol-2026.7.0].
+
+### Consensus rule for the temporary vulnerability mitigation
+
+Add a consensus rule to § 7.1.2 ‘Transaction Consensus Rules’ [^protocol-txnconsensus]:
+
+> [Pre-NU6.2] From block height 3363426 (Mainnet) or 4048500 (Testnet) onward,
+> until the activation of NU6.2 on each network, if $\mathsf{effectiveVersion} \geq 5$
+> then the transaction MUST NOT contain any Orchard Action descriptions, i.e.
+> $\mathsf{nActionsOrchard} = 0$.
+
+### Orchard Action verifying key selection
+
+The correction to the Orchard Action circuit changes the Orchard Action verifying
+key after NU6.2 activation.
+
+In § 4.1.13 ‘Zero-Knowledge Proving System’ [^protocol-abstractzk], replace the
+sentence
+
+> We also omit subscripts on $\mathsf{ZKAction.Prove}$ and $\mathsf{ZKAction.Verify}$.
+
+with
+
+> Subscripts are not omitted on $\mathsf{ZKAction.Prove}$ and $\mathsf{ZKAction.Verify}$,
+> since more than one version of the $\mathsf{Orchard}$ circuit has been deployed.
+
+In § 4.6 ‘Action Descriptions’ [^protocol-actiondesc]:
+
+Before "An Action description comprises", add:
+
+> Let $\mathsf{vk}$ be the halo2 verifying key identified by the Orchard
+> circuit version, as specified in the consensus rules below.
+
+Replace the last consensus rule with the following three rules:
+
+> * [NU5 to NU6.1 inclusive, pre NU6.2] $\mathsf{vk}$ MUST be the key identified by
+>   $\texttt{OrchardCircuitVersion::InsecurePreNU6\_2}$.
+> * [NU6.2 onward] $\mathsf{vk}$ MUST be the key identified by
+>   $\texttt{OrchardCircuitVersion::FixedPostNU6\_2}$.
+> * The proof $\pi$ MUST be valid for verifying key $\mathsf{vk}$ given a primary input
+>   $(\mathsf{cv}, \mathsf{rt}^{\textit{OrchardPool}}, \mathsf{nf}, \mathsf{rk}, \mathsf{cm}_x, \mathsf{enableSpends}, \mathsf{enableOutputs})$ — i.e.
+>   $\mathsf{ZKAction.Verify_{vk}}\big(\kern-0.1em(\mathsf{cv}, \mathsf{rt}^{\textit{OrchardPool}}, \mathsf{nf}, \mathsf{rk}, \mathsf{cm}_x, \mathsf{enableSpends}, \mathsf{enableOutputs}), \pi\big) = 1$.
+
+In § 4.18.4 ‘Action Statement ($\mathsf{Orchard}$)’ [^protocol-actionstatement],
+add a vulnerability disclosure (styled similarly to the one for $\mathsf{BCTV14}$
+in § 5.4.10.1):
+
+> Vulnerability disclosure: The pre-NU6.2 Orchard Action circuit had a soundness
+> bug in its variable-base scalar multiplication gadget [^GHSA-circuit], which
+> could have allowed balance violation. The bug is in the circuit implementation
+> only; the Action statement specified above is as intended. The corrected circuit
+> deployed at NU6.2 has a different verifying key, so pre-NU6.2 Action proofs
+> verify only under the insecure pre-NU6.2 key, and NU6.2-onward proofs only
+> under the corrected one. The two circuits differ only in the additional copy
+> constraints added to ensure soundness [^halo2-commit]. The consensus rule specifying
+> which key is used for verification is in § 4.6 ‘Action Descriptions’.
+
+### Canonical Orchard Action proof length
+
+Add a consensus rule in § 7.5 ‘Action Description Encoding and Consensus’
+[^protocol-actionencodingandconsensus]:
+
+> * [NU6.2 onward] The $\mathtt{proofsOrchard}$ field MUST have the canonical length
+>   of $2720 + 2272 \cdot \mathtt{nActionsOrchard}$ bytes.
+
+Add a non-normative note:
+
+> * Before NU6.2, the length of the $\mathtt{proofsOrchard}$ field was not enforced
+>   as a consensus rule. The canonical length is determined by the circuit, and is
+>   the same for the pre-NU6.2 and post-NU6.2 circuits. See § 5.4.10.3
+>   ‘Encoding of $\mathsf{Halo\;2}$ Proofs’ [^protocol-halo2encoding], where a
+>   $\mathsf{Halo\;2}$ proof is encoded as the proof byte sequence itself.
 
 ## Backward compatibility
 
@@ -141,9 +214,23 @@ will always disconnect peers using lower protocol versions.
 
 [^BCP14]: [Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
 
-[^protocol]: [Zcash Protocol Specification, Version 2026.7.0 [NU6.2] or later](protocol/protocol.pdf)
+[^protocol-2026.6.4]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]](protocol/nu6_1.pdf#2026.6.4)
 
-[^protocol-networks]: [Zcash Protocol Specification, Version 2026.7.0 [NU6.2]. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
+[^protocol-2026.7.0]: [Zcash Protocol Specification, Version 2026.7.0 [NU6.2]](protocol/protocol.pdf#2026.7.0)
+
+[^protocol-networks]: [Zcash Protocol Specification, Version 2026.7.0 [NU6.2] or later. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
+
+[^protocol-abstractzk]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]. Section 4.1.13: Zero-Knowledge Proving System](protocol/nu6_1.pdf#abstractzk)
+
+[^protocol-actiondesc]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]. Section 4.6: Action Descriptions](protocol/nu6_1.pdf#actiondesc)
+
+[^protocol-actionstatement]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]. Section 4.18.4: Action Statement ($\mathsf{Orchard}$)](protocol/nu6_1.pdf#actionstatement)
+
+[^protocol-halo2encoding]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]. Section 5.4.10.3: Encoding of $\mathsf{Halo\;2}$ Proofs](protocol/nu6_1.pdf#halo2encoding)
+
+[^protocol-txnconsensus]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]. Section 7.1.2: Transaction Consensus Rules](protocol/nu6_1.pdf#txnconsensus)
+
+[^protocol-actionencodingandconsensus]: [Zcash Protocol Specification, Version 2026.6.4 [NU6.1]. Section 7.5: Action Description Encoding and Consensus](protocol/nu6_1.pdf#actionencodingandconsensus)
 
 [^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
 
@@ -154,6 +241,8 @@ will always disconnect peers using lower protocol versions.
 [^orchard-0.14.0]: [orchard v0.14.0 release (zcash/orchard#500)](https://github.com/zcash/orchard/pull/500)
 
 [^halo2-0.5.0]: [halo2_gadgets v0.5.0 release (zcash/halo2#888)](https://github.com/zcash/halo2/pull/888)
+
+[^halo2-commit]: [zcash/halo2 PR 888, commit d8e48ef. halo2_gadgets: Anchor variable-base scalar-mul incomplete-addition base](https://github.com/zcash/halo2/pull/888/changes/d8e48efddbe4746d76eb2c8a843a6ddc2b9a727a)
 
 [^Hornby2026]: [Taylor Hornby — work log for the Orchard counterfeiting vulnerability](https://drive.google.com/file/d/1SVK41y-ip3Vw9eB69E9QRy-Qn3idTOwV/view)
 

--- a/zips/zip-0257.md
+++ b/zips/zip-0257.md
@@ -2,7 +2,7 @@
     ZIP: 257
     Title: Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade
     Owners: Daira-Emma Hopwood <daira@jacaranda.org>
-    Status: Proposed
+    Status: Final
     Category: Consensus / Network
     Created: 2026-06-09
     License: MIT

--- a/zips/zip-0257.md
+++ b/zips/zip-0257.md
@@ -139,9 +139,9 @@ will always disconnect peers using lower protocol versions.
 
 [^BCP14]: [Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
 
-[^protocol]: [Zcash Protocol Specification, Version 2025.6.3 or later](protocol/protocol.pdf)
+[^protocol]: [Zcash Protocol Specification, Version 2026.7.0 [NU6.2] or later](protocol/protocol.pdf)
 
-[^protocol-networks]: [Zcash Protocol Specification, Version 2025.6.3 [NU6.1]. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
+[^protocol-networks]: [Zcash Protocol Specification, Version 2026.7.0 [NU6.2]. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
 
 [^zip-0200]: [ZIP 200: Network Upgrade Mechanism](zip-0200.rst)
 

--- a/zips/zip-0257.md
+++ b/zips/zip-0257.md
@@ -37,7 +37,7 @@ AI-assisted security audit of the Orchard shielded protocol, reported a
 soundness vulnerability in the
 [Orchard Action circuit implementation](https://github.com/zcash/orchard).
 Details of the vulnerability are described in Taylor's work log [^Hornby2026]
-and in GHSA-ww9q-8r59-xv46. [^GHSA-halo2]
+and in GHSA-ww9q-8r59-xv46. [^GHSA-circuit]
 
 This vulnerability could have allowed balance violation and theft of funds.
 Therefore, it was imperative to immediately disable use of Orchard, until a
@@ -57,7 +57,7 @@ onward, until the activation of NU6.2 on each network, v5 and later transactions
 MUST NOT contain any Orchard Action descriptions, i.e. $\mathsf{nActionsOrchard} = 0$.
 
 The Mainnet mitigation was deployed as an emergency hotfix in zcashd v6.12.5
-and zebra v4.5.3. [^GHSA-zcash-hotfix] [^GHSA-zebra-hotfix] These releases did
+and zebra v4.5.3. [^GHSA-zcashd] [^GHSA-zebra] These releases did
 not have the "until the activation of NU6.2" restriction; i.e. they disabled
 Orchard until deployment of the subsequent releases. Note that zcashd v6.12.4
 also deployed other security fixes described in ZIP 256 [^zip-0256].
@@ -88,7 +88,7 @@ consensus changes relative to the original Orchard rules:
 
 - From the activation of NU6.2, an Orchard Action proof MUST have the canonical
   length for the corrected circuit. Before NU6.2, this length was not enforced
-  as a consensus rule. [^GHSA-zebra-hotfix]
+  as a consensus rule. [^GHSA-zebra]
 
 From the activation of NU6.2, the temporary mitigation no longer applies.
 Transactions containing Orchard Action descriptions MUST again be accepted,
@@ -155,8 +155,8 @@ will always disconnect peers using lower protocol versions.
 
 [^Hornby2026]: [Taylor Hornby — work log for the Orchard counterfeiting vulnerability](https://drive.google.com/file/d/1SVK41y-ip3Vw9eB69E9QRy-Qn3idTOwV/view)
 
-[^GHSA-halo2]: [Missing copy constraint in halo2_gadgets variable-base scalar multiplication allows under-constrained base, breaking Orchard Action circuit soundness (fixed in zcashd v6.20.0 and zebra v5.0.0)](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-ww9q-8r59-xv46)
+[^GHSA-circuit]: [GitHub Security Advisory ww9q-8r59-xv46: Missing copy constraint in halo2_gadgets variable-base scalar multiplication allows under-constrained base, breaking Orchard Action circuit soundness](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-ww9q-8r59-xv46)
 
-[^GHSA-zcash-hotfix]: [Urgent Zcash hotfixes v6.12.4 & v6.20.0 (zcashd, affected v5.0.0–v6.13.0)](https://github.com/zcash/zcash/security/advisories/GHSA-ghc3-g8w4-whf9)
+[^GHSA-zcashd]: [GitHub Security Advisory ghc3-g8w4-whf9: Urgent zcashd hotfixes v6.12.4 and v6.20.0](https://github.com/zcash/zcash/security/advisories/GHSA-ghc3-g8w4-whf9)
 
-[^GHSA-zebra-hotfix]: [‹GHSA-jfw5-j458-pfv6 title — fill from GitHub once published› (zebrad; soft-fork disable in v4.5.3, NU6.2 proof-size rule in v5.0.0)](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-jfw5-j458-pfv6)
+[^GHSA-zebra]: [GitHub Security Advisory jfw5-j458-pfv6: Zebra vulnerability remediation for the soundness flaw in the pre-NU6.2 Orchard Action circuit](https://github.com/ZcashFoundation/zebra/security/advisories/GHSA-jfw5-j458-pfv6)

--- a/zips/zip-0318.rst
+++ b/zips/zip-0318.rst
@@ -1,0 +1,11 @@
+::
+
+  ZIP: 318
+  Title: Orchard to Ironwood Migration
+  Owners: Schell Carl Scivally <efsubenovex@gmail.com>
+          Pacu Gindre <pacu@zecdev.org>
+  Status: Reserved
+  Category: Wallet
+  Created: 2026-06-16
+  License: MIT
+  Discussions-To: <https://github.com/zcash/zips/issues/1315>

--- a/zips/zip-0326.rst
+++ b/zips/zip-0326.rst
@@ -1,0 +1,10 @@
+::
+
+  ZIP: 326
+  Title: NU6.3 Consequences for Wallets
+  Owners: Daira-Emma Hopwood <daira@jacaranda.org>
+  Status: Reserved
+  Category: Wallet
+  Created: 2026-06-30
+  License: MIT
+  Discussions-To: <https://github.com/zcash/zips/issues/1318>

--- a/zips/zip-2006.rst
+++ b/zips/zip-2006.rst
@@ -1,0 +1,10 @@
+::
+
+  ZIP: 2006
+  Title: Restricting Transfers to the Orchard Pool
+  Owners: Daira-Emma Hopwood <daira@jacaranda.org>
+  Status: Reserved
+  Category: Consensus
+  Created: 2026-06-20
+  License: MIT
+  Discussions-To: <https://github.com/zcash/zips/issues/1305>


### PR DESCRIPTION
This is the NU6.2 update to the Zcash Protocol Specification (version 2026.7.0), together with ZIP 257. It builds on the 2026.6.4 release (#1322, merged).

## ZIP 257 — Deployment of the Orchard Temporary Vulnerability Mitigation and NU6.2 Network Upgrade

Adds ZIP 257, which retrospectively documents the Orchard temporary vulnerability mitigation (the soft fork that disabled Orchard between the mitigation heights and NU6.2 activation), and specifies the NU6.2 network upgrade:

- the temporary-mitigation consensus rule (from the mitigation block height on each network until NU6.2 activation, v5-and-later transactions MUST NOT contain Orchard Action descriptions);
- the Orchard Action verifying key selection — the corrected post-NU6.2 circuit has a different verifying key from the insecure pre-NU6.2 one, so pre-NU6.2 Action proofs verify only under the historical key and NU6.2-onward proofs only under the corrected one;
- the canonical Orchard Action proof length rule;
- the NU6.2 network upgrade constants.

## Protocol specification changes (ZIP 257)

- **§ 4.6**: consensus rules selecting the Orchard Action verifying key (`InsecurePreNU6_2` before NU6.2, `FixedPostNU6_2` from NU6.2 onward), plus the proof-validity rule over the primary input.
- **§ 4.18.4**: a vulnerability disclosure for the soundness bug in the pre-NU6.2 Orchard Action circuit (the circuit implementation only; the Action statement is as intended).
- **§ 4.1.13**: stop omitting the subscripts on `ZKAction.Prove`/`ZKAction.Verify`, since more than one version of the Orchard circuit has been deployed.
- **§ 7.1.2**: the temporary-mitigation consensus rule.
- **§ 7.5**: the canonical Orchard Action proof length rule (`[NU6.2 onward]`), with a non-normative note.

## Mark NU6.2 as a settled Network Upgrade

- Give the NU6.2 Mainnet and Testnet activation block hashes (Mainnet and Testnet section), and specify (Blockchain section) that NU6.2 is the most recent settled Network Upgrade on Testnet and Mainnet.
- Note that Testnet does not always activate Network Upgrades before Mainnet — NU6.2 activated on Testnet *after* Mainnet, the first upgrade for which this happened.

## ZIP statuses

- Set **ZIP 255, ZIP 256, and ZIP 257** to `Final` — NU6.1, the consensus bug fixes between NU6.1 and NU6.2, and the NU6.2 deployment are all deployed. (ZIP 255/256 → Final is the first commit, since they should already have been Final.)

## README

- Update the "Settled Mainnet Network Upgrade" section to NU6.2 (activated at Mainnet block height 3364600 on 2026-06-03), and fix the settled link to use reStructuredText syntax.
- Add a "NU6.3 Candidate ZIPs" section: ZIP 258 (deployment), and ZIP 229, 2005, 2006, 318, 326; plus a note on the ZIP 209 and 317 updates. `Reserved` stubs are added for the not-yet-drafted ZIP 318, 326, and 2006 (each with `Discussions-To` pointing at its tracking issue) so their links resolve; the NU6.3 PRs will replace them.
- Regenerate `README.rst`.

## Boilerplate

- Add NU6.2 (and NU6.3-proposal) build boilerplate; the production `protocol.pdf` is now the NU6.2 build. The NU6.3 PDF is not built yet.

Released as spec version 2026.7.0 (tagged `v2026.7.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


