### PR TITLE
Ironwood ZIPs and protocol spec followup

### DIFF
--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1453,11 +1453,23 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\transactionFees}{\terms{transaction fee}}
 \newcommand{\transactionVersion}{\termandindex{transaction version}{transaction version number}}
 \newcommand{\transactionVersions}{\termandindex{transaction versions}{transaction version number}}
+\newcommand{\TransactionVersion}{\termandindex{Transaction version}{transaction version number}}
+\newcommand{\TransactionVersions}{\termandindex{Transaction versions}{transaction version number}}
 \newcommand{\transactionVersionNumber}{\term{transaction version number}}
 \newcommand{\transactionVersionNumbers}{\terms{transaction version number}}
 \newcommand{\versionNumber}{\termandindex{version number}{transaction version number}}
-\newcommand{\Transactionversion}{\termandindex{Transaction version}{transaction version number}}
-\newcommand{\versionFiveOrSix}{version 5\nusixthree{ or version 6}\xspace}
+% For maintainability, make sure to use the semantically correct macro, not just one that happens to match.
+\newcommand{\versionsForSaplingPool}{version 4\nufive{ or version 5}\nusixthree{ or version 6}\xspace}
+\newcommand{\VersionsForSaplingPool}{Version 4\nufive{ or version 5}\nusixthree{ or version 6}\xspace}
+\newcommand{\versionsForOrchardPool}{version 5\nusixthree{ or version 6}\xspace}
+\newcommand{\VersionsForOrchardPool}{Version 5\nusixthree{ or version 6}\xspace}
+\newcommand{\versionsAfterFourForSaplingPool}{version 5\nusixthree{ or version 6}\xspace}
+\newcommand{\versionsWithWtxid}{version 5\nusixthree{ or version 6}\xspace}
+\newcommand{\versionsForIronwoodPool}{version 6\xspace}
+\newcommand{\VersionsForIronwoodPool}{Version 6\xspace}
+\newcommand{\transactionVersionsForOrchardPool}{\notnusixthree{\transactionVersion 5}\notbeforenusixthree{\transactionVersions 5\nusixthree{ and 6}}\xspace}
+\newcommand{\TransactionVersionsForOrchardPool}{\notnusixthree{\TransactionVersion 5}\notbeforenusixthree{\TransactionVersions 5\nusixthree{ and 6}}\xspace}
+\newcommand{\TransactionVersionsForOrchardPoolDoNot}{\notnusixthree{\TransactionVersion 5 does not}\nusixthree{\TransactionVersions 5\nusixthree{ and 6} do not}\xspace}
 \newcommand{\versionGroupID}{\term{version group ID}}
 \newcommand{\consensusBranchID}{\term{consensus branch ID}}
 \newcommand{\xConsensusBranchID}{\termx{consensus branch ID}}
@@ -3207,8 +3219,8 @@ has been publically revealed on the \blockChain prior to that point, but the
 A \transaction can contain \transparent inputs, outputs, and scripts, which all
 work as in \Bitcoin \cite{Bitcoin-Protocol}.
 It also can include \joinSplitDescriptions,\sapling{ \spendDescriptions,\notnufive{ and}
-\outputDescriptions}\nufive{ and \actionDescriptions}. Together these describe
-\defining{\shieldedTransfers} which take in \defining{\shieldedInput} \notes,
+\outputDescriptions}\nufive{ and\nusixthree{ (for the \OrchardLikePools)} \actionDescriptions}.
+Together these describe \defining{\shieldedTransfers} which take in \defining{\shieldedInput} \notes,
 and/or produce \defining{\shieldedOutput} \notes.
 (For \Sprout, each \joinSplitDescription handles up to two \shieldedInputs and
 up to two \shieldedOutputs.\sapling{ For \Sapling, each \shieldedInput or \shieldedOutput
@@ -4045,7 +4057,7 @@ Each \transaction has a \defining{\transactionID}. \xTransactionIDs are used to 
 \transactions in $\txOut$ fields, in \merkleLeafNodes of a \block's \transaction tree
 rooted at $\hashMerkleRoot$, and in other parts of the ecosystem; for example they are
 shown in \blockChain explorers and can be used in higher-level protocols.
-\nufive{Version 5 \transactions also have a \defining{\wtxid}, which is used instead of
+\nufive{\TransactionVersionsForOrchardPool also have a \defining{\wtxid}, which is used instead of
 the \transactionID when gossiping \transactions in the \peerToPeerProtocol \cite{ZIP-239}.}
 The computation of \transactionIDs\nufive{ and \wtxids} is described in \crossref{txnidentifiers}.
 \nufive{For more detail on the distinction between these two identifiers and when to
@@ -4252,8 +4264,8 @@ i.e.\ the value of the spent \note minus the value of the created \note.
 It is associated with an instance of an \actionStatement (\crossref{actionstatement})
 for which it provides a \zkSNARKProof.
 
-Each version 5 \transaction has a sequence of \actionDescriptions for the \OrchardPool.
-\nusixthree{Version 6 \transactions additionally have a sequence of \actionDescriptions
+Each \versionsForOrchardPool \transaction has a sequence of \actionDescriptions for the \OrchardPool.
+\nusixthree{\VersionsForIronwoodPool \transactions additionally have a sequence of \actionDescriptions
 for the \IronwoodPool.} Version 4 \transactions cannot contain \actionDescriptions.
 
 As in \Sapling, we use the homomorphic property of \xPedersenCommitments to enforce
@@ -4403,9 +4415,10 @@ implementations should be modified. Currently these implementations are \zebra m
 Zcash Foundation, and \zcashd maintained by the Zcash Open Development Lab.
 
 \nusixthree{
-It is proposed that \zcashd will not support the consensus changes defined for \NUSixThree, and
-therefore \zebra will be the only \fullValidator implementation able to follow the consensus Zcash
-\blockChain from \NUSixThree activation onward.
+The \zcashd \fullValidator implementation maintained by Zcash Open Development Lab will not support
+the consensus changes defined for \NUSixThree, and therefore \zebra will be the only long-term-supported
+\fullValidator implementation able to follow the consensus Zcash \blockChain from \NUSixThree activation
+onward.
 } %nusixthree
 
 Subject to errors and omissions, each version of this document intends to describe some version
@@ -6547,13 +6560,13 @@ performs the following steps:
 \end{algorithm}
 
 \vspace{-0.5ex}
-If no real \OrchardPoolAdj \note is being spent in the same \actionTransfer, the sender
+If no real \OrchardLikePoolAdj \note is being spent in the same \actionTransfer, the sender
 \SHOULD create a \dummyNote to spend as described in \crossref{orcharddummynotes},
 and use that \dummyNote's \nullifier as the $\NoteUniqueRand$ value.
 
 In order to minimize information leakage, the sender \SHOULD randomize the order of
-\actionDescriptions in a \transaction. Other considerations relating to information
-leakage from the structure of \transactions are beyond the scope of this specification.
+\actionDescriptions in a \transaction\nusixthree{ for each pool}. Other considerations relating to
+information leakage from the structure of \transactions are beyond the scope of this specification.
 The encoded \transaction is submitted to the \peerToPeerNetwork.
 
 \pnote{
@@ -6890,24 +6903,29 @@ as part of the \NUOverwinter upgrade.
 } %overwinter
 
 \nufive{
-\Orchard and the \NUFive \networkUpgrade introduce \transaction version 5, which \MUST be
-used if any \actionTransfers are present. This version also provides nonmalleable \transaction
-identifiers, and \MAY be used for that reason whether or not \actionTransfers are present.
+\Orchard and the \NUFive \networkUpgrade introduce \transactionVersion 5.
+\nusixthree{\NUSixThree introduces \transaction version 6.}
+If \OrchardPoolAdj \actionTransfers are present, \versionsForOrchardPool \MUST be used.
+\nusixthree{If \IronwoodPoolAdj \actionTransfers are present, \versionsForIronwoodPool \MUST be used.}
+
+\TransactionVersionsForOrchardPool also provide\notnusix{s} nonmalleable \transaction identifiers,
+and \MAY be used for that reason whether or not \actionTransfers are present.
 } %nufive
 
 \begin{consensusrules}
-  \nufiveonwarditem{Any \sighashType encoding used in a version 5 \transaction \MUST be the
+  \nufiveonwarditem{Any \sighashType encoding used in a \versionsForOrchardPool \transaction \MUST be the
         canonical encoding of one of the defined \sighashTypes, i.e.\ one of \hexint{01},
-        \hexint{02}, \hexint{03}, \hexint{81}, \hexint{82}, or \hexint{83}. (Previously,
-        undefined bits of a \sighashType encoding were ignored.)}
+        \hexint{02}, \hexint{03}, \hexint{81}, \hexint{82}, or \hexint{83}. (In previous
+        \transactionVersions, undefined bits of a \sighashType encoding were ignored.)}
   \preoverwinteritem{The \sighashAlgorithm used prior to \NUOverwinter activation, i.e.\ for
         version 1 and 2 \transactions, will be defined in \cite{ZIP-76} (to be written).}
   \overwinteronlyitem{The \sighashAlgorithm used after \NUOverwinter activation and before
         \NUSapling activation, i.e.\ for version 3 \transactions, is defined in \cite{ZIP-143}.}
+  \saplingonwarditem{The \sighashAlgorithm used for version 4 \transactions is defined in \cite{ZIP-243}.}
+  \nufiveonwarditem{The \sighashAlgorithm used for version 5 \transactions is defined in \cite{ZIP-244}.}
+  \nusixthreeonwarditem{The \sighashAlgorithm used for version 6 \transactions is defined in \cite{ZIP-229}.}
   \overwinteronlyitem{All \transactions \MUST use the \NUOverwinter \consensusBranchID \hexint{5BA81B19}
         as defined in \cite{ZIP-201}.}
-  \saplingonwarditem{The \sighashAlgorithm used after \NUSapling activation, i.e.\ for
-        version 4 \transactions, is defined in \cite{ZIP-243}.}
   \saplingonlyitem{All \transactions \MUST use the \NUSapling \consensusBranchID \hexint{76B809BB}
         as defined in \cite{ZIP-205}.}
   \blossomonlyitem{All \transactions \MUST use the \NUBlossom \consensusBranchID \hexint{2BB40E60}
@@ -6916,9 +6934,6 @@ identifiers, and \MAY be used for that reason whether or not \actionTransfers ar
         as defined in \cite{ZIP-250}.}
   \canopyonlyitem{All \transactions \MUST use the \NUCanopy \consensusBranchID \hexint{E9FF75A6}
         as defined in \cite{ZIP-251}.}
-  \nufiveonwarditem{The \sighashAlgorithm used for version 5 \transactions introduced by the
-        \NUFive \networkUpgrade is defined in \cite{ZIP-244}. Version 4 \transactions continue
-        to use the \sighashAlgorithm defined in \cite{ZIP-243}.}
   \nufiveonlyitem{All \transactions \MUST use the \NUFive \consensusBranchID \hexint{F919A198}
         as defined in \cite{ZIP-252}.}
   \nusixonlyitem{All \transactions \MUST use the \NUSix \consensusBranchID \hexint{C8E71055}
@@ -7105,9 +7120,12 @@ In order to check for implementation faults, the signer \SHOULD also check that
 \end{formulae}
 
 \vspace{-1ex}
-Let $\SigHash$ be the \sighashTxHash as defined in \cite{ZIP-243} for a version 4
-\transaction\nufive{ or \cite{ZIP-244} for a version 5 \transaction}, not associated with
-an input, using the \sighashType $\SIGHASHALL$.
+A \transaction containing \actionDescriptions is necessarily a \versionsForSaplingPool \transaction.
+Let $\SigHash$ be the \sighashTxHash for\notnufive{ a version 4 \transaction}\nufive{ the
+appropriate \transactionVersion}, not associated with an input, using the \sighashType $\SIGHASHALL$.
+This is defined in \cite{ZIP-243}\notbeforenufive{ for a version 4 \transaction}\nufive{, or in
+\cite{ZIP-244} for a version 5 \transaction}\nusixthree{, or in \cite{ZIP-229} for a version 6
+\transaction}.
 
 A validator checks balance by validating that
 $\BindingSigValidate{Sapling}{\BindingPublic{Sapling}}(\SigHash, \bindingSig{Sapling}) = 1$.
@@ -7307,9 +7325,11 @@ In order to check for implementation faults, the signer \SHOULD also check that
   \item $\BindingPublic{Orchard} = \BindingSigDerivePublic{Orchard}(\BindingPrivate{Orchard})$.
 \end{formulae}
 
-A \transaction containing \actionDescriptions is necessarily a version 5 \transaction.
-Let $\SigHash$ be the \sighashTxHash for a version 5 \transaction as defined in \cite{ZIP-244}
-as modified by \cite{ZIP-225}, not associated with an input, using the \sighashType $\SIGHASHALL$.
+A \transaction containing \actionDescriptions is necessarily a \versionsForOrchardPool \transaction.
+Let $\SigHash$ be the \sighashTxHash for\notnusixthree{ a version 5 \transaction}\nusixthree{ the
+appropriate \transactionVersion}, not associated with an input, using the \sighashType $\SIGHASHALL$.
+This is defined in \cite{ZIP-244}\notbeforenusixthree{ for a version 5\transaction}\nusixthree{, or
+in \cite{ZIP-229} for a version 6 \transaction}.
 
 A validator checks balance by validating that
 $\BindingSigValidate{Orchard}{\BindingPublic{Orchard}}(\SigHash, \bindingSig{Orchard}) = 1$.
@@ -7450,7 +7470,9 @@ For each \spendDescription\nufive{ or \actionDescription}, the signer chooses a 
 \end{enumerate}
 
 The resulting $\spendAuthSig$ and $\Proof{}$ are included in the \spendDescription\nufive{, or
-in the \vSpendAuthSigs{Sapling} or \vSpendAuthSigs{Orchard} field of a version 5 \transaction}.
+in the \vSpendAuthSigs{Sapling} or \vSpendAuthSigs{Orchard} field of a \versionsForOrchardPool
+\transaction}\nusixthree{ or in the \vSpendAuthSigs{Ironwood} field of a \versionsForIronwoodPool
+\transaction}.
 
 \vspace{1ex}
 \pnote{
@@ -9088,8 +9110,9 @@ $16$-byte personalization string $p$, and input $x$.
 $\BlakeTwobGeneric$ is used to instantiate $\hSigCRH$, $\EquihashGen{}$,
 and $\KDF{Sprout}$.
 \overwinter{From \NUOverwinter onward, it is used to compute \sighashTxHashes
-as specified in \cite{ZIP-143}\sapling{, or as in \cite{ZIP-243} after
-\NUSapling activation}\nufive{, or as in \cite{ZIP-244} for version 5 \transactions}.}
+as specified in \cite{ZIP-143}\sapling{, or as in \cite{ZIP-243} after \NUSapling
+activation}\nufive{, or as in \cite{ZIP-244} for version 5 \transactions}\nusixthree{,
+or as in \cite{ZIP-229} for version 6 \transactions}.}
 \sapling{For \Sapling, it is also used to instantiate $\PRFexpand{}$,
 $\PRFock{Sapling}{}$, $\KDF{Sapling}$, and in the $\RedJubjub$ \signatureScheme
 which instantiates $\SpendAuthSig{Sapling}$ and $\BindingSig{Sapling}$.}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -13441,7 +13441,7 @@ $\bindingSig{} \rightarrow \bindingSig{Sapling}$.
 
 \nufive{
 \introlist
-The \Zcash{} \defining{\transaction} format for \transactionVersion 5 is as follows
+The \Zcash{} \defining{\transaction} format for \transactionVersionsForOrchardPool is as follows
 (this should be read in the context of consensus rules later in the section):
 \vspace{-1.2ex}
 \begin{center}
@@ -13482,13 +13482,13 @@ A \blockHeight after which the \transaction will expire, or $0$ to disable expir
 & \Varies & $\nSpendsSapling$ & \type{compactSize} &
 The number of \spendDescriptions in $\vSpendsSapling$.\! \\ \hline
 
-& \Longunderstack{$96 \mult$ \\$\!\nSpendsSapling\!$} & $\vSpendsSapling$ & \type{SpendDescriptionV5} \type{[$\nSpendsSapling$]} &
+& \Longunderstack{$96 \mult$ \\$\!\nSpendsSapling\!$} & $\vSpendsSapling$ & \type{SpendDescriptionV5Onward} \type{[$\nSpendsSapling$]} &
 A sequence of \spendDescriptions{}, encoded per \crossref{spendencodingandconsensus}.\! \\ \hline
 
 & \Varies & $\nOutputsSapling\!$ & \type{compactSize} &
 The number of \outputDescriptions in $\vOutputsSapling$.\! \\ \hline
 
-& \Longunderstack{$756 \mult$ \\$\!\nOutputsSapling\!$} & $\vOutputsSapling\!$ & \type{OutputDescriptionV5} \type{[$\nOutputsSapling$]} &
+& \Longunderstack{$756 \mult$ \\$\!\nOutputsSapling\!$} & $\vOutputsSapling\!$ & \type{OutputDescriptionV5Onward} \type{[$\nOutputsSapling$]} &
 A sequence of \outputDescriptions{}, encoded per \crossref{outputencodingandconsensus}.\! \\ \hline
 
 $\dagger$ & $8$ & $\valueBalance{Sapling}\!$ & \type{int64} &
@@ -13510,16 +13510,16 @@ $\dagger$ & $64$ & $\bindingSig{Sapling}$ & \type{byte[64]} &
 A \saplingBindingSignature on the \sighashTxHash, validated per \crossref{concretebindingsig}.\! \\
 \hhline{|=====|}
 
-& \Varies &\setnufive $\nActionsOrchard\!$ & \type{compactSize} &
-The number of \actionDescriptions in $\vActionsOrchard$.\! \\ \hline
+& \Varies &\setnufive $\nActionsField{Orchard}\!$ & \type{compactSize} &
+The number of \actionDescriptions in $\vActionsField{Orchard}$.\! \\ \hline
 
-& \Longunderstack{$820 \mult$ \\$\!\nActionsOrchard\!$} & $\vActionsOrchard$ & \type{ActionDescription} \type{[$\nActionsOrchard$]} &
+& \Longunderstack{$820 \mult$ \\$\!\nActionsField{Orchard}\!$} & $\vActionsField{Orchard}$ & \type{ActionDescription} \type{[$\nActionsField{Orchard}$]} &
 A sequence of \actionDescriptions{}, encoded per \crossref{actionencodingandconsensus}.\! \\ \hline
 
-$\mathsection$ & $1$ & $\flagsOrchard$ & \type{byte} &
+$\mathsection$ & $1$ & $\flagsField{Orchard}$ & \type{byte} &
 Contains: \begin{compactitemize}
-  \item $\enableSpendsOrchard$ flag (bit $0$)
-  \item $\enableOutputsOrchard$ flag (bit $1$)
+  \item $\enableSpendsField{Orchard}$ flag (bit $0$)
+  \item $\enableOutputsField{Orchard}$ flag (bit $1$)
   \item Reserved, zeros (bits $\barerange{2}{7}$).\!
 \end{compactitemize} \\ \hline
 
@@ -13529,17 +13529,49 @@ The net value of \OrchardPoolAdj spends minus outputs.\! \\ \hline
 $\mathsection$ & $32$ & $\anchorField{Orchard}$ & \type{byte[32]} &
 A \merkleRoot of the \OrchardPoolAdj \noteCommitmentTree at some \blockHeight in the past, $\LEBStoOSP{256}\big(\rt{\OrchardPoolId}\big)$.\! \\ \hline
 
-$\mathsection$ & \Varies & $\sizeProofsOrchard$ & \type{compactSize} &
-The length of the aggregated \zkSNARKProof $\ProofAction$. Value is $2720 + 2272 \cdot \nActionsOrchard$.\! \\ \hline
+$\mathsection$ & \Varies & $\sizeProofsField{Orchard}$ & \type{compactSize} &
+The length of the aggregated \zkSNARKProof $\ProofAction{\OrchardPoolId}$. Value is $2720 + 2272 \cdot \nActionsField{Orchard}$.\! \\ \hline
 
-$\mathsection$ & \!$\sizeProofsOrchard$\! & $\proofsOrchard$ & \type{byte[$\sizeProofsOrchard$]}\!\! &
-The aggregated \zkSNARKProof $\ProofAction$ (see \crossref{halo2}).\! \\ \hline
+$\mathsection$ & \!$\sizeProofsField{Orchard}$\! & $\proofsField{Orchard}$ & \type{byte[$\sizeProofsField{Orchard}$]}\!\! &
+The aggregated \zkSNARKProof $\ProofAction{\OrchardPoolId}$ (see \crossref{halo2}).\! \\ \hline
 
-& \Longunderstack{$64 \mult$ \\$\!\nActionsOrchard\!$} & $\vSpendAuthSigs{Orchard}$ & \type{byte[64]} \type{[$\nActionsOrchard$]} &
+& \Longunderstack{$64 \mult$ \\$\!\nActionsField{Orchard}\!$} & $\vSpendAuthSigs{Orchard}$ & \type{byte[64]} \type{[$\nActionsField{Orchard}$]} &
 Authorizing signatures for each spend of an \OrchardPoolAdj \actionDescription.\! \\ \hline
 
 $\mathsection$ & $64$ & $\bindingSig{Orchard}$ & \type{byte[64]} &
 An \orchardBindingSignature on the \sighashTxHash, validated per \crossref{concretebindingsig}.\! \\ \hline
+\hhline{|=====|}
+
+& \Varies &\setnusixthree $\nActionsField{Ironwood}\!$ & \type{compactSize} &
+The number of \actionDescriptions in $\vActionsField{Ironwood}$.\! \\ \hline
+
+& \Longunderstack{$820 \mult$ \\$\!\nActionsField{Ironwood}\!$} & $\vActionsField{Ironwood}$ & \type{ActionDescription} \type{[$\nActionsField{Ironwood}$]} &
+A sequence of \actionDescriptions{}, encoded per \crossref{actionencodingandconsensus}.\! \\ \hline
+
+$\mathsection$ & $1$ & $\flagsField{Ironwood}$ & \type{byte} &
+Contains: \begin{compactitemize}
+  \item $\enableSpendsField{Ironwood}$ flag (bit $0$)
+  \item $\enableOutputsField{Ironwood}$ flag (bit $1$)
+  \item Reserved, zeros (bits $\barerange{2}{7}$).\!
+\end{compactitemize} \\ \hline
+
+$\mathsection$ & $8$ & $\valueBalance{Ironwood}\!$ & \type{int64} &
+The net value of \IronwoodPoolAdj spends minus outputs.\! \\ \hline
+
+$\mathsection$ & $32$ & $\anchorField{Ironwood}$ & \type{byte[32]} &
+A \merkleRoot of the \IronwoodPoolAdj \noteCommitmentTree at some \blockHeight in the past, $\LEBStoOSP{256}\big(\rt{\IronwoodPoolId}\big)$.\! \\ \hline
+
+$\mathsection$ & \Varies & $\sizeProofsField{Ironwood}$ & \type{compactSize} &
+The length of the aggregated \zkSNARKProof $\ProofAction{\IronwoodPoolId}$. Value is $2720 + 2272 \cdot \nActionsField{Ironwood}$.\! \\ \hline
+
+$\mathsection$ & \!$\sizeProofsField{Ironwood}$\! & $\proofsField{Ironwood}$ & \type{byte[$\sizeProofsField{Ironwood}$]}\!\! &
+The aggregated \zkSNARKProof $\ProofAction{\IronwoodPoolId}$ (see \crossref{halo2}).\! \\ \hline
+
+& \Longunderstack{$64 \mult$ \\$\!\nActionsField{Ironwood}\!$} & $\vSpendAuthSigs{Ironwood}$ & \type{byte[64]} \type{[$\nActionsField{Ironwood}$]} &
+Authorizing signatures for each spend of an \IronwoodPoolAdj \actionDescription.\! \\ \hline
+
+$\mathsection$ & $64$ & $\bindingSig{Ironwood}$ & \type{byte[64]} &
+An \ironwoodBindingSignature on the \sighashTxHash, validated per \crossref{concretebindingsig}.\! \\ \hline
 
 \end{tabularx}
 \renewcommand{\arraystretch}{\defaultarraystretch}
@@ -13554,16 +13586,23 @@ is not present, then $\vBalance{\SaplingPoolId}$ is defined to be $0$. \\[-0.8ex
 
 $\ddagger$ & The field \anchorField{Sapling} is present if and only if $\nSpendsSapling > 0$. \\[-0.5ex]
 
-$\mathsection$ & The fields \flagsOrchard, \valueBalance{Orchard}, \anchorField{Orchard},
-\sizeProofsOrchard, \proofsOrchard, and \bindingSig{Orchard} are present if and only if
-$\nActionsOrchard > 0$. If \valueBalance{Orchard} is not present, then $\vBalance{\OrchardPoolId}$
+$\mathsection$ & The fields \flagsField{Orchard}, \valueBalance{Orchard}, \anchorField{Orchard},
+\sizeProofsField{Orchard}, \proofsField{Orchard}, and \bindingSig{Orchard} are present if and only if
+$\nActionsField{Orchard} > 0$. If \valueBalance{Orchard} is not present, then $\vBalance{\OrchardPoolId}$
+is defined to be $0$. \\
+
+\notbeforenusixthree{
+$\medlozenge$ & The fields \flagsField{Ironwood}, \valueBalance{Ironwood}, \anchorField{Ironwood},
+\sizeProofsField{Ironwood}, \proofsField{Ironwood}, and \bindingSig{Ironwood} are present if and only if
+$\nActionsField{Ironwood} > 0$. If \valueBalance{Ironwood} is not present, then $\vBalance{\IronwoodPoolId}$
 is defined to be $0$.
+} %notbeforenusixthree
 \end{tabularx}
 } %scalebox
 \end{center}
 \vspace{-1.5ex}
 \scalebox{0.86}{
-\raggedright\!\!\Transactionversion 5 does not support \joinSplitTransfers.
+\raggedright\!\!\TransactionVersionsForOrchardPoolDoNot support \joinSplitTransfers.
 Several fields are reordered and/or renamed relative to prior versions.}} %scalebox %nufive
 
 \lsubsubsection{Transaction Identifiers}{txnidentifiers}
@@ -13571,11 +13610,12 @@ Several fields are reordered and/or renamed relative to prior versions.}} %scale
 The \transactionID of a \sapling{version 4} or earlier \transaction is the \shadHash hash
 of the \transaction encoding in the \notbeforenufive{pre-v5} format described above.
 
-\nufive{
-The \transactionID of a version 5 \transaction is as defined in \cite{ZIP-244}. A v5
-\transaction also has a \wtxid (used for example in the \peerToPeerProtocol) as defined
-in \cite{ZIP-239}.
-} %nufive
+\nufive{The \transactionID of a version 5 \transaction is as defined in \cite{ZIP-244}.}
+
+\nusixthree{The \transactionID of a version 6 \transaction is as defined in \cite{ZIP-229}.}
+
+\nufive{A \versionsWithWtxid \transaction also has a \wtxid (used for example in the
+\peerToPeerProtocol) as defined in \cite{ZIP-239}.}
 
 \lsubsubsection{Transaction Consensus Rules}{txnconsensus}
 
@@ -13821,7 +13861,7 @@ each \spendDescription\, (\crossref{spendencodingandconsensus}),\,\notnufive{ an
 The changes relative to \Bitcoin version 1 \transactions as described in \cite{Bitcoin-Format} are:
 
 \begin{itemize}
-  \item \Transactionversion 0 is not supported.
+  \item \TransactionVersion 0 is not supported.
   \item A version 1 \transaction is equivalent to a version 2 \transaction with
         $\nJoinSplit = 0$.
   \item The fields $\nJoinSplit$, $\vJoinSplit$, $\joinSplitPubKey$, and $\joinSplitSig$ have been added.
@@ -13829,12 +13869,15 @@ The changes relative to \Bitcoin version 1 \transactions as described in \cite{B
   \saplingonwarditem{The following fields have been added: $\nSpendsSapling$, $\vSpendsSapling$, $\nOutputsSapling$,
         $\vOutputsSapling$, and $\bindingSig{Sapling}$.}
   \nufiveonwarditem{In version 5 \transactions, these fields have been added: $\nConsensusBranchId$,
-        $\nActionsOrchard$, $\vActionsOrchard$, $\flagsOrchard$, $\valueBalance{Orchard}$,
-        $\anchorField{Orchard}$, $\sizeProofsOrchard$, $\proofsOrchard$, $\bindingSig{Orchard}$, and
+        $\nActionsField{Orchard}$, $\vActionsField{Orchard}$, $\flagsField{Orchard}$, $\valueBalance{Orchard}$,
+        $\anchorField{Orchard}$, $\sizeProofsField{Orchard}$, $\proofsField{Orchard}$, $\bindingSig{Orchard}$, and
         $\vSpendAuthSigs{Orchard}$.}
-  \item In \Zcash it is permitted for a \transaction to have no \transparentInputs, provided
-        at least one of $\nJoinSplit$\sapling{, $\nSpendsSapling$,\notnufive{ and}
-        $\nOutputsSapling$}\nufive{, and $\nActionsOrchard$} are nonzero.
+  \nufiveonwarditem{In version 6 \transactions, these fields have been added:
+        $\nActionsField{Ironwood}$, $\vActionsField{Ironwood}$, $\flagsField{Ironwood}$, $\valueBalance{Ironwood}$,
+        $\anchorField{Ironwood}$, $\sizeProofsField{Ironwood}$, $\proofsField{Ironwood}$, $\bindingSig{Ironwood}$, and
+        $\vSpendAuthSigs{Ironwood}$.}
+  \item In \Zcash it is permitted for a \transaction to have no \transparentInputs, provided that there
+        could be \shieldedInputs.
   \item A consensus rule limiting \transaction size has been added. In \Bitcoin there is
         a corresponding standard rule but no consensus rule.
 \end{itemize}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -13631,28 +13631,32 @@ of the \transaction encoding in the \notbeforenufive{pre-v5} format described ab
   \nusixthreeonwarditem{The \transactionVersionNumber \MUST be $4$ or $5$ or $6$.}
   \saplingonwarditem{If the \transactionVersionNumber{} is $4$ then the \versionGroupID \MUST be $\hexint{892F2085}$.}
   \nufiveonwarditem{If the \transactionVersionNumber{} is $5$ then the \versionGroupID \MUST be $\hexint{26A7270A}$.}
-  \nusixthreeonwarditem{If the \transactionVersionNumber{} is $6$ then the \versionGroupID \MUST be $\hexint{????????}$.}
+  \nusixthreeonwarditem{If the \transactionVersionNumber{} is $6$ then the \versionGroupID \MUST be $\hexint{D884B698}$.}
   \nufiveonwarditem{If $\effectiveVersion \geq 5$, the \nConsensusBranchId{} field \MUST match the
         \consensusBranchID used for \sighashTxHashes, as specified in \cite{ZIP-244}.}
   \presaplingitem{The encoded size of the \transaction \MUST be less than or equal to
         $100000$ bytes.}
-  \nufiveonwarditem{\nSpendsSapling, \nOutputsSapling, and \nActionsOrchard{} \MUST all be less
+  \nufiveonwarditem{\nSpendsSapling, \nOutputsSapling, and (if $\effectiveVersion \geq 5$) $\nActionsField{Orchard}$ \MUST all be less
         than $2^{16}$.}
-  \nusixthreeonwarditem{\nActionsIronwood{} \MUST be less than $2^{16}$.}
+  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$, then $\nActionsField{Ironwood}$ \MUST be less than $2^{16}$.}
   \presaplingitem{If $\effectiveVersion = 1$ or $\nJoinSplit = 0$, then both \txInCount{} and \txOutCount{} \MUST be nonzero.\!}
   \saplingonwarditem{If $\effectiveVersion < 5$, then at least one of \txInCount, \nSpendsSapling, and \nJoinSplit{} \MUST be nonzero.}
   \saplingonwarditem{If $\effectiveVersion < 5$, then at least one of \txOutCount, \nOutputsSapling, and \nJoinSplit{} \MUST be nonzero.}
-  \nufiveonwarditem{If $\effectiveVersion \geq 5$ then this condition \MUST hold: $\txInCount > 0$ or \mbox{$\nSpendsSapling > 0$} or
-        $(\nActionsOrchard > 0$ and $\enableSpendsOrchard = 1)$\nusixthree{ or [\NUSixThree onward] $(\nActionsIronwood > 0$ and $\enableSpendsIronwood = 1)$}.}
-  \nufiveonwarditem{If $\effectiveVersion \geq 5$ then this condition \MUST hold: $\txOutCount > 0$ or \mbox{$\nOutputsSapling > 0$} or
-        $(\nActionsOrchard > 0$ and $\enableOutputsOrchard = 1)$\nusixthree{ or [\NUSixThree onward] $(\nActionsIronwood > 0$ and $\enableOutputsIronwood = 1)$}.}
-  \nufiveonwarditem{If $\effectiveVersion \geq 5$ and $\nActionsOrchard > 0$, then at least one of
-        $\enableSpendsOrchard$ and $\enableOutputsOrchard$ \MUST be $1$.}
-  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$ and $\nActionsIronwood > 0$, then at least one of
-        $\enableSpendsIronwood$ and $\enableOutputsIronwood$ \MUST be $1$.}
+  \nufiveonwarditem{If $\effectiveVersion = 5$ then this condition \MUST hold: $\txInCount > 0$ or \mbox{$\nSpendsSapling > 0$} or
+        $(\nActionsField{Orchard} > 0$ and $\enableSpendsField{Orchard} = 1)$.}
+  \nufiveonwarditem{If $\effectiveVersion = 5$ then this condition \MUST hold: $\txOutCount > 0$ or \mbox{$\nOutputsSapling > 0$} or
+        $(\nActionsField{Orchard} > 0$ and $\enableOutputsField{Orchard} = 1)$.}
+  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$ then this condition \MUST hold: $\txInCount > 0$ or \mbox{$\nSpendsSapling > 0$} or
+        $(\nActionsField{Orchard} > 0$ and $\enableSpendsField{Orchard} = 1)$ or $(\nActionsField{Ironwood} > 0$ and $\enableSpendsField{Ironwood} = 1)$.}
+  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$ then this condition \MUST hold: $\txOutCount > 0$ or \mbox{$\nOutputsSapling > 0$} or
+        $(\nActionsField{Orchard} > 0$ and $\enableOutputsField{Orchard} = 1)$ or $(\nActionsField{Ironwood} > 0$ and $\enableOutputsField{Ironwood} = 1)$.}
+  \nufiveonwarditem{If $\effectiveVersion \geq 5$ and $\nActionsField{Orchard} > 0$, then at least one of
+        $\enableSpendsField{Orchard}$ and $\enableOutputsField{Orchard}$ \MUST be $1$.}
+  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$ and $\nActionsField{Ironwood} > 0$, then at least one of
+        $\enableSpendsField{Ironwood}$ and $\enableOutputsField{Ironwood}$ \MUST be $1$.}
   \nufive{\prenusixtwoitem{From \blockHeight $3363426$ (\Mainnet) or $4048500$ (\Testnet)
         onward, until the activation of \NUSixTwo on each \network, if $\effectiveVersion \geq 5$ then
-        the \transaction \MUSTNOT contain any \Orchard \actionDescriptions, i.e.\ $\nActionsOrchard = 0$.}}
+        the \transaction \MUSTNOT contain any \Orchard \actionDescriptions, i.e.\ $\nActionsField{Orchard} = 0$.}}
   \item A \transaction with one or more \transparentInputs from \coinbaseTransactions \MUST have no
         \transparentOutputs (i.e.\ \txOutCount{} \MUST be $0$). Inputs from
         \coinbaseTransactions include \foundersReward outputs\canopy{ and \fundingStream outputs}.
@@ -13684,7 +13688,7 @@ of the \transaction encoding in the \notbeforenufive{pre-v5} format described ab
         \outputDescriptions were present, with the consequence that the failure case for this rule was never
         reached. For clarification, $\valueBalance{Sapling}$ refers to the value as encoded in the \transaction,
         which is not normalized in this way; it does not refer to $\vBalance{\SaplingPoolId}$.}}}
-  \nufiveonwarditem{If $\effectiveVersion \geq 5$ and $\nActionsOrchard > 0$,
+  \nufiveonwarditem{If $\effectiveVersion \geq 5$ and $\nActionsField{Orchard} > 0$,
         then:
         \begin{itemize}
           \item let $\BindingPublic{Orchard}$ and $\SigHash$ be as defined in \crossref{orchardbalance};
@@ -13695,7 +13699,7 @@ of the \transaction encoding in the \notbeforenufive{pre-v5} format described ab
                 of the signature prohibits \nonCanonicalPoint encodings.
         \end{itemize}}
         \vspace{-1ex}
-  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$ and $\nActionsIronwood > 0$,
+  \nusixthreeonwarditem{If $\effectiveVersion \geq 6$ and $\nActionsField{Ironwood} > 0$,
         then:
         \begin{itemize}
           \item let $\BindingPublic{Ironwood}$ and $\SigHash$ be as defined in \crossref{orchardbalance};
@@ -13723,9 +13727,13 @@ of the \transaction encoding in the \notbeforenufive{pre-v5} format described ab
   \item A \coinbaseTransaction \MUSTNOT have any \joinSplitDescriptions.
   \item \sapling{A \coinbaseTransaction \MUSTNOT have any \spendDescriptions.}
   \preheartwooditem{\sapling{A \coinbaseTransaction \MUSTNOT have any \outputDescriptions.}}
-  \nufiveonwarditem{In a version 5 \coinbaseTransaction, the \enableSpendsOrchard{} flag \MUST be $0$.}
-  \nufiveonwarditem{In a version 5 \transaction, the reserved bits $\barerange{2}{7}$ of the
-        \flagsOrchard{} field \MUST be zero.}
+  \nusixthreeonwarditem{A \coinbaseTransaction \MUSTNOT have any \OrchardPoolAdj \actionDescriptions.}
+  \nufiveonwarditem{In a \versionsForOrchardPool \coinbaseTransaction, the \enableSpendsField{Orchard} flag \MUST be $0$.}
+  \nusixthreeonwarditem{In a v6 \coinbaseTransaction, the \enableSpendsField{Ironwood} flag \MUST be $0$.}
+  \nufiveonwarditem{In a \versionsForOrchardPool \transaction, the reserved bits $\barerange{2}{7}$ of the
+        \flagsField{Orchard} field \MUST be zero. \todo{Is bit 2 reserved after \NUSixThree?}}
+  \nusixthreeonwarditem{In a v6 \transaction, the reserved bits $\barerange{3}{7}$ of the
+        \flagsField{Ironwood} field \MUST be zero.}
   \item A \coinbaseTransaction for a \block at \blockHeight greater than $0$ \MUST have a script that,
         as its first item, encodes the \blockHeight $\BlockHeight$ as follows. For $\BlockHeight$ in
         the range $\range{1}{16}$, the encoding is a single byte of value $\hexint{50} + \BlockHeight$.
@@ -13819,12 +13827,12 @@ each \spendDescription\, (\crossref{spendencodingandconsensus}),\,\notnufive{ an
   \canopyonwarditem{The rule that \SaplingPoolAdj outputs in \coinbaseTransactions \MUST decrypt to a \notePlaintext
         with lead byte $\hexint{02}$, also applies to \fundingStream outputs that specify \Sapling
         \shieldedPaymentAddresses, if there are any.}
-  \nufiveonwarditem{The flags in \flagsOrchardLike{} allow a \versionFiveOrSix \transaction
+  \nufiveonwarditem{The flags in \flagsField{\OrchardLike} allow a \versionsForOrchardPool \transaction
         to declare that no funds are spent from \OrchardLikePoolAdj \notes (by setting
-        \enableSpendsOrchardLike{} to $0$), or that no new \OrchardLikePoolAdj \notes with nonzero
-        values are created (by setting \enableOutputsOrchardLike{} to $0$). This has two primary
-        purposes. First, the value of the \enableSpendsOrchardLike{} flag is required to be $0$ in
-        \versionFiveOrSix \coinbaseTransactions to ensure that they cannot spend from existing
+        \enableSpendsField{\OrchardLike} to $0$), or that no new \OrchardLikePoolAdj \notes with nonzero
+        values are created (by setting \enableOutputsField{\OrchardLike} to $0$). This has two primary
+        purposes. First, the value of the \enableSpendsField{\OrchardLike} flag is required to be $0$ in
+        \versionsForOrchardPool \coinbaseTransactions to ensure that they cannot spend from existing
         \OrchardLikePoolAdj outputs. This maintains a restriction present in \coinbaseTransactions
         for \TransparentPoolAdj, \SproutPoolAdj, or \SaplingPoolAdj funds, which would not otherwise
         be enforceable in the combined \actionTransfer design.
@@ -13835,11 +13843,12 @@ each \spendDescription\, (\crossref{spendencodingandconsensus}),\,\notnufive{ an
         validation of \spendAuthSignatures, or other consensus rules associated with \actionDescriptions.
         These \note spending and creation consensus rules are specified as part of the \Orchard
         \actionStatement (\crossref{actionstatement}).}
-  \nufiveonwarditem{Because \enableSpendsOrchard{} is set to $0$ in \versionFiveOrSix
+  \nufiveonwarditem{Because \enableSpendsField{Orchard} is set to $0$ in \versionsForOrchardPool
         \coinbaseTransactions\ --which disables non-zero-valued \OrchardLikePoolAdj spends-- the
-        $\valueBalanceOrchardLike$ field of a \coinbaseTransaction must have a negative or zero value.
+        $\valueBalance{\OrchardLike}$ field of a \coinbaseTransaction must have a negative or zero value.
         The negative case can only occur for \transactions with \cite{ZIP-213} \shieldedOutputs.}
-  \nufiveonwarditem{The rule that \nSpendsSapling, \nOutputsSapling, and \nActionsOrchard{} \MUST all
+  \nufiveonwarditem{The rule that \nSpendsSapling, \nOutputsSapling,\notnusixthree{ and}
+        \nActionsField{Orchard}\nusixthree{, and \nActionsField{Ironwood}} \MUST all
         be less than $2^{16}$, is technically redundant because a \transaction that could violate this
         rule would not fit within the $2$ MB \block size limit. It is included in order to simplify
         the security argument for balance preservation.}
@@ -14132,15 +14141,17 @@ The $\ephemeralKey$, $\encCiphertext$, and $\outCiphertext$ fields together form
 
 \begin{consensusrules}
     \item $\LEOStoIPOf{256}{\cmxField}$ \MUST be less than $\ParamP{q}$.
-    \nusixtwoonwarditem{The $\proofsOrchard$ field \MUST have the canonical length of
-          $2720 + 2272 \cdot \nActionsOrchard$ bytes.}
+    \nusixtwoonwarditem{The $\proofsField{Orchard}$ field \MUST have the canonical length of
+          $2720 + 2272 \cdot \nActionsField{Orchard}$ bytes.}
+    \nusixthreeonwarditem{For version 6 \transactions, the $\proofsField{Ironwood}$ field \MUST
+          have the canonical length of $2720 + 2272 \cdot \nActionsField{Ironwood}$ bytes.}
 \end{consensusrules}
 
 Other consensus rules applying to an \actionDescription are given in \crossref{actiondesc}.
 
 \notbeforenusixtwo{\begin{nnotes}}
 \nusixtwo{
-    \item Before \NUSixTwo, the length of the $\proofsOrchard$ field was not enforced as a
+    \item Before \NUSixTwo, the length of the $\proofsField{Orchard}$ field was not enforced as a
           consensus rule. The canonical length is determined by the circuit, and is the same
           for the pre-\NUSixTwo and post-\NUSixTwo circuits. See \crossref{halo2encoding},
           where a \HaloTwo proof is encoded as the proof byte sequence itself.

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1535,6 +1535,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\xPaymentAddresses}{\termxes{payment address}}
 \newcommand{\shieldedPaymentAddress}{\term{shielded payment address}}
 \newcommand{\shieldedPaymentAddresses}{\termes{shielded payment address}}
+\newcommand{\expandedReceiver}{\term{expanded receiver}}
 \newcommand{\unifiedPaymentAddress}{\term{unified payment address}}
 \newcommand{\unifiedPaymentAddresses}{\termes{unified payment address}}
 \newcommand{\xUnifiedPaymentAddresses}{\termxes{unified payment address}}
@@ -2184,6 +2185,8 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\nfOldRepr}[1]{{\MakeRepr{\nf}{\mathsf{old}}}_{#1}}
 \newcommand{\enableSpends}{\mathsf{enableSpends}}
 \newcommand{\enableOutputs}{\mathsf{enableOutputs}}
+\newcommand{\enableCrossAddress}{\mathsf{enableCrossAddress}}
+\newcommand{\disableCrossAddress}{\mathsf{disableCrossAddress}}
 \newcommand{\Memo}{\mathsf{memo}}
 \newcommand{\MemoByteLength}{512}
 \newcommand{\MemoType}{\byteseq{\MemoByteLength}}
@@ -6149,8 +6152,10 @@ where
 \vspace{-1ex}
 An \actionTransfer, as specified in \crossref{actions}, is encoded in \transactions as an
 \defining{\actionDescription}.
-Each version 5 \transaction includes a sequence of zero or more \defining{\actionDescriptions}.
-(Version 4 \transactions cannot contain \actionDescriptions.)
+
+Each \versionsForOrchardPool \transaction has a sequence of \actionDescriptions for the \OrchardPool.
+\nusixthree{Version 6 \transactions additionally have a sequence of \actionDescriptions
+for the \IronwoodPool.} Version 4 \transactions cannot contain \actionDescriptions.
 
 \introlist
 Each \actionDescription is authorized by a signature, called the \defining{\spendAuthSignature}.
@@ -6176,6 +6181,9 @@ Let $\vk$ be the \HaloTwo \verifyingKey identified by the \Orchard circuit versi
 in the consensus rules below.
 
 \nusixthree{Let $\Pool$ be $\OrchardPoolId$ or $\IronwoodPoolId$.}
+
+\nusixthree{Define an \expandedReceiver as in \cite{ZIP-2006}, i.e. $(\DiversifiedTransmitBase, \DiversifiedTransmitPublic)$
+for a \shieldedPaymentAddress.}
 
 \vspace{0.5ex}
 \introsection
@@ -6217,16 +6225,22 @@ An \actionDescription comprises $(\cvNet{}\kern-0.2em, \rt{\OrchardLikePoolId}\k
   \item $\enableOutputs \typecolon \bit$ is a flag that is set in order to enable \nh{non-zero-valued}
         outputs in this Action;
         \vspace{-0.3ex}
-  \item $\Proof{} \typecolon \ActionProof$ is a \zkSNARKProof for the \actionStatement defined in
-        \shortcrossref{actionstatement}, with \primaryInput
-        $(\cv, \rt{\OrchardPoolId}\kern-0.1em, \nf\kern-0.1em, \AuthSignRandomizedPublic, \cmX, \enableSpends, \enableOutputs)$
+  \item $\enableCrossAddress \typecolon \bit$ is a flag that is set in order to enable the \expandedReceiver
+        of the output \note to be different from the \expandedReceiver of the input \note in this Action
+        \cite{ZIP-2006};
+        \vspace{-0.3ex}
+  \item $\Proof{}^{\OrchardLikePoolId} \typecolon \ActionProof$ is a \zkSNARKProof for the \actionStatement
+        defined in \shortcrossref{actionstatement}, with \primaryInput
+        $(\cv, \rt{\OrchardPoolId}\kern-0.1em, \nf\kern-0.1em, \AuthSignRandomizedPublic, \cmX, \enableSpends, \enableOutputs, \disableCrossAddress)$
+        where $\disableCrossAddress = 1 - \enableCrossAddress$.
 \end{itemize}
 
 \vspace{-1.5ex}
-\pnote{The $\rt{\OrchardLikePoolId}$, $\enableSpends$, and $\enableOutputs$ components are the
-same for all \actionTransfers in a \transaction, and are encoded once in the \transaction body
-(\crossref{txnencoding}), not the $\type{ActionDescription}$ structure.
-$\Proof{}$ is aggregated with other Action proofs and encoded in the $\proofsOrchard$ field.}
+\pnote{The $\rt{\OrchardLikePoolId}$, $\enableSpendsField{\OrchardLike}$, and $\enableOutputsField{\OrchardLike}$
+components are the same for all \actionTransfers in a \transaction, and are encoded once\nusixthree{ for each pool}
+in the \transaction body (\crossref{txnencoding}), not the $\type{ActionDescription}$ structure.
+$\Proof{}^{\OrchardLikePoolId}$ is aggregated with other \OrchardLikePoolId Action proofs and
+encoded in the $\proofsField{\OrchardLike}$ field.}
 
 \begin{consensusrules}
         \vspace{-0.25ex}
@@ -6235,21 +6249,24 @@ $\Proof{}$ is aggregated with other Action proofs and encoded in the $\proofsOrc
   \item Let $\SigHash$ be the \sighashTxHash of this \transaction, not associated with an input,
         as defined in \crossref{sighash} using $\SIGHASHALL$.
 
-        The \spendAuthSignature \MUST be a valid $\SpendAuthSig{Orchard}$ signature over $\SigHash$
+        The \spendAuthSignature \MUST be a valid $\SpendAuthSig{\OrchardLike}$ signature over $\SigHash$
         using $\AuthSignRandomizedPublic$ as the \validatingKey ---
-        i.e.\ $\SpendAuthSigValidate{Orchard}{\AuthSignRandomizedPublic}(\SigHash, \spendAuthSig) = 1$.
+        i.e.\ $\SpendAuthSigValidate{\OrchardLike}{\AuthSignRandomizedPublic}(\SigHash, \spendAuthSig) = 1$.
         As specified in \crossref{concretereddsa}, validation of the $\RedDSAReprR{}$ component
         of the signature prohibits \nonCanonicalPoint encodings.
         \vspace{-0.25ex}
   \nufiveprenusixtwoitem{$\vk$ \MUST be the \verifyingKey identified by
         \texttt{OrchardCircuitVersion::}\linebreak[2]\texttt{InsecurePreNU6\_2}.}
         \vspace{-0.25ex}
-  \nusixtwoonwarditem{$\vk$ \MUST be the \verifyingKey identified by
+  \nusixtwoonly{$\vk$ \MUST be the \verifyingKey identified by
         \texttt{OrchardCircuitVersion::FixedPostNU6\_2}.}
         \vspace{-0.25ex}
-  \item The proof $\Proof{}$ \MUST be valid for \verifyingKey $\vk$ given a \primaryInput
+  \nusixthreeonwarditem{$\vk$ \MUST be the \verifyingKey identified by
+        \texttt{OrchardCircuitVersion::PostNU6\_3}.}
+        \vspace{-0.25ex}
+  \item The proof $\Proof{}^{\OrchardLikePoolId}$ \MUST be valid for \verifyingKey $\vk$ given a \primaryInput
         $(\cv, \rt{\OrchardLikePoolId}, \nf, \AuthSignRandomizedPublic, \cmX, \enableSpends,$ $\enableOutputs)$ ---
-        i.e.\ ${\ActionVerify}_{\vk}\big(\kern-0.1em(\cv, \rt{\OrchardLikePoolId}, \nf, \AuthSignRandomizedPublic, \cmX, \enableSpends, \enableOutputs), \Proof{}\big) = 1$.
+        i.e.\ ${\ActionVerify}_{\vk}\big(\kern-0.1em(\cv, \rt{\OrchardLikePoolId}, \nf, \AuthSignRandomizedPublic, \cmX, \enableSpends, \enableOutputs), \Proof{}^{\OrchardLikePoolId}\big) = 1$.
         \vspace{-0.25ex}
   \item $\AuthSignRandomizedPublic$ \MUSTNOT be the identity point $\ZeroP$.
 \end{consensusrules}

--- a/protocol/protocol.tex
+++ b/protocol/protocol.tex
@@ -1053,7 +1053,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 
 % The Sapling-like pools are Sapling, Orchard, and Ironwood, which share a note plaintext format
 % (modulo changes of interpretation at Canopy and NU6.3).
-\newcommand{\SaplingLikePoolIds}{\sapling{\SaplingPoolId}\notbeforenufive{, \OrchardPoolId}\notbeforenusixthree{, \IronwoodPoolId}}
+\newcommand{\SaplingLikePoolIds}{\sapling{\SaplingPoolId}\nufive{, \OrchardPoolId}\nusixthree{, \IronwoodPoolId}}
 \newcommand{\SaplingLikePoolList}{\sapling{\SaplingPool{}}\nufive{,\notnusix{ and} \OrchardPool{}}\nusixthree{, \IronwoodPool{}}}
 
 \newcommand{\SaplingLikeChainValuePool}{\notnufive{\SaplingChainValuePool{}}%
@@ -2443,7 +2443,6 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\nJoinSplit}{\mathtt{nJoinSplit}}
 \newcommand{\vJoinSplit}{\mathtt{vJoinSplit}}
 \newcommand{\valueBalance}[1]{\mathtt{valueBalance#1}}
-\newcommand{\valueBalanceOrchardLike}{\valueBalance{Orchard\notbeforenusixthree{/Ironwood}}}
 \newcommand{\nShieldedSpend}{\mathtt{nShieldedSpend}}
 \newcommand{\vShieldedSpend}{\mathtt{vShieldedSpend}}
 \newcommand{\nShieldedOutput}{\mathtt{nShieldedOutput}}
@@ -2455,21 +2454,14 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\vSpendProofsSapling}{\mathtt{vSpendProofsSapling}}
 \newcommand{\vSpendAuthSigs}[1]{\mathtt{vSpendAuthSigs{#1}}}
 \newcommand{\vOutputProofsSapling}{\mathtt{vOutputProofsSapling}}
-\newcommand{\nActionsOrchard}{\mathtt{nActionsOrchard}}
-\newcommand{\vActionsOrchard}{\mathtt{vActionsOrchard}}
-\newcommand{\flagsOrchard}{\mathtt{flagsOrchard}}
-\newcommand{\flagsOrchardLike}{\mathtt{flagsOrchard\notbeforenusixthree{/Ironwood}}}
-\newcommand{\enableSpendsOrchard}{\mathtt{enableSpendsOrchard}}
-\newcommand{\enableSpendsOrchardLike}{\mathtt{enableSpendsOrchard\notbeforenusixthree{/Ironwood}}}
-\newcommand{\enableOutputsOrchard}{\mathtt{enableOutputsOrchard}}
-\newcommand{\enableOutputsOrchardLike}{\mathtt{enableOutputsOrchard\notbeforenusixthree{/Ironwood}}}
-\newcommand{\sizeProofsOrchard}{\mathtt{sizeProofsOrchard}}
-\newcommand{\proofsOrchard}{\mathtt{proofsOrchard}}
-\newcommand{\nActionsIronwood}{\mathtt{nActionsIronwood}}
-\newcommand{\vActionsIronwood}{\mathtt{vActionsIronwood}}
-\newcommand{\enableSpendsIronwood}{\mathtt{enableSpendsIronwood}}
-\newcommand{\enableOutputsIronwood}{\mathtt{enableOutputsIronwood}}
-\newcommand{\flagsIronwood}{\mathtt{flagsIronwood}}
+\newcommand{\OrchardLike}{Orchard\notbeforenusixthree{/Ironwood}}
+\newcommand{\nActionsField}[1]{\mathtt{nActions#1}}
+\newcommand{\vActionsField}[1]{\mathtt{vActions#1}}
+\newcommand{\flagsField}[1]{\mathtt{flags#1}}
+\newcommand{\enableSpendsField}[1]{\mathtt{enableSpends#1}}
+\newcommand{\enableOutputsField}[1]{\mathtt{enableOutputs#1}}
+\newcommand{\sizeProofsField}[1]{\mathtt{sizeProofs#1}}
+\newcommand{\proofsField}[1]{\mathtt{proofs#1}}
 \newcommand{\vpubOldField}{\mathtt{vpub\_old}}
 \newcommand{\vpubNewField}{\mathtt{vpub\_new}}
 \newcommand{\anchorField}[1]{\mathtt{anchor#1}}
@@ -2576,7 +2568,7 @@ electronic commerce and payment, financial privacy, proof of work, zero knowledg
 \newcommand{\ProofJoinSplit}{\pi_\JoinSplit}
 \newcommand{\ProofSpend}{\pi_\Spend}
 \newcommand{\ProofOutput}{\pi_\Output}
-\newcommand{\ProofAction}{\pi_\Action}
+\newcommand{\ProofAction}[1]{\pi_\Action^{#1}}
 \newcommand{\zkproof}{\mathtt{zkproof}}
 \newcommand{\POUR}{\texttt{POUR}}
 \newcommand{\Prob}[2]{\mathrm{Pr}\scalebox{0.88}{\ensuremath{
@@ -7230,7 +7222,7 @@ In the rest of this section, let $\Pool$ be $\OrchardPoolId$ or $\IronwoodPoolId
 } %nusixthree
 
 $\vBalanceOrchardLikePoolId$ is encoded in a \transaction as the field
-\valueBalanceOrchardLike. If a \transaction has no \actionDescriptions\nusixthree{ for
+\valueBalance{\OrchardLike}. If a \transaction has no \actionDescriptions\nusixthree{ for
 $\Pool$}, $\vBalanceOrchardLikePoolId$ is implicitly zero. Transaction fields are described
 in \shortcrossref{txnencoding}.
 
@@ -7517,7 +7509,7 @@ $\NoteUniqueRandRepr = \reprJ(\NoteUniqueRand)$.
 \vspace{1ex}
 \nufive{
 \introlist
-The derivation of \nullifiers for \OrchardPoolAdj \notes is a little more complicated.
+The derivation of \nullifiers for \OrchardLikePoolAdj \notes is a little more complicated.
 
 Let $\GroupP$ and $\ParamP{q}$ be as defined in \crossref{pallasandvesta}.
 
@@ -12413,8 +12405,8 @@ verifier \MUST check, for the encoding of each element, that:
 \lsubsubsubsection{\HaloTwoText}{halo2}
 
 \vspace{-1ex}
-For \Orchard \actionDescriptions in version 5 \transactions, \Zcash uses \zkSNARKs with the
-\defining{\HaloTwo} \provingSystem described in \cite{Zcash-halo2}.
+For \OrchardLikePoolAdj \actionDescriptions in \versionsForOrchardPool \transactions, \Zcash uses
+\zkSNARKs with the \defining{\HaloTwo} \provingSystem described in \cite{Zcash-halo2}.
 
 \introlist
 \lsubsubsubsubsection{Encoding of \HaloTwoText{} Proofs}{halo2encoding}
@@ -13882,12 +13874,13 @@ Let $\reprJ$ and $\ParamJ{q}$ be as defined in \crossref{jubjub}.
 Let $\spendAuthSig$ be the \spendAuthSignature for this \spendTransfer, and let $\ProofSpend$ be the
 \zkSNARKProof of the corresponding \spendStatement. In a version 4 \transaction these are encoded in
 the $\spendAuthSigField$ field and $\zkproof$ field respectively of the \spendDescription.\nufive{ In
-a version 5 \transaction, \spendAuthSignatures in $\vSpendAuthSigs{Sapling}$ and proofs in
-$\vSpendProofsSapling$ are in one-to-one correspondence with \spendDescriptions in $\vSpendsSapling$.}
+a \versionsAfterFourForSaplingPool \transaction, \spendAuthSignatures in $\vSpendAuthSigs{Sapling}$
+and proofs in $\vSpendProofsSapling$ are in one-to-one correspondence with \spendDescriptions in
+$\vSpendsSapling$.}
 
 \introsection
 An abstract \spendDescription, as described in \crossref{spendsandoutputs}, is encoded in
-a \transaction as an instance of a \type{SpendDescriptionV4}\nufive{ or \type{SpendDescriptionV5}} type:
+a \transaction as an instance of a \type{SpendDescriptionV4}\nufive{ or \type{SpendDescriptionV5Onward}} type:
 
 \vspace{-2.5ex}
 \begin{center}
@@ -13920,10 +13913,11 @@ A signature authorizing this Spend. \\ \hline
 
 \vspace{-1.5ex}
 \nufive{$\dagger$ The $\anchorField{}$, $\zkproof$, and $\spendAuthSigField$ fields are only present in a
-\spendDescription if the \transactionVersion is $4$. For v5 \transactions, all \spendDescriptions share
-the same \anchor, which is encoded once as the $\anchorField{Sapling}$ field of the \transaction as
-described in \crossref{txnencoding}. The $\zkproof$ and $\spendAuthSigField$ fields have been moved into
-$\vSpendProofsSapling$ and $\vSpendAuthSigs{Sapling}$ respectively for v5.}
+\spendDescription if the \transactionVersion is $4$. For \versionsAfterFourForSaplingPool \transactions,
+all \spendDescriptions share the same \anchor, which is encoded once as the $\anchorField{Sapling}$ field
+of the \transaction as described in \crossref{txnencoding}. The $\zkproof$ and $\spendAuthSigField$ fields
+have been moved into $\vSpendProofsSapling$ and $\vSpendAuthSigs{Sapling}$ respectively
+for\notnusixthree{ v5}\nusixthree{ these versions}.}
 
 \vspace{-2ex}
 \consensusrule{$\LEOStoIPOf{256}{\anchorField{Sapling}}$\nufive{, if present,} \MUST be less than $\ParamJ{q}$.}
@@ -13941,13 +13935,14 @@ Let $\LEBStoOSP{}{}$ be as defined in \crossref{endian}.
 \vspace{-0.5ex}
 Let $\reprJ$ and $\ParamJ{q}$ be as in \crossref{jubjub}, and $\ExtractJ$ as in \crossref{concreteextractorjubjub}.
 
-Let $\ProofOutput$ be the \zkSNARKProof of the \outputStatement for this \outputStatement. In a version 4
-\transaction this is encoded in the $\zkproof$ field of the \spendDescription.\nufive{ In a v5 \transaction,
-proofs in $\vOutputProofsSapling$ are in one-to-one correspondence with \outputDescriptions in $\vOutputsSapling$.}
+Let $\ProofOutput$ be the \zkSNARKProof of the \outputStatement for this \outputStatement. In a
+version 4 \transaction this is encoded in the $\zkproof$ field of the \spendDescription.\nufive{ In
+a \versionsAfterFourForSaplingPool \transaction, proofs in $\vOutputProofsSapling$ are in one-to-one
+correspondence with \outputDescriptions in $\vOutputsSapling$.}
 
 \vspace{-0.5ex}
 An abstract \outputDescription, described in \crossref{spendsandoutputs}, is encoded in
-a \transaction as an instance of an \type{OutputDescriptionV4}\nufive{ or \type{OutputDescriptionV5}} type:
+a \transaction as an instance of an \type{OutputDescriptionV4}\nufive{ or \type{OutputDescriptionV5Onward}} type:
 
 \vspace{-2.5ex}
 \begin{center}
@@ -13982,7 +13977,7 @@ $\ProofOutput$ (see \crossref{groth}). \\ \hline
 \vspace{-1.5ex}
 \nufive{$\dagger$ The $\zkproof$ field is only present in a \spendDescription if the
 \transactionVersion is $4$. This field has been moved into the $\vOutputProofsSapling$
-field of version 5 \transactions.}
+field of \versionsAfterFourForSaplingPool \transactions.}
 
 \introlist
 The $\ephemeralKey$, $\encCiphertext$, and $\outCiphertext$ fields together form the
@@ -14005,10 +14000,12 @@ Let $\LEBStoOSP{}{}$ be as defined in \crossref{endian}.
 Let $\reprP$ and $\ParamP{q}$ be as defined in \crossref{pallasandvesta}.
 
 \vspace{-0.5ex}
-Let $\spendAuthSig$ be the \spendAuthSignature for this \actionTransfer from $\vSpendAuthSigs{Orchard}$,
-and let $\ProofAction$ be the \zkSNARKProof of the corresponding \actionStatement. \xSpendAuthSignatures
-in the $\vSpendAuthSigs{Orchard}$ field of a version 5 \transaction and aggregated proofs in the
-$\proofsOrchard$ field are in one-to-one correspondence with \actionDescriptions in $\vActionsOrchard$.
+Let $\spendAuthSig$ be the \spendAuthSignature for this \actionTransfer from
+$\vSpendAuthSigs{\OrchardLike}$, and let $\ProofAction{\OrchardLikePoolId}$
+be the \zkSNARKProof of the corresponding \actionStatement. \xSpendAuthSignatures in the
+$\vSpendAuthSigs{\OrchardLike}$ field of a version 5 \transaction and aggregated proofs in the
+$\proofsField{\OrchardLike}$ field are in one-to-one correspondence with \actionDescriptions in
+$\vActionsField{\OrchardLike}$.
 
 \vspace{0.5ex}
 An abstract \actionDescription, as described in \crossref{actions}, is encoded in
@@ -15856,7 +15853,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
               \item Remove the note in \crossref{abstractzk} saying that these subscripts
                     are dropped.
               \nusixtwoonwarditem{Add a consensus rule in \crossref{actionencodingandconsensus}
-                    that the $\proofsOrchard$ field \MUST be of the canonical length.}
+                    that the $\proofsField{Orchard}$ field \MUST be of the canonical length.}
           \end{itemize}
           \vspace{-1.5ex}
 } %nufive
@@ -16193,7 +16190,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
     \item In \crossref{networks}, update the settled activation \blockHashes to be
           those for \NUFive on \Mainnet and \Testnet.
     \item Correct the history entry for \historyref{2022.3.2} to include the
-          entry about the calculation for \sizeProofsOrchard.
+          entry about the calculation for \sizeProofsField{Orchard}.
 } %nufive
     \item Rename $\mathsf{ExcludedPointEncodings}$ to $\PreCanopyExcludedPointEncodings$.
     \item In \crossref{sproutspendingkeyencoding}, remove the statement that
@@ -16213,7 +16210,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
           not explicitly encode the \nConsensusBranchId{} field).
     \item Correction in \crossref{constants}:
           $\Uncommitted{Orchard} \typecolon \MerkleHashOrchard$ is not a \bitSequence.
-    \item In \crossref{txnencoding}, add the calculation for \sizeProofsOrchard{}
+    \item In \crossref{txnencoding}, add the calculation for \sizeProofsField{Orchard}
           to the v5 \transaction format table.
 }
     \item Make \crossref{overview} more precise about \chainValuePools.
@@ -16458,8 +16455,8 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \begin{itemize}
 \nufive{
     \item Add a consensus rule for version 5 or later \transactions, that if
-          $\nActionsOrchard > 0$ then at least one of $\enableSpendsOrchard$ and
-          $\enableOutputsOrchard$ \MUST be $1$.
+          $\nActionsField{Orchard} > 0$ then at least one of $\enableSpendsField{Orchard}$ and
+          $\enableOutputsField{Orchard}$ \MUST be $1$.
     \item Delete the consensus rule in \crossref{transactions} that required checking
           that each intermediate \merkleRoot of the \noteCommitmentTree is not $\bot$.
           Checking this rule would have imposed a significant performance penalty,
@@ -16549,7 +16546,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \nufive{
     \item Change the consensus rule that requires at least one input to, and at
           least one output from a v5 or later \transaction, to take into account
-          the \enableSpendsOrchard{} and \enableOutputsOrchard{} flags.
+          the \enableSpendsField{Orchard} and \enableOutputsField{Orchard} flags.
     \item Correct the type of $\ExtractPbot$ imported in \crossref{concretesinsemillahash}\,
           (from $\GroupP \rightarrow \GroupP_{\!x}$ to \mbox{$\maybe{\GroupP} \rightarrow \maybe{\GroupP_{\!x}}$}).
     \item Add \cite{ZIP-209} to the list of ZIPs updated for \NUFive.
@@ -16564,7 +16561,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \begin{itemize}
 \nufive{
     \item Add an explicit consensus rule in \crossref{txnconsensus} that the
-          reserved bits of the \flagsOrchard{} field \MUST be zero.
+          reserved bits of the \flagsField{Orchard} field \MUST be zero.
     \item Correct a cut-and-paste error in the algorithm for \crossref{orcharddummynotes},
           which should refer to the \actionStatement rather than the \spendStatement.
 } %nufive
@@ -16619,7 +16616,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
 \historyentry{2021.2.1}{2021-05-20}
 \begin{itemize}
 \nufive{
-    \item Correct the size of \vActionsOrchard{} in \crossref{txnencoding}.
+    \item Correct the size of \vActionsField{Orchard} in \crossref{txnencoding}.
     \item Change the type of \Orchard Merkle \merkleHashes to $\MerkleHashOrchard$, with
           a corresponding change to the signature of $\MerkleCRH{Orchard}$. Add a note to
           \crossref{merklepath} clarifying that \nonCanonicalFieldElement encodings are
@@ -16791,7 +16788,7 @@ Peter Newell's illustration of the Jubjub bird, from \cite{Carroll1902}.
                   output of $\maptocurvesimpleswuIsoG$.
             \item Document the limitation on the domain separation string for the \groupHash
                   into \Pallas and \Vesta.
-            \item Correct the sizes of \type{SpendDescriptionV5} and \type{OutputDescriptionV5}
+            \item Correct the sizes of \type{SpendDescriptionV5Onward} and \type{OutputDescriptionV5Onward}
                   in the version 5 \transaction format.
             \item Make the description of when fields are included in v5 \transactions consistent
                   between the protocol specification and \cite{ZIP-225}.

--- a/zips/zip-0213.rst
+++ b/zips/zip-0213.rst
@@ -115,7 +115,7 @@ of other rules as of NU5 activation.
 Once the NU6.3 network upgrade activates:
 
 - Coinbase transactions MAY contain Sapling-pool and/or Ironwood-pool outputs.
-- Coinbase transactions MUST NOT contain any Orchard-pool component.
+- As specified in [#zip-0229]_, coinbase transactions MUST NOT contain any Orchard-pool component.
 
 
 Interaction with the Founders' Reward

--- a/zips/zip-0229.md
+++ b/zips/zip-0229.md
@@ -237,28 +237,103 @@ and `flagsIronwood`, so the previous `...Orchard` suffix would be misleading.
 
 ## Consensus Rules
 
-* `nVersionGroupId` and `nConsensusBranchId` MUST be as specified and constrained in
-  § 7.1.2 [^protocol-txnconsensus]. The NU6.3 consensus branch ID value is given in [^zip-0258].
+The version 6 transaction format requires the changes below to the transaction consensus rules in
+§ 7.1.2 'Transaction Consensus Rules' [^protocol-txnconsensus], effective from NU6.3 activation.
+Purely editorial generalizations — such as replacing *Orchard pool* with *Orchard or Ironwood pool*,
+or updating cross-references — are not enumerated.
 
-* The proofs in `proofsOrchard` and the signatures in `vSpendAuthSigsOrchard` each
-  correspond 1:1 to the elements of `vActionsOrchard`, in the same order; likewise the
-  proofs in `proofsIronwood` and the signatures in `vSpendAuthSigsIronwood` to the
-  elements of `vActionsIronwood`. (Conditional presence of fields is given in the format
-  table above.)
+* Replace
 
-* In each of `flagsOrchard` and `flagsIronwood`:
-    * Bits 3..7 inclusive MUST be 0.
-    * The semantics of the `enableSpends` and `enableOutputs` bits are as specified in
-      § 7.1.2 [^protocol-txnconsensus].
-    * The `enableCrossAddress` bit is specified in [^zip-2006].
-      Before NU6.3 this bit of `flagsOrchard` was reserved as 0 in v5 transactions.
+  > [Pre-NU6.3] The transaction version number MUST be 4 or 5.
 
-* For coinbase transactions,
-    * The `enableSpends` bit of `flagsIronwood` MUST be 0.
+  with
 
-* The `anchorOrchard` field refers to the Orchard note commitment tree, and the
-  `anchorIronwood` field to the Ironwood note commitment tree. The *Orchard* and
-  *Ironwood pools* have separate, independent note commitment trees and nullifier sets.
+  > [NU6.3 onward] The transaction version number MUST be 4 or 5 or 6.
+
+* Add
+
+  > [NU6.3 onward] If the transaction version number is 6 then the version group ID MUST be
+  > `0xD884B698`.
+
+* Add
+
+  > [NU6.3 onward] If `effectiveVersion` $\geq 6$, then `nActionsIronwood` MUST be less than
+  > $2^{16}$.
+
+* Replace
+
+  > [NU5 onward] If `effectiveVersion` $\geq 5$ then this condition MUST hold: `tx_in_count` $> 0$
+  > or `nSpendsSapling` $> 0$ or (`nActionsOrchard` $> 0$ and `enableSpendsOrchard` $= 1$).
+
+  with
+
+  > [NU5, pre-NU6.3] If `effectiveVersion` $= 5$ then this condition MUST hold: `tx_in_count` $> 0$
+  > or `nSpendsSapling` $> 0$ or (`nActionsOrchard` $> 0$ and `enableSpendsOrchard` $= 1$).
+  >
+  > [NU6.3 onward] If `effectiveVersion` $\geq 6$ then this condition MUST hold: `tx_in_count` $> 0$
+  > or `nSpendsSapling` $> 0$ or (`nActionsOrchard` $> 0$ and `enableSpendsOrchard` $= 1$) or
+  > (`nActionsIronwood` $> 0$ and `enableSpendsIronwood` $= 1$).
+
+  and likewise for the corresponding output-side condition, with `tx_out_count`, `nOutputsSapling`,
+  `enableOutputsOrchard`, and `enableOutputsIronwood` in place of `tx_in_count`, `nSpendsSapling`,
+  `enableSpendsOrchard`, and `enableSpendsIronwood` respectively.
+
+* Add
+
+  > [NU6.3 onward] If `effectiveVersion` $\geq 6$ and `nActionsIronwood` $> 0$, then at least one of
+  > `enableSpendsIronwood` and `enableOutputsIronwood` MUST be 1.
+
+* Add, parallel to the Orchard-pool binding-signature rule,
+
+  > [NU6.3 onward] If `effectiveVersion` $\geq 6$ and `nActionsIronwood` $> 0$, then
+  > `bindingSigIronwood` MUST represent a valid signature, under the *Ironwood pool*'s transaction
+  > binding validating key, of the SIGHASH transaction hash — with the binding validating key and
+  > SIGHASH as defined for the *Ironwood pool* in § 4.14 'Balance and Binding Signature (Orchard)'.
+  > As for the *Orchard pool*, validation of the `R` component of the signature prohibits
+  > non-canonical point encodings.
+
+* Add
+
+  > [NU6.3 onward] A coinbase transaction MUST NOT have any *Orchard-pool* Action Descriptions.
+
+* Replace
+
+  > [NU5 onward] In a version 5 coinbase transaction, the `enableSpendsOrchard` flag MUST be 0.
+
+  with
+
+  > [NU5 onward] In a version 5 or version 6 coinbase transaction, the `enableSpendsOrchard` flag
+  > MUST be 0.
+
+* Add
+
+  > [NU6.3 onward] In a version 6 coinbase transaction, the `enableSpendsIronwood` flag MUST be 0.
+
+* Replace
+
+  > [NU5 onward] In a version 5 transaction, the reserved bits 2..7 of the `flagsOrchard` field
+  > MUST be zero.
+
+  with
+
+  > [NU5 onward] In a version 5 or version 6 transaction, the reserved bits 2..7 of the
+  > `flagsOrchard` field MUST be zero.
+
+* Add
+
+  > [NU6.3 onward] In a version 6 transaction, the reserved bits 3..7 of the `flagsIronwood` field
+  > MUST be zero.
+
+The `enableCrossAddress` bit is specified in [^zip-2006]. Note that the reserved-bit rules above
+leave bit 2 of `flagsOrchard` reserved as 0 (bits 2..7), while bit 2 of `flagsIronwood` is the
+`enableCrossAddress` bit (reserved bits 3..7); the *Orchard pool*'s cross-address restriction is
+enforced for its Actions from NU6.3 onward as specified in [^zip-2006].
+
+This ZIP additionally specifies, for the version 6 format, that the proofs in `proofsOrchard` and the
+signatures in `vSpendAuthSigsOrchard` each correspond 1:1 to the elements of `vActionsOrchard`, in
+the same order; and likewise the proofs in `proofsIronwood` and the signatures in
+`vSpendAuthSigsIronwood` to the elements of `vActionsIronwood`. (Conditional presence of fields is
+given in the format table above.)
 
 Version 4, version 5, and version 6 transactions are all valid from NU6.3 activation onward;
 this ZIP defines only the version 6 format (the version 4 and version 5 formats are


### PR DESCRIPTION
Follow-up to #1319, adding the NU6.3 / Ironwood transaction-format and consensus-rule changes to the protocol specification and the corresponding ZIPs. The commits are factored so each is a self-contained, reviewable change. This is an **incremental** improvement, merged ahead of NU6.3 activation; it does **not** complete the NU6.3 protocol-spec changes — see **Caveats** below.

## Protocol specification (`protocol.tex`)

- **Parameterize the Orchard/Ironwood transaction-field macros** — replace the flat per-pool field macros (`\nActionsOrchard`, `\flagsOrchard`, `\enableSpendsOrchard`, `\sizeProofsOrchard`, `\proofsOrchard`, `\vActionsOrchard`, and the Ironwood equivalents) with pool-parameterized `\nActionsField{…}`, `\flagsField{…}`, etc.; add `\OrchardLike`; give `\ProofAction` a pool argument; and rename `SpendDescriptionV5`/`OutputDescriptionV5` to `…V5Onward`. Mechanical only — no change to the rendered consensus rules.
- **NU6.3 transaction-version, sighash, and pool prose** — the version-for-pool macros and the prose using them (Orchard-pool Action transfers require a version 5 or 6 transaction, Ironwood-pool ones a version 6); the per-transaction-version sighash-algorithm rules and the ZIP 229 citations for the version 6 sighash and transaction ID; and the note that zcashd will not support NU6.3.
- **Action Description — `enableCrossAddress` flag and NU6.3 verifying key** — the `enableCrossAddress` flag in the Action Description, the `disableCrossAddress = 1 − enableCrossAddress` primary input, the `OrchardCircuitVersion::PostNU6_3` verifying key, and the pool-superscripted Action proof. (The cross-address restriction itself is specified in ZIP 2006.)
- **Version 6 transaction format with the Ironwood bundle** — the Ironwood bundle in the v6 format table (`nActionsIronwood` … `bindingSigIronwood`) with its field-presence footnote, the version 6 header and transaction ID (defined in ZIP 229), and the added-fields list.
- **§ 7.1.2 consensus rules for version 6 and the Ironwood pool** — version group ID `0xD884B698`; `nActionsIronwood < 2^16`; the split of the at-least-one-input / at-least-one-output conditions into a version-5 form and a version-6-onward form that accounts for the Ironwood flags; the Ironwood enable-flag and binding-signature rules; the coinbase rules (no Orchard-pool Actions, `enableSpendsIronwood = 0`) and the reserved-bit rules; and the `proofsIronwood` canonical-length rule.

## ZIPs

- **ZIP 229, ZIP 213** — rewrite ZIP 229's Consensus Rules section as full-detail before/after changes to protocol § 7.1.2, and cross-reference from ZIP 213 that a coinbase transaction must not contain any Orchard-pool component.

## Caveats — not yet done

We ran out of time to land all of the NU6.3 protocol-spec changes before activation. Several of the specification changes mandated by ZIP 2005 (*Ironwood Quantum Recoverability*) are **not** included here (nor already in the base spec). Of ZIP 2005's spec changes, only the Ironwood note-commitment *format* edits are in the base spec (the lead byte `0x03` in § 3.2.1, and the `Derive_rcm^Orchard` / `g⋆_d` / `pk⋆_d` note-creation structure in § 4.7.3 and § 4.8.3). Still outstanding:

- **Quantum-recovery / `use_qsk` key derivation (§ 4.2.3).** The `qsk` / `qk` / `use_qsk` machinery, the `H^ask` / `H^nk` / `H^rivk` / `H^qsk` / `H^qk` / `H^{rivk_ext}` definitions, the `ℓ_qsk` / `ℓ_qk` constants (§ 5.3), and the `0x0C` / `0x0D` domain separators (§ 4.1.2) are entirely absent.
- **Decryption side (§ 4.20).** ⚠️ Note *creation* (§ 4.7.3) is updated for lead byte `0x03` but *decryption* (§ 4.20) is not, so as the spec currently stands an Ironwood note can be created but not decrypted — a create/decrypt asymmetry.
- **Sapling note-encryption refactor** into `Derive_rcm^Sapling` / `H^esk,Sapling` (§ 4.7.2, § 4.8.2).
- **§ 4.1.2 usage list** is not updated for the `0x0B` domain separator now used by § 4.7.3.
- **Cross-ZIP edits**: the ZIP 32 Orchard-internal-key-diagram note, and the ZIP 212 abstract note referencing ZIP 2005.

Open question in the text merged here: § 7.1.2 carries a `\todo{Is bit 2 reserved after NU6.3?}` on the `flagsOrchard` reserved-bit rule — i.e. whether `flagsOrchard` bit 2 stays reserved-zero or becomes `enableCrossAddress`.

The ZIP 2005 security-analysis refinements are a separate concern and were merged in #1338.
