### PR TITLE
ZIP 2005 refinements

### DIFF
--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1580,17 +1580,22 @@ an internally-derived witness decodes as external. Both readings give
 the same $\mathsf{rivk}$, and the accounting partitions pairs by the
 decode.
 
-*Per-pair bound and union bound.*
-Fix distinct combined inputs $x \neq x'$. Conditioning on all
-$\mathsf{H^{ask}}$/$\mathsf{H^{nk}}$ responses fixes the shifts
-$s(x), s(x')$, while $\mathsf{H}^*(x), \mathsf{H}^*(x')$ remain
-independent uniform on $\mathbb{F}_{r_{\mathbb{P}}}$. For each sign
-there is exactly one value of $\mathsf{H}^*(x)$ that collides, so
-$$\Pr\big[\mathsf{H}^s(x) \equiv \pm \mathsf{H}^s(x') \pmod{r_{\mathbb{P}}}\big] \leq \frac{2}{r_{\mathbb{P}}}$$
-under every such conditioning, hence unconditionally. Union-bounding
-over the at most ${q_{\mathsf{kb}} \choose 2}$ unordered pairs of
-distinct queries,
-$$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq {q_{\mathsf{kb}} \choose 2} \cdot \frac{2}{r_{\mathbb{P}}} = \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}\textsf{.}$$
+*Sequential collision bound.*
+The adversary chooses each query adaptively, so we reveal the oracle
+responses in query order rather than fixing a pair in advance. Before
+the $j$-th query $x_j$ to $\mathsf{H}^*$, condition on the transcript
+so far: the $\mathsf{H^{ask}}$/$\mathsf{H^{nk}}$ responses (which fix
+the shifts $s(\cdot)$) and the $j-1$ recorded $\mathsf{H}^*$
+responses. Under every such conditioning the fresh response
+$\mathsf{H}^*(x_j)$ is uniform on $\mathbb{F}_{r_{\mathbb{P}}}$, and
+for each recorded input $x_i$ and each sign there is exactly one value
+of $\mathsf{H}^*(x_j)$ with
+$\mathsf{H}^s(x_j) \equiv \pm \mathsf{H}^s(x_i) \pmod{r_{\mathbb{P}}}$;
+so the fresh response completes a shifted ±-collision with probability
+at most $2(j-1)/r_{\mathbb{P}}$. Because the conditioning is on the
+transcript itself, this holds however $x_j$ was chosen from the
+transcript. Summing over the queries,
+$$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \sum_{j=1}^{q_{\mathsf{kb}}} \frac{2(j-1)}{r_{\mathbb{P}}} = \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}\textsf{.}$$
 
 
 ## Security argument for Spendability

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1437,7 +1437,7 @@ key-binding break.
 **Theorem (key-binding, classical ROM).** <a id="thm-key-binding-rom"></a>
 Let $\mathcal{A}$ be a classical adversary making at most $q_{\mathsf{kb}}$
 total queries to the random oracles used in the key-binding condition. Then
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
 
 **Proof sketch.**
 
@@ -1495,68 +1495,83 @@ $G_i = h(\mathsf{ak}_i, \mathsf{nk}_i) + O_i(x_i) \pmod{r_{\mathbb{P}}}$,
 with the deterministic shift $h$ independent of $O_i$'s responses
 (by non-querying).
 
-*Independence claim per pair.*
-For distinct witnesses $w_1, w_2$ both satisfying the key-binding
-condition, $G_1$ and $G_2$ are independent uniform on
-$\mathbb{F}_{r_{\mathbb{P}}}$, except for a residual event of
-probability at most $1/r_{\mathbb{P}}$ per pair (accounting for
-upstream-RO collisions in the both-internal sub-case). By case on
-$(O_1, O_2)$:
-
-**$O_1 \neq O_2$.** The two random oracles are domain-separated
-(independent BLAKE2b instantiations), so $O_1$'s outputs are
-independent of $O_2$'s outputs. Each $G_i$ is uniform on
-$\mathbb{F}_{r_{\mathbb{P}}}$ marginally; the pair is independent.
-
-**$O_1 = O_2 \in \{\mathsf{H^{rivk\_ext}}, \mathsf{H^{rivk\_legacy}}\}$.**
-Both witnesses are in the same branch and external IVK. If
-$x_1 = x_2$, the predicate's functional determinations
-($\mathsf{rivk\_ext}_i$ from $x_i$; $\mathsf{rivk}_i = \mathsf{rivk\_ext}_i$;
-$\mathsf{ivk}_i = \mathsf{Commit^{ivk}}(\mathsf{ak}_i, \mathsf{nk}_i, \mathsf{rivk}_i)$;
-in the sk-branch additionally $\mathsf{ak}_i, \mathsf{nk}_i$ from
-$\mathsf{sk}_i$ via $\mathsf{H^{ask}}, \mathsf{H^{nk}}$) force the
-witnesses to coincide on all fields constrained by the key-binding
-condition, contradicting distinctness. Hence WLOG $x_1 \neq x_2$, so
-the two RO outputs at $x_1, x_2$ are independent uniform.
-
-**$O_1 = O_2 = \mathsf{H^{rivk\_int}}$.** Both witnesses are
-internal IVK. If $x_1 = x_2$ as $\mathsf{H^{rivk\_int}}$ inputs, then
-$\mathsf{rivk}_1 = \mathsf{rivk}_2$ and $\mathsf{ivk}_1 = \mathsf{ivk}_2$.
-Sub-cases on the upstream branches:
-
-* same upstream branch (qk×qk or sk×sk):
-  $\mathsf{rivk\_ext}_1 = \mathsf{rivk\_ext}_2$ either forces upstream
-  input coincidence (and hence witness coincidence on all constrained
-  fields, contradicting distinctness) or requires an upstream-RO
-  collision — probability at most $1/r_{\mathbb{P}}$ per pair of
-  upstream queries.
-* cross upstream branch (qk×sk):
-  $\mathsf{rivk\_ext}_1 = \mathsf{rivk\_ext}_2$ requires a cross-RO
-  collision between $\mathsf{H^{rivk\_ext}}$ and
-  $\mathsf{H^{rivk\_legacy}}$, which by domain separation is
-  probability at most $1/r_{\mathbb{P}}$ per pair of upstream queries.
-
-In every sub-case the residual $x_1 = x_2$ event has probability at
-most $1/r_{\mathbb{P}}$ per pair. Conditional on $x_1 \neq x_2$,
-$\mathsf{H^{rivk\_int}}$'s outputs at $x_1, x_2$ are independent
-uniform.
-
-*Bounding the break probability.*
-For any pair of distinct witnesses, the break condition
-$G_1 \equiv \pm G_2 \pmod{r_{\mathbb{P}}}$ holds with probability
-at most $2/r_{\mathbb{P}}$ when $G_1, G_2$ are independent uniform
-(one per sign), plus at most $1/r_{\mathbb{P}}$ residual for
-upstream collisions in the both-internal sub-case — total at most
-$3/r_{\mathbb{P}}$ per pair.
-
-Treating the five rivk-derivation random oracles
+*The shifted combined oracle.*
+Treat the three rivk-derivation oracles
 ($\mathsf{H^{rivk\_ext}}$, $\mathsf{H^{rivk\_legacy}}$,
-$\mathsf{H^{rivk\_int}}$, $\mathsf{H^{ask}}$, $\mathsf{H^{nk}}$) as a
-single combined uniform random oracle on the joint query domain (each
-RO contributes its outputs independently of the others), and
-union-bounding over the at most ${q_{\mathsf{kb}} \choose 2}$ pairs
-of distinct witnesses,
-$$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3 q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2 r_{\mathbb{P}}}\textsf{.}$$
+$\mathsf{H^{rivk\_int}}$) as a single combined oracle $\mathsf{H}^*$
+on the disjoint union of their input domains. Each instance
+contributes outputs uniform on $\mathbb{F}_{r_{\mathbb{P}}}$,
+independently of the others, by domain separation.
+$\mathsf{H^{ask}}$ and $\mathsf{H^{nk}}$ are *not* part of
+$\mathsf{H}^*$: they enter only through the shifts below, and their
+output types differ.
+
+For a combined input $x$, define the shift
+$s(x) := h(\mathsf{ak}, \mathsf{nk})$, with $(\mathsf{ak}, \mathsf{nk})$
+read off the input: directly for $\mathsf{H^{rivk\_ext}}$ and
+$\mathsf{H^{rivk\_int}}$ inputs, and via
+$\mathsf{ak} = \mathsf{Extract}_{\mathbb{P}}\big([\mathsf{H^{ask}}(\mathsf{sk})]\, \mathcal{G}^{\mathsf{Orchard}}\big)$,
+$\mathsf{nk} = \mathsf{H^{nk}}(\mathsf{sk})$ for an
+$\mathsf{H^{rivk\_legacy}}$ input $\mathsf{sk}$. So $s$ is a function
+of the input and of the $\mathsf{H^{ask}}$/$\mathsf{H^{nk}}$ oracles
+only; since $h$ is non-querying, $s$ never depends on the
+rivk-derivation responses. Define the *shifted* combined oracle
+$$\mathsf{H}^s(x) := s(x) + \mathsf{H}^*(x) \pmod{r_{\mathbb{P}}}\textsf{.}$$
+For every witness satisfying the key-binding condition the derivation
+constraints give $G_i = \mathsf{H}^s(x_i)$, so the break condition is
+a ±-collision of $\mathsf{H}^s$ at the pair $(x_1, x_2)$.
+
+*Distinct final inputs.*
+The final inputs $x_1, x_2$ of a break need not be distinct, but the
+case $x_1 = x_2$ is fully deterministic. If either witness is
+externally decoded, equal final inputs force the witnesses to coincide
+on all fields constrained by the key-binding condition, contradicting
+distinctness. (Equal $\mathsf{H^{rivk\_ext}}$ inputs determine
+$(\mathsf{qk}, \mathsf{ak}, \mathsf{nk})$ and thence
+$\mathsf{rivk\_ext} = \mathsf{rivk}$; equal
+$\mathsf{H^{rivk\_legacy}}$ inputs determine $\mathsf{sk}$ and thence
+everything, via $\mathsf{H^{ask}}$ and $\mathsf{H^{nk}}$.)
+So both witnesses are internally decoded, sharing
+$(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk\_ext}, \mathsf{rivk})$ and
+differing only in their branch data. Then
+$\mathsf{rivk\_ext}_1 = \mathsf{rivk\_ext}_2$ is an equality of
+$\mathsf{H}^*$ outputs at the two *upstream*
+(rivk_ext-derivation) inputs, which the differing branch data make
+distinct. The shifts at those inputs agree: both equal
+$h(\mathsf{ak}, \mathsf{nk})$, using the derivation constraints on the
+$\mathsf{sk}$ side. So this is again a ±-collision of $\mathsf{H}^s$,
+at distinct inputs. In every case:
+**a key-binding break yields a ±-collision of $\mathsf{H}^s$ at two
+distinct inputs among the adversary's queries**, under the convention
+that $q_{\mathsf{kb}}$ counts the derivation inputs of the adversary's
+output witnesses among its queries. This convention is without loss of
+generality: replace $\mathcal{A}$ by the adversary that runs
+$\mathcal{A}$, queries the (at most 4) derivation inputs of its output
+witnesses, and returns the output unchanged. This "reasonable
+adversary" normalization[^BS2023] leaves the output distribution —and
+therefore the break probability— unchanged, puts the collision inputs
+among the queries by construction, and adds at most 4 to
+$q_{\mathsf{kb}}$.
+
+Note that the external/internal decode is by value
+($\mathsf{rivk} \overset{?}{=} \mathsf{rivk\_ext}$), not by how the witness was
+derived: at a fixpoint
+$\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) = \mathsf{rivk\_ext}$
+an internally-derived witness decodes as external. Both readings give
+the same $\mathsf{rivk}$, and the accounting partitions pairs by the
+decode.
+
+*Per-pair bound and union bound.*
+Fix distinct combined inputs $x \neq x'$. Conditioning on all
+$\mathsf{H^{ask}}$/$\mathsf{H^{nk}}$ responses fixes the shifts
+$s(x), s(x')$, while $\mathsf{H}^*(x), \mathsf{H}^*(x')$ remain
+independent uniform on $\mathbb{F}_{r_{\mathbb{P}}}$. For each sign
+there is exactly one value of $\mathsf{H}^*(x)$ that collides, so
+$$\Pr\big[\mathsf{H}^s(x) \equiv \pm \mathsf{H}^s(x') \pmod{r_{\mathbb{P}}}\big] \leq \frac{2}{r_{\mathbb{P}}}$$
+under every such conditioning, hence unconditionally. Union-bounding
+over the at most ${q_{\mathsf{kb}} \choose 2}$ unordered pairs of
+distinct queries,
+$$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq {q_{\mathsf{kb}} \choose 2} \cdot \frac{2}{r_{\mathbb{P}}} = \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}\textsf{.}$$
 
 
 ## Security argument for Spendability
@@ -1777,12 +1792,12 @@ $$\Pr[\text{win}] \leq \frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}
 This completes the classical-ROM proof.
 
 The [key-binding theorem](#thm-key-binding-rom) bounds
-$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
+$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
 Substituting, an adversary $\mathcal{A}$ that makes at most
 $q_{\mathsf{rcm}}$ queries to $\mathsf{H^{rcm}}$ and at most
 $q_{\mathsf{kb}}$ queries to the key-binding random oracles
 wins the Spendability-collision game with probability at most
-$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} \;+\; \frac{3\, q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{2\, r_{\mathbb{P}}}$.
+$\frac{q_{\mathsf{rcm}}(q_{\mathsf{rcm}}-1)}{r_{\mathbb{P}}} \;+\; \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}$.
 
 For the post-quantum lift of this bound and of the
 [key-binding bound](#thm-key-binding-rom) above, see the next section.
@@ -2184,6 +2199,8 @@ manipulate the note selection algorithm to some extent.
 [^CDDGS2025]: [Quantum Rewinding for IOP-Based Succinct Arguments. Alessandro Chiesa, Marcel Dall'Agnol, Zijing Di, Ziyi Guan, and Nicholas Spooner.](https://eprint.iacr.org/2025/947)
 
 [^ACMT2025]: [The Sponge is Quantum Indifferentiable. Gorjan Alagic, Joseph Carolan, Christian Majenz, and Saliha Tokat.](https://eprint.iacr.org/2025/731)
+
+[^BS2023]: [A Graduate Course in Applied Cryptography (Version 0.6). Dan Boneh and Victor Shoup.](https://toc.cryptobook.us/) See the "reasonable adversary" step in the proof of Theorem 8.4 (Davies–Meyer).
 
 [^Google2025]: [Securing Elliptic Curve Cryptocurrencies against Quantum Vulnerabilities: Resource Estimates and Mitigations. Ryan Babbush, Adam Zalcman, Craig Gidney, Michael Broughton, Tanuj Khattar, Hartmut Neven, Thiago Bergamaschi, Justin Drake, and Dan Boneh](https://quantumai.google/static/site-assets/downloads/cryptocurrency-whitepaper.pdf)
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1447,7 +1447,10 @@ $\mathsf{H^{nk}}$.
 Let $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$
 be the probability, over $\mathcal{A}$'s randomness and at most $q_{\mathsf{kb}}$
 queries in total to these random oracles, that $\mathcal{A}$ outputs a
-key-binding break.
+key-binding break. Here $q_{\mathsf{kb}}$ counts the derivation inputs of
+$\mathcal{A}$'s output witnesses among its queries — a convention that is
+without loss of generality, by the
+[accounting normalization](#kb-query-accounting) in the proof.
 
 **Theorem (key-binding, classical ROM).** <a id="thm-key-binding-rom"></a>
 Let $\mathcal{A}$ be a classical adversary making at most $q_{\mathsf{kb}}$
@@ -1559,7 +1562,8 @@ at distinct inputs. In every case:
 **a key-binding break yields a ±-collision of $\mathsf{H}^s$ at two
 distinct inputs among the adversary's queries**, under the convention
 that $q_{\mathsf{kb}}$ counts the derivation inputs of the adversary's
-output witnesses among its queries. This convention is without loss of
+output witnesses among its queries. <a id="kb-query-accounting"></a>
+This convention is without loss of
 generality: replace $\mathcal{A}$ by the adversary that runs
 $\mathcal{A}$, queries the (at most 4) derivation inputs of its output
 witnesses, and returns the output unchanged. This "reasonable
@@ -1665,7 +1669,10 @@ A key-binding break is as defined above in the
 Let $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$
 be the probability, over $\mathcal{A}$'s randomness and at most
 $q_{\mathsf{kb}}$ queries to the random oracles used in the
-key-binding argument, that $\mathcal{A}$ outputs a key-binding break.
+key-binding argument, that $\mathcal{A}$ outputs a key-binding break
+(with $q_{\mathsf{kb}}$ counting the derivation inputs of the output
+witnesses among the queries, as in the
+[accounting normalization](#kb-query-accounting)).
 $\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}})$ is
 bounded separately by that argument; the bound below is unconditional,
 but is only useful to the extent that

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1600,6 +1600,9 @@ at most $2(j-1)/r_{\mathbb{P}}$. Because the conditioning is on the
 transcript itself, this holds however $x_j$ was chosen from the
 transcript. Summing over the queries,
 $$\varepsilon_{\mathsf{kb}}(\mathcal{A}, q_{\mathsf{kb}}) \leq \sum_{j=1}^{q_{\mathsf{kb}}} \frac{2(j-1)}{r_{\mathbb{P}}} = \frac{q_{\mathsf{kb}}(q_{\mathsf{kb}}-1)}{r_{\mathbb{P}}}\textsf{.}$$
+(Queries to $\mathsf{H^{ask}}$ or $\mathsf{H^{nk}}$ are not
+$\mathsf{H}^*$ inputs and cannot complete a collision, so counting
+them in $q_{\mathsf{kb}}$ is conservative.)
 
 
 ## Security argument for Spendability

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1541,8 +1541,11 @@ a ±-collision of $\mathsf{H}^s$ at the pair $(x_1, x_2)$.
 
 *Distinct final inputs.*
 The final inputs $x_1, x_2$ of a break need not be distinct, but the
-case $x_1 = x_2$ is fully deterministic. If either witness is
-externally decoded, equal final inputs force the witnesses to coincide
+case $x_1 = x_2$ is fully deterministic. If the witnesses decode
+differently —one external, one internal— their final inputs lie in
+disjoint summands of the combined domain, so $x_1 = x_2$ is impossible
+outright. If both witnesses are externally decoded, equal final inputs
+force the witnesses to coincide
 on all fields constrained by the key-binding condition, contradicting
 distinctness. (Equal $\mathsf{H^{rivk\_ext}}$ inputs determine
 $(\mathsf{qk}, \mathsf{ak}, \mathsf{nk})$ and thence
@@ -1566,7 +1569,8 @@ output witnesses among its queries. <a id="kb-query-accounting"></a>
 This convention is without loss of
 generality: replace $\mathcal{A}$ by the adversary that runs
 $\mathcal{A}$, queries the (at most 4) derivation inputs of its output
-witnesses, and returns the output unchanged. This "reasonable
+witnesses —each witness's final input and its rivk_ext-derivation
+input— and returns the output unchanged. This "reasonable
 adversary" normalization[^BS2023] leaves the output distribution —and
 therefore the break probability— unchanged, puts the collision inputs
 among the queries by construction, and adds at most 4 to

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1310,7 +1310,7 @@ witness pinned:
 * **Nullifier-binding** (used by the Balance argument and by the
   [Spendability argument](#securityargumentforspendability) below
   — the latter via the
-  [$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning)):
+  [$\mathsf{nf}$-pinning lemma](#lemma-nf-pinning)):
   $\mathsf{nk}$ uniquely determined by $\mathsf{ivk}$.
 * **Spend Authorization**: $\mathsf{ak}$ (up to $y$-sign of
   $\mathsf{ak}^{\mathbb{P}}$) and $\mathsf{qk}$ uniquely determined by
@@ -1719,16 +1719,18 @@ prime-order Pallas curve and
 $\mathsf{ivk} \in [0, q_{\mathbb{P}}) \subseteq [0, r_{\mathbb{P}})$;
 $\mathsf{ivk}$ is therefore uniquely determined by $\mathsf{notetuple}$.
 
-**$\mathsf{PRF^{nf}}$-pinning lemma.** <a id="lemma-prf-nf-pinning"></a>
+**$\mathsf{nf}$-pinning lemma.** <a id="lemma-nf-pinning"></a>
 Suppose $\mathcal{A}$'s output $(w_1, w_2)$ does not contain a
-key-binding break. Then for each $i \in \{1, 2\}$,
-$\mathsf{PRF^{nf}_{\mathsf{nk}_i}}(\text{ρ}_i)$ is uniquely determined
-by $\mathsf{notetuple}_i$: by the conditioning,
+key-binding break. Then for each $i \in \{1, 2\}$, $\mathsf{nf}_i$ is
+uniquely determined by $\mathsf{notetuple}_i$: by the conditioning,
 $(\mathsf{ak}_i, \mathsf{nk}_i, \mathsf{rivk}_i)$ is the only opening of
 $\mathsf{ivk}_i$ appearing in $\mathcal{A}$'s output, so $\mathsf{nk}_i$
 is a function of $\mathsf{ivk}_i$, which is in turn a function of
-$\mathsf{notetuple}_i$ by the $\mathsf{ivk}$-pinning lemma; and
-$\text{ρ}_i$ is a field of $\mathsf{notetuple}_i$.
+$\mathsf{notetuple}_i$ by the $\mathsf{ivk}$-pinning lemma; $\text{ρ}_i$
+is a field of $\mathsf{notetuple}_i$; and the remaining
+$\mathsf{DeriveNullifier}$ inputs $\text{ψ}_i$ and $\mathsf{cm}_i$ are
+determined by $\mathsf{notetuple}_i$ through the Recovery Statement's
+deterministic derivations.
 
 The argument here covers nullifier-binding — it argues that $\mathsf{nf}$
 binds the note tuple $(\mathsf{rseed}, \mathsf{noterepr})$
@@ -1794,9 +1796,9 @@ $$\mathsf{F}(\mathsf{notetuple}) := \mathsf{H^{rcm}}(\mathsf{notetuple}) +
 \text{ψ}) \bmod q_{\mathbb{P}}\big) \cdot K_{\kern-.08em\mathcal{R}}
 \pmod{r_{\mathbb{P}}}$$,
 where $\mathsf{rseed}, \text{ρ}, \text{ψ}$ are fields of
-$\mathsf{notetuple}$ and $\mathsf{PRF^{nf}_{nk}}(\text{ρ})$ is
-determined by $\mathsf{notetuple}$ via the
-[$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning), and let
+$\mathsf{notetuple}$ and $\mathsf{nk}$ is determined by
+$\mathsf{notetuple}$ via the key-binding leg of the
+[$\mathsf{nf}$-pinning lemma](#lemma-nf-pinning), and let
 $F_i := \mathsf{F}(\mathsf{notetuple}_i)$ for $i \in \{1, 2\}$.
 
 $\mathsf{Extract}_{\mathbb{P}}$ (§ 5.4.9.7 'Coordinate Extractor for

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1387,7 +1387,7 @@ $\begin{array}{rll}
 \end{array}$
 
 Let the key-binding condition on a witness
-$w = (\mathsf{ivk}, \mathsf{qk\_or\_sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}, \mathsf{rivk})$ be:
+$w = (\mathsf{ivk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}, \mathsf{rivk}, \mathsf{qk\_or\_sk})$ be:
 
 $\begin{array}{l}
 \;\;\;   \text{match } \mathsf{qk\_or\_sk} \text{ with } \begin{cases}
@@ -1436,7 +1436,7 @@ $\mathsf{is\_internal\_rivk}$ it is additional robustness.
 
 A **key-binding break** is a pair of witnesses $(w_1, w_2)$ with
 shared $\mathsf{ivk}$ satisfying the key-binding condition, whose
-$(\mathsf{qk\_or\_sk}, \mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$
+$(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk}, \mathsf{qk\_or\_sk})$
 projections differ — i.e., $w_1$ and $w_2$ differ in some component
 other than the $y$-sign of $\mathsf{ak}^{\mathbb{P}}$.
 

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1312,12 +1312,12 @@ witness pinned:
   $\mathsf{nk}$ uniquely determined by $\mathsf{ivk}$.
 * **Spend Authorization**: $\mathsf{ak}$ (up to $y$-sign of
   $\mathsf{ak}^{\mathbb{P}}$) and $\mathsf{qk}$ uniquely determined by
-  $\mathsf{ivk}$. This includes uniquely determining whether
-  $\mathsf{qk} = \bot$, i.e. which of the $\mathsf{qk}$- and
-  $\mathsf{sk}$-branches produced the $\mathsf{ivk}$.
+  $\mathsf{ivk}$. This includes uniquely determining the tag of
+  $\mathsf{qk\_or\_sk}$, i.e. which of the $\mathsf{QK}$ and
+  $\mathsf{SK}$ branches produced the $\mathsf{ivk}$.
 
 The determination of $\mathsf{qk}$ must fix the branch itself, not merely
-the value of $\mathsf{qk}$ conditioned on $\mathsf{qk} \neq \bot$. Suppose
+the value of $\mathsf{qk}$ within the $\mathsf{QK}$ branch. Suppose
 an address generated with $\mathsf{use\_qsk} = \mathsf{true}$ —whose owner
 authorizes recovery by proving knowledge of $\mathsf{qsk}$ via
 $\mathsf{SoK^{qsk}}$— shared its $\mathsf{ivk}$ with an $\mathsf{sk}$-branch
@@ -1619,7 +1619,8 @@ free variables that the adversary can control are the sources of the
 derivation digraph within that statement and either $\mathsf{SoK^{sk}}$
 or $\mathsf{SoK^{qk}}$. That is, the adversary can control all of
 $$(\text{ρ}, \mathsf{g_d}, \mathsf{rseed}, \mathsf{sk}, \mathsf{nk}, \mathsf{ak}, \mathsf{qk}, \mathsf{qsk}, \mathsf{rivk})$$
-subject to $(\mathsf{sk} = \bot) \neq (\mathsf{qk} = \bot)$. The
+subject to exactly one of $\mathsf{sk}$ and $\mathsf{qk}$ being
+present, per the $\mathsf{qk\_or\_sk}$ tagged union. The
 choice between external and internal IVK is encoded in
 $\mathsf{rivk}$'s value (either $\mathsf{rivk\_ext}$ or
 $\mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})$).

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -216,11 +216,11 @@ oracles, depending on which key material the user holds:
 
 Both branches (and both cases $\mathsf{rivk} \in \{ \mathsf{rivk\_ext}, \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) \}$) are covered uniformly by the
 [Security argument for key binding](#securityargumentforkeybinding):
-each binds the keys $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ —and,
-when in use, $\mathsf{qk}$— to the incoming-viewing key $\mathsf{ivk}$
-post-quantumly, up to a small advantage against collision-finding in
-the random oracles used for $\mathsf{rivk}$ derivation. The FROST and
-hardware-wallet use cases are described in
+each binds the keys $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ —and
+$\mathsf{qk}$, including whether it is in use— to the incoming-viewing
+key $\mathsf{ivk}$ post-quantumly, up to a small advantage against
+collision-finding in the random oracles used for $\mathsf{rivk}$
+derivation. The FROST and hardware-wallet use cases are described in
 [Usage with FROST](#usagewithfrost) and
 [Usage with hardware wallets](#usagewithhardwarewallets).
 
@@ -1302,11 +1302,27 @@ witness pinned:
   [$\mathsf{PRF^{nf}}$-pinning lemma](#lemma-prf-nf-pinning)):
   $\mathsf{nk}$ uniquely determined by $\mathsf{ivk}$.
 * **Spend Authorization**: $\mathsf{ak}$ (up to $y$-sign of
-  $\mathsf{ak}^{\mathbb{P}}$) uniquely determined by $\mathsf{ivk}$;
-  and $\mathsf{qk}$ uniquely determined by $\mathsf{ivk}$ when
-  $\mathsf{qk} \neq \bot$ (i.e., when $\mathsf{use\_qsk} = \mathsf{true}$).
+  $\mathsf{ak}^{\mathbb{P}}$) and $\mathsf{qk}$ uniquely determined by
+  $\mathsf{ivk}$. This includes uniquely determining whether
+  $\mathsf{qk} = \bot$, i.e. which of the $\mathsf{qk}$- and
+  $\mathsf{sk}$-branches produced the $\mathsf{ivk}$.
 
-The formal key-binding condition stated below covers both of these
+The determination of $\mathsf{qk}$ must fix the branch itself, not merely
+the value of $\mathsf{qk}$ conditioned on $\mathsf{qk} \neq \bot$. Suppose
+an address generated with $\mathsf{use\_qsk} = \mathsf{true}$ —whose owner
+authorizes recovery by proving knowledge of $\mathsf{qsk}$ via
+$\mathsf{SoK^{qsk}}$— shared its $\mathsf{ivk}$ with an $\mathsf{sk}$-branch
+witness. An adversary holding a suitable $\mathsf{sk}$ could then recover
+the note through the $\mathsf{sk}$-branch of the
+[Recovery Statement](#proposedrecoverystatement), authorizing the spend
+with $\mathsf{SoK^{sk}}$ and never demonstrating knowledge of
+$\mathsf{qsk}$. Against a discrete-logarithm-breaking adversary —for which
+the accompanying RedDSA signature over $\mathsf{ak}$ gives no protection—
+this breaks Spend Authorization for such addresses. Ruling out these
+cross-branch collisions (both $\mathsf{qk}$-values pinned, $\bot$ included)
+is therefore a requirement of the argument, not incidental strength.
+
+The formal key-binding condition stated below covers all of these
 uniformly: a key-binding break is a pair of distinct witnesses sharing
 the same $\mathsf{ivk}$, where each witness carries the full key tuple
 — $(\mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$ plus whichever of
@@ -1398,7 +1414,10 @@ either flag (e.g., $w_1$ with $\mathsf{qk} \neq \bot$ and $w_2$ with
 $\mathsf{sk} \neq \bot$, or $w_1$ with external $\mathsf{rivk}$ and
 $w_2$ with internal $\mathsf{rivk}$), provided both produce the same
 $\mathsf{ivk}$. A flag-based formulation would forbid only same-branch
-breaks.
+breaks. For the $\mathsf{use\_qsk}$ flag this extra strength is required
+by Spend Authorization —forbidding the $\mathsf{qk}$-versus-$\mathsf{sk}$
+cross-branch collision described above— and not merely incidental; for
+$\mathsf{is\_internal\_rivk}$ it is additional robustness.
 
 A **key-binding break** is a pair of witnesses $(w_1, w_2)$ with
 shared $\mathsf{ivk}$ satisfying the key-binding condition, whose

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -48,13 +48,15 @@ and similarly for other Orchard-protocol-specific hash function names.
 The changes to the protocol specification and to other ZIPs use the full
 forms.
 
-We will use the syntax $\mathsf{Left}(T_1) \mid \mathsf{Right}(T_2)$ for
-a tagged union type with tags $\mathsf{Left}$ and $\mathsf{Right}$.
+We will use the syntax
+$\mathsf{Constructor}_1(T_1) \mid \mathsf{Constructor}_2(T_2)$ for
+a tagged union type with tags $\mathsf{Constructor}_1$ and
+$\mathsf{Constructor}_2$.
 Such types can be destructured using a $\text{match}$ construct:
 
 $\hspace{2em}\text{match } e \text{ with} \begin{cases}
-    \mathsf{Left}(t_1)  \!\!\!&\Rightarrow f(t_1) \\
-    \mathsf{Right}(t_2) \!\!\!&\Rightarrow g(t_2)\textsf{.}
+    \mathsf{Constructor}_1(t_1) \!\!\!&\Rightarrow f(t_1) \\
+    \mathsf{Constructor}_2(t_2) \!\!\!&\Rightarrow g(t_2)\textsf{.}
   \end{cases}$
 
 The terms "*Ironwood pool*" and "*Orchard pool*" are to be interpreted as

--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -48,6 +48,15 @@ and similarly for other Orchard-protocol-specific hash function names.
 The changes to the protocol specification and to other ZIPs use the full
 forms.
 
+We will use the syntax $\mathsf{Left}(T_1) \mid \mathsf{Right}(T_2)$ for
+a tagged union type with tags $\mathsf{Left}$ and $\mathsf{Right}$.
+Such types can be destructured using a $\text{match}$ construct:
+
+$\hspace{2em}\text{match } e \text{ with} \begin{cases}
+    \mathsf{Left}(t_1)  \!\!\!&\Rightarrow f(t_1) \\
+    \mathsf{Right}(t_2) \!\!\!&\Rightarrow g(t_2)\textsf{.}
+  \end{cases}$
+
 The terms "*Ironwood pool*" and "*Orchard pool*" are to be interpreted as
 described in [^zip-0229]. Following the convention in the protocol
 specification, we use *slanted text* to refer to pool names, in order to
@@ -1347,15 +1356,20 @@ for $\mathsf{NoteCommit}$, with the $\mathsf{rivk}$-derivation hashes
 playing the role of $\mathsf{H^{rcm}}$. The Recovery Statement checks
 the derivation of $\mathsf{rivk}$:
 
-* When $\mathsf{qk} \neq \bot$,
+The witness carries the branch as a tagged union
+$\mathsf{qk\_or\_sk} \;{\small ⦂}\;
+\mathsf{QK}\big(\mathbb{B}^{{\kern-0.1em\tiny\mathbb{Y}}[\ell_{\mathsf{qk}}/8]}\big) \mid
+\mathsf{SK}\big(\mathbb{B}^{[\ell_{\mathsf{sk}}]}\big)$
+—following the formalization's sum type— so exactly one branch is
+present per witness, by construction. This is equivalent to
+case-splitting by $\mathsf{use\_qsk}$.
+
+* In the $\mathsf{QK}$ branch,
   $\mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk})$.
-* When $\mathsf{sk} \neq \bot$,
+* In the $\mathsf{SK}$ branch,
   $\mathsf{rivk\_ext} = \mathsf{H^{rivk\_legacy}}(\mathsf{sk})$, with
   $\mathsf{ak}$ and $\mathsf{nk}$ also derived from $\mathsf{sk}$ via
   $\mathsf{H^{ask}}$ and $\mathsf{H^{nk}}$.
-
-Exactly one of $\mathsf{qk}$ and $\mathsf{sk}$ is non-$\bot$ per
-witness; this is equivalent to case-splitting by $\mathsf{use\_qsk}$.
 
 In either case, $\mathsf{rivk}$ is then either $\mathsf{rivk\_ext}$
 directly (external IVK) or
@@ -1373,12 +1387,13 @@ $\begin{array}{rll}
 \end{array}$
 
 Let the key-binding condition on a witness
-$w = (\mathsf{ivk}, \mathsf{qk}, \mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}, \mathsf{rivk})$ be:
+$w = (\mathsf{ivk}, \mathsf{qk\_or\_sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}, \mathsf{rivk})$ be:
 
 $\begin{array}{l}
-\;\;\;   (\mathsf{sk} = \bot) \neq (\mathsf{qk} = \bot) \\
-\wedge\; \mathsf{qk} \neq \bot \Rightarrow \big(\; \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk}) \,\big) \\
-\wedge\; \mathsf{sk} \neq \bot \Rightarrow \mathsf{BindKeys^{sk}}(\mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}) \\
+\;\;\;   \text{match } \mathsf{qk\_or\_sk} \text{ with } \begin{cases}
+           \mathsf{QK}(\mathsf{qk}) \!\!\!&\Rightarrow \mathsf{rivk\_ext} = \mathsf{H^{rivk\_ext}_{qk}}(\mathsf{ak}, \mathsf{nk}) \\
+           \mathsf{SK}(\mathsf{sk}) \!\!\!&\Rightarrow \mathsf{BindKeys^{sk}}(\mathsf{sk}, \mathsf{ak}^{\mathbb{P}}, \mathsf{nk}, \mathsf{rivk\_ext}) \vphantom{\Big(}
+         \end{cases} \\
 \wedge\; \mathsf{rivk} \in \big\{\, \mathsf{rivk\_ext},\, \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk}) \,\big\} \\
 \wedge\; \mathsf{ivk} = \mathsf{Commit^{ivk}_{rivk}}(\mathsf{ak}, \mathsf{nk}) \\
 \wedge\; \mathsf{ivk} \not\in \{0, \bot\}
@@ -1400,18 +1415,18 @@ appear in the protocol diagram do not appear in this witness — nor in
 the formal Recovery Statement above. Their roles are absorbed into the
 witness's structural form:
 
-* $\mathsf{use\_qsk}$ is encoded in
-  $(\mathsf{sk} = \bot) \neq (\mathsf{qk} = \bot)$: exactly one of
-  $\mathsf{sk}$ and $\mathsf{qk}$ is non-$\bot$, and the branch-specific
-  constraints apply to whichever is present.
+* $\mathsf{use\_qsk}$ is encoded in the tag of $\mathsf{qk\_or\_sk}$:
+  the witness carries exactly one of the two branches by construction
+  (enforced by the tagged form, not by a $\bot$-exclusion constraint),
+  and the branch-specific constraint applies to whichever is present.
 * $\mathsf{is\_internal\_rivk}$ is encoded in
   $\mathsf{rivk} \in \big\{\mathsf{rivk\_ext},\, \mathsf{H^{rivk\_int}_{rivk\_ext}}(\mathsf{ak}, \mathsf{nk})\big\}$:
   both $\mathsf{rivk}$ derivations are admitted simultaneously.
 
 This formulation is strictly stronger than a flag-conditioned one: a
 key-binding break can have $w_1$ and $w_2$ in different branches across
-either flag (e.g., $w_1$ with $\mathsf{qk} \neq \bot$ and $w_2$ with
-$\mathsf{sk} \neq \bot$, or $w_1$ with external $\mathsf{rivk}$ and
+either flag (e.g., $w_1$ in the $\mathsf{QK}$ branch and $w_2$ in the
+$\mathsf{SK}$ branch, or $w_1$ with external $\mathsf{rivk}$ and
 $w_2$ with internal $\mathsf{rivk}$), provided both produce the same
 $\mathsf{ivk}$. A flag-based formulation would forbid only same-branch
 breaks. For the $\mathsf{use\_qsk}$ flag this extra strength is required
@@ -1421,7 +1436,7 @@ $\mathsf{is\_internal\_rivk}$ it is additional robustness.
 
 A **key-binding break** is a pair of witnesses $(w_1, w_2)$ with
 shared $\mathsf{ivk}$ satisfying the key-binding condition, whose
-$(\mathsf{qk}, \mathsf{sk}, \mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$
+$(\mathsf{qk\_or\_sk}, \mathsf{ak}, \mathsf{nk}, \mathsf{rivk})$
 projections differ — i.e., $w_1$ and $w_2$ differ in some component
 other than the $y$-sign of $\mathsf{ak}^{\mathbb{P}}$.
 
@@ -1847,8 +1862,8 @@ memory.) Therefore, an output size of 253 bits does not exclude a hash
 function from being collapsing.
 
 $\mathsf{Extract}_{\mathbb{P}}$ does not interfere with the QROM lift:
-it is a deterministic 2-to-1 map on non-identity Pallas points (sending
-$P$ and $-P$ to the same $x$-coordinate) and does not query
+it is a deterministic 2-to-1 map on non-identity Pallas points (sending $P$
+and $-P$ to the same $x$-coordinate) and does not query
 $\mathsf{H^{rcm}}$ or any other random oracle, so it composes with the
 underlying random oracle the same way classically and quantumly. The
 factor of 2 from the 2-to-1 reduction is already absorbed into the


### PR DESCRIPTION
Refinements to the ZIP 2005 key-binding security argument, incorporating what the Lean formalization surfaced (zcash/ironwood#50 for the deterministic reduction, zcash/ironwood#73 for the probabilistic layer). Fixes #1335.

* **The key-binding condition must pin `qk`'s branch, not just its value**. The condition previously pinned the value of `qk`; the formalization showed the branch selection itself must be pinned, closing a cross-branch substitution admitted by the original wording.

* **Restructure the proof around the shifted oracle; sharpen the bound**. The proof of `thm-key-binding-rom` now works with the *shifted* combined final `rivk`-derivation oracle: the shift is a function of the query and the `H^ask`/`H^nk` responses alone, so conditioning fixes the shifts while the oracle outputs at distinct inputs stay independently uniform. Each unordered query pair then contributes at most $2/r_{\mathbb{P}}$ (one colliding value per sign), not $3/r_{\mathbb{P}}$. The residual same-final-query case needs no separate term — it relocates the collision to the `rivk_ext`-derivation query pair, which the union bound already counts. The bound sharpens from $3q(q-1)/2r_{\mathbb{P}}$ to $q(q-1)/r_{\mathbb{P}}$, and the combined Spendability + key-binding total is updated to match. The query-inclusion step is now stated precisely: the bound holds under the convention that $q_{\mathsf{kb}}$ counts the adversary's output witnesses' derivation inputs. This convention is justified by the standard "reasonable adversary" normalization (run the adversary, query the at most 4 derivation inputs of its output, return the output unchanged), with a reference to Boneh–Shoup, Theorem 8.4.

* **Use tagged unions for the qk/sk branch** (third commit). The abstract key-binding witness carries the branch as a tagged union qk_or_sk ${\small ⦂} \mathsf{QK}(\ldots) \mid \mathsf{SK}(\ldots)$. Exactly one branch is present per witness, by construction, and the branch conditions are stated with match-cases syntax. This follows the formalization's sum-type witness (`Branch`/`qk_or_sk`), which type-enforces the exclusivity the flags only asserted. The Recovery Statement's auxiliary input itself keeps its nullable fields.

* **Canonical component order**: the key-binding witness tuple becomes (ivk, $\mathsf{ak}^{\mathbb{P}}$, nk, rivk_ext, rivk, qk_or_sk)$ and the break projection (ak, nk, rivk, qk_or_sk), matching the formalization's canonical order; oracle argument orders are unchanged.

* **Review responses**, one commit per point: the query-accounting convention is stated at both definitions of $\varepsilon_{\mathsf{kb}}$, linking to the normalization; the collision bound is justified for adaptively chosen queries by sequential transcript conditioning (summing $2(j-1)/r_{\mathbb{P}}$); the remaining ⊥-flag phrasings are aligned with the tagged union; the mixed-decode case is explicitly vacuous by disjointness, with the derivation inputs named; a note records that only $\mathsf{H}^*$ queries can complete a collision; and the tagged-union notation uses generic $\mathsf{Constructor}_1/\mathsf{Constructor}_2$ tags.

* **Rename $\mathsf{PRF^{nf}}$-pinning to $\mathsf{nf}$-pinning**, stated for the full nullifier: the Spendability argument's interface is that $\mathsf{nf}$ itself is determined by the note tuple. The key-binding-dependent leg ($\mathsf{nk}$ via $\mathsf{ivk}$-pinning under the no-break conditioning) sits alongside the Recovery Statement's deterministic derivations of the remaining $\mathsf{DeriveNullifier}$ inputs. The formalization delivers this as `nfOldEqOrBreak`.

The sharpened bound and the normalization are machine-checked in the formalization: `break_measure_le_adaptive` proves $\varepsilon_{\mathsf{kb}} \le q(q-1)/r$ for an adaptive bounded-query adversary, and `break_measure_le_of_queryBound` proves the hypothesis-free $(q+4)(q+3)/r$ form via the explicit completion.

🤖 Claude Fable 5