### PR TITLE
Specify ZIP 318 note-preparation expiry

### DIFF
--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -419,6 +419,11 @@ note distribution, and the distinction is not visible on-chain (see
 * Note preparation MUST be implemented as one or more wallet-internal
   send-to-self transactions with no external receiver.
 
+* Each note-preparation transaction SHOULD use the canonical expiry height
+  specified for migration transactions in
+  [Canonical migration transaction structure](#canonicalmigrationtransactionstructure),
+  computed from the note-preparation transaction's scheduled broadcast height.
+
 * For mobile wallets, proving time is a concern. For that reason, and also for
   indistinguishability, Note preparation transactions SHOULD be constructed 
   such that each preparation transaction contains exactly


### PR DESCRIPTION
## Summary

- Specify that each note-preparation transaction should use ZIP 318's
  canonical expiry-height rule.
- Derive the expiry from the note-preparation transaction's own scheduled
  broadcast height, matching migration transactions.

## Why

ZIP 318's error handling already covers expired note-preparation transactions,
but the note-preparation construction rules did not define how to select their
expiry heights. This change closes that gap while reusing the existing
privacy-preserving, bucketed expiry rule.

## Impact

Wallet implementations get an explicit, consistent expiry-height rule for both
phases of the migration flow. No API or protocol-constant changes are
introduced.

## Validation

- `git diff --check`
- `make all-zips` returned success, but local rendering dependencies
  (`multimarkdown` and `rst2html5`) were unavailable, so the generated output
  was not treated as a valid render check.
- `nix develop -c make all` could not be run because `nix` is not installed in
  the local environment; CI will run the canonical renderer.
