### PR TITLE
ZIP 318: Shorten migration timing

### DIFF
--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -603,7 +603,8 @@ the wallet's own account, and whether its value is a canonical denomination.
   proving time, is drawn (using a CSPRNG) from a geometric distribution with
   parameter **1/2** — so the most recent boundary has age zero and is the most
   probable, and the mean age is one boundary (about three hours). A draw
-  exceeding `ANCHOR_AGE_CAP` (provisionally **8 boundaries**, about one day)
+  exceeding `ANCHOR_AGE_CAP` (provisionally **4 boundaries**, about twelve
+  hours)
   or falling outside the candidate set MUST be discarded and redrawn;
   equivalently, the distribution is truncated to the candidate set.
 

--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -582,7 +582,7 @@ the wallet's own account, and whether its value is a canonical denomination.
 
 * Buckets are delimited by **boundaries**: blocks whose height is
   $\equiv 0 \pmod{M}$, with $M$ provisionally `144`. At the current target
-  block spacing of 75 seconds, a boundary occurs every
+  block spacing of 75 seconds, a boundary occurs approximately every
   $144 \times 75\,\text{s} = 3$ hours. This interval concentrates migration
   transactions onto fewer shared anchors, enlarging per-anchor cohorts.
   `EXPIRY_MODULUS` (34560 blocks) is an exact multiple of $M$ (240 buckets),
@@ -605,8 +605,8 @@ the wallet's own account, and whether its value is a canonical denomination.
   probable age is one boundary, and the mean age is two boundaries (about six
   hours). A draw exceeding `ANCHOR_AGE_CAP` (provisionally **4 boundaries**,
   about twelve hours) or falling outside the candidate set MUST be discarded
-  and redrawn;
-  equivalently, the distribution is truncated to the candidate set.
+  and redrawn; equivalently, the distribution is truncated to the candidate
+  set.
 
 * The set of all migration transactions sharing a boundary anchor forms a
   **cohort**. A wallet MAY contribute several migration transactions to the
@@ -631,7 +631,7 @@ wallet's broadcasts approximate a Poisson process.
 
 * The delay to each successive migration transaction MUST be drawn from an
   exponential distribution with rate $\lambda = 1 /$ `MEAN_DELAY`, so that the
-  expected delay is `MEAN_DELAY` (provisionally **66 blocks**, about ninety
+  expected delay is `MEAN_DELAY` (provisionally **66 blocks**, about 82
   minutes at 75-second block spacing), rounded to a whole number of blocks; any
   draw exceeding `MAX_DELAY` (provisionally **576 blocks**, about twelve
   hours) MUST be discarded and redrawn.

--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -603,7 +603,7 @@ the wallet's own account, and whether its value is a canonical denomination.
   proving time, is drawn (using a CSPRNG) from a geometric distribution with
   parameter **1/2** — so the most recent boundary has age zero and is the most
   probable, and the mean age is one boundary (about three hours). A draw
-  exceeding `ANCHOR_AGE_CAP` (provisionally **16 boundaries**, about two days)
+  exceeding `ANCHOR_AGE_CAP` (provisionally **8 boundaries**, about one day)
   or falling outside the candidate set MUST be discarded and redrawn;
   equivalently, the distribution is truncated to the candidate set.
 

--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -1480,14 +1480,6 @@ The following alternative designs were considered and rejected.
 - **A privacy/speed slider exposed to the user**: the decision and the UI are
   too complex for typical users; the wallet picks sensible defaults instead.
 
-# Acknowledgements
-
-The faster timing parameters and inclusion of the most recent anchor boundary
-were informed by real-world migration data and user feedback gathered by the
-Vizor Wallet team. We especially thank [@dogemos](https://github.com/dogemos)
-and [@thunnini](https://github.com/thunnini) for their analysis and
-recommendations.
-
 # References
 
 [^BCP14]: [Information on BCP 14, "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)

--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -482,7 +482,7 @@ note distribution, and the distinction is not visible on-chain (see
 * The broadcasts of a wallet's preparation transactions SHOULD be temporally
   decoupled from one another: the delay from each preparation transaction to
   the next is drawn (using a CSPRNG) from an exponential distribution with
-  mean `PREP_MEAN_DELAY` (**24 blocks**, about thirty minutes at 75-second 
+  mean `PREP_MEAN_DELAY` (**16 blocks**, about twenty minutes at 75-second
   block spacing), rounded to the nearest whole number of blocks, with any
   draw exceeding `PREP_MAX_DELAY` (**96 blocks**, about two
   hours) discarded and redrawn; a later layer's schedule begins after the
@@ -581,12 +581,12 @@ the wallet's own account, and whether its value is a canonical denomination.
   last synchronized.
 
 * Buckets are delimited by **boundaries**: blocks whose height is
-  $\equiv 0 \pmod{M}$, with $M$ provisionally `144`, equal to `MEAN_DELAY`. At
-  the current target block spacing of 75 seconds, a boundary occurs every
-  $144 \times 75\,\text{s} = 3$ hours. A longer interval concentrates
-  migration transactions onto fewer shared anchors, enlarging per-anchor
-  cohorts. `EXPIRY_MODULUS` (34560 blocks) is an exact multiple of $M$ (240
-  buckets), so expiry buckets align with anchor buckets.
+  $\equiv 0 \pmod{M}$, with $M$ provisionally `144`. At the current target
+  block spacing of 75 seconds, a boundary occurs every
+  $144 \times 75\,\text{s} = 3$ hours. This interval concentrates migration
+  transactions onto fewer shared anchors, enlarging per-anchor cohorts.
+  `EXPIRY_MODULUS` (34560 blocks) is an exact multiple of $M$ (240 buckets),
+  so expiry buckets align with anchor buckets.
 
 * Each migration transaction MUST take, as its *Orchard* anchor, the tree
   state as of a boundary drawn from the **candidate anchor set**: those
@@ -598,14 +598,14 @@ the wallet's own account, and whether its value is a canonical denomination.
   a wallet's transactions to one another (see
   [Rationale for anchor selection](#rationaleforanchorselection)).
 
-* The draw MUST be recency-weighted: the anchor's age $a \geq 1$, measured in
+* The draw MUST be recency-weighted: the anchor's age $a \geq 0$, measured in
   boundaries before the most recent boundary the wallet has observed at
   proving time, is drawn (using a CSPRNG) from a geometric distribution with
-  parameter **1/2** — so the most recent boundary is never used, the most
-  probable age is one boundary, and the mean age is two boundaries (about six
-  hours). A draw exceeding `ANCHOR_AGE_CAP` (provisionally **16 boundaries**,
-  about two days) or falling outside the candidate set MUST be discarded and
-  redrawn; equivalently, the distribution is truncated to the candidate set.
+  parameter **1/2** — so the most recent boundary has age zero and is the most
+  probable, and the mean age is one boundary (about three hours). A draw
+  exceeding `ANCHOR_AGE_CAP` (provisionally **16 boundaries**, about two days)
+  or falling outside the candidate set MUST be discarded and redrawn;
+  equivalently, the distribution is truncated to the candidate set.
 
 * The set of all migration transactions sharing a boundary anchor forms a
   **cohort**. A wallet MAY contribute several migration transactions to the
@@ -630,8 +630,8 @@ wallet's broadcasts approximate a Poisson process.
 
 * The delay to each successive migration transaction MUST be drawn from an
   exponential distribution with rate $\lambda = 1 /$ `MEAN_DELAY`, so that the
-  expected delay is `MEAN_DELAY` (provisionally **144 blocks**, about three
-  hours at 75-second block spacing), rounded to a whole number of blocks; any
+  expected delay is `MEAN_DELAY` (provisionally **66 blocks**, about ninety
+  minutes at 75-second block spacing), rounded to a whole number of blocks; any
   draw exceeding `MAX_DELAY` (provisionally **576 blocks**, about twelve
   hours) MUST be discarded and redrawn.
 
@@ -952,16 +952,18 @@ analysis. Shuffling the parts before scheduling extends the same property to
 values: the sequence of denominations a wallet emits is not a predictable
 function of its balance.
 
-The mean delay must not be short relative to the anchor-bucket interval. A
+The mean delay must not be too short relative to the anchor-bucket interval. A
 schedule whose delays are much shorter than the bucket interval (for example,
 minutes) would compress a wallet's entire migration into a tight, predictable
-window, and the burst itself would be a clustering signal. With `MEAN_DELAY`
-equal to the bucket modulus ($M$ = 144), a wallet's broadcasts spread across
-many boundary intervals, and its transfers are distributed across several
-cohorts. Resampling draws above `MAX_DELAY` bounds the
-worst-case gap so that the migration completes in bounded time and canonical
-expiry windows remain practical, at a negligible cost in memorylessness at
-the tail.
+window, and the burst itself would be a clustering signal. With
+`MEAN_DELAY` = 66 blocks and the bucket modulus $M$ = 144, a wallet broadcasts
+about two parts per bucket on average while the exponential tail continues to
+spread its transfers across several cohorts. This roughly halves the expected
+inter-transfer latency compared with a 144-block mean. Keeping `MAX_DELAY` at
+576 blocks, more than eight mean delays, preserves nearly all of the
+exponential distribution's variance while bounding the worst-case gap so that
+migration completes in bounded time and canonical expiry windows remain
+practical.
 
 Delays are denominated in blocks rather than wall-clock time because bucket
 boundaries, anchors, and expiry heights are all block-denominated, and block
@@ -1179,23 +1181,23 @@ already reveals. Third, concentration: the same reasoning that prefers
 canonical denominations to high-entropy amounts prefers few, heavily-used
 anchors to many thinly-used ones; recency weighting produces large per-anchor
 cohorts. Fourth, alignment with manual spends: a conforming wallet making a
-one-off *Orchard*→*Ironwood* spend will naturally use a recent boundary, and
-keeping the migration flow's anchor ages similar prevents anchor age from
-partitioning automated and manual traffic. The cap also bounds the tree
-states a wallet must retain for proving to the last `ANCHOR_AGE_CAP`
-boundaries.
+one-off *Orchard*→*Ironwood* spend will naturally use the most recent boundary.
+Giving that boundary age zero lets scheduled migrations join the same anchor
+cohort, instead of partitioning automated and manual traffic by anchor age.
+The cap also bounds the tree states a wallet must retain for proving to the
+last `ANCHOR_AGE_CAP` boundaries.
 
 The cost of recency weighting is a sharper posterior on proving time (a
 recent anchor implies proving shortly after it); this is blunted by the
 decoupling of proving from broadcast and by the exponential scheduling delay
 between them, which together turn "shortly after the anchor" into a
-multi-boundary window. The most recent boundary is excluded entirely because
-transactions anchored to it could only have been produced by wallets that
-synchronized within the current boundary interval — the bottleneck in
-miniature. In the first days after activation, every wallet's window is
-shallow and all distributions collapse onto the few boundaries that exist;
-privacy in that regime rests on cohort size (all migrating wallets share
-those anchors), not on anchor diversity.
+multi-boundary window. Including the most recent boundary increases the cohort
+shared with manual migrations, at the cost that transactions anchored to it
+could only have been produced by wallets that synchronized past that boundary.
+In the first days after activation, every wallet's window is shallow and all
+distributions collapse onto the few boundaries that exist; privacy in that
+regime rests on cohort size (all migrating wallets share those anchors), not
+on anchor diversity.
 
 # Privacy Implications
 
@@ -1476,6 +1478,14 @@ The following alternative designs were considered and rejected.
 
 - **A privacy/speed slider exposed to the user**: the decision and the UI are
   too complex for typical users; the wallet picks sensible defaults instead.
+
+# Acknowledgements
+
+The faster timing parameters and inclusion of the most recent anchor boundary
+were informed by real-world migration data and user feedback gathered by the
+Vizor Wallet team. We especially thank [@dogemos](https://github.com/dogemos)
+and [@thunnini](https://github.com/thunnini) for their analysis and
+recommendations.
 
 # References
 

--- a/zips/zip-0318.md
+++ b/zips/zip-0318.md
@@ -598,14 +598,14 @@ the wallet's own account, and whether its value is a canonical denomination.
   a wallet's transactions to one another (see
   [Rationale for anchor selection](#rationaleforanchorselection)).
 
-* The draw MUST be recency-weighted: the anchor's age $a \geq 0$, measured in
+* The draw MUST be recency-weighted: the anchor's age $a \geq 1$, measured in
   boundaries before the most recent boundary the wallet has observed at
   proving time, is drawn (using a CSPRNG) from a geometric distribution with
-  parameter **1/2** — so the most recent boundary has age zero and is the most
-  probable, and the mean age is one boundary (about three hours). A draw
-  exceeding `ANCHOR_AGE_CAP` (provisionally **4 boundaries**, about twelve
-  hours)
-  or falling outside the candidate set MUST be discarded and redrawn;
+  parameter **1/2** — so the most recent boundary is never used, the most
+  probable age is one boundary, and the mean age is two boundaries (about six
+  hours). A draw exceeding `ANCHOR_AGE_CAP` (provisionally **4 boundaries**,
+  about twelve hours) or falling outside the candidate set MUST be discarded
+  and redrawn;
   equivalently, the distribution is truncated to the candidate set.
 
 * The set of all migration transactions sharing a boundary anchor forms a
@@ -1182,23 +1182,23 @@ already reveals. Third, concentration: the same reasoning that prefers
 canonical denominations to high-entropy amounts prefers few, heavily-used
 anchors to many thinly-used ones; recency weighting produces large per-anchor
 cohorts. Fourth, alignment with manual spends: a conforming wallet making a
-one-off *Orchard*→*Ironwood* spend will naturally use the most recent boundary.
-Giving that boundary age zero lets scheduled migrations join the same anchor
-cohort, instead of partitioning automated and manual traffic by anchor age.
-The cap also bounds the tree states a wallet must retain for proving to the
-last `ANCHOR_AGE_CAP` boundaries.
+one-off *Orchard*→*Ironwood* spend will naturally use a recent boundary, and
+keeping the migration flow's anchor ages similar prevents anchor age from
+partitioning automated and manual traffic. The cap also bounds the tree
+states a wallet must retain for proving to the last `ANCHOR_AGE_CAP`
+boundaries.
 
 The cost of recency weighting is a sharper posterior on proving time (a
 recent anchor implies proving shortly after it); this is blunted by the
 decoupling of proving from broadcast and by the exponential scheduling delay
 between them, which together turn "shortly after the anchor" into a
-multi-boundary window. Including the most recent boundary increases the cohort
-shared with manual migrations, at the cost that transactions anchored to it
-could only have been produced by wallets that synchronized past that boundary.
-In the first days after activation, every wallet's window is shallow and all
-distributions collapse onto the few boundaries that exist; privacy in that
-regime rests on cohort size (all migrating wallets share those anchors), not
-on anchor diversity.
+multi-boundary window. The most recent boundary is excluded entirely because
+transactions anchored to it could only have been produced by wallets that
+synchronized within the current boundary interval — the bottleneck in
+miniature. In the first days after activation, every wallet's window is
+shallow and all distributions collapse onto the few boundaries that exist;
+privacy in that regime rests on cohort size (all migrating wallets share
+those anchors), not on anchor diversity.
 
 # Privacy Implications
 


### PR DESCRIPTION
Reduce preparation and transfer delay means based on observed migration rates
and user impatience feedback while retaining the existing tail caps. Include
the most recent anchor boundary to mix scheduled transfers with manual
migrations.

## Parameter changes

- Change the preparation delay from a mean of 24 blocks (about 30 minutes) and
  a maximum of 96 blocks (about 2 hours), to a mean of 16 blocks (about
  20 minutes) with the same 96-block maximum.
- Change the migration latency from a mean of 144 blocks (about 3 hours) and a
  maximum of 576 blocks (about 12 hours), to a mean of 66 blocks (about
  90 minutes) with the same 576-block maximum. A 66-block mean roughly halves
  the expected inter-transfer latency while retaining the longer Poisson tail. 
  Its half when you account for the tail resampling behavior lowering the old-mean)
- Change anchor-age selection from $a \geq 1$ to $a \geq 0$, allowing scheduled
  migrations to join the most recent anchor cohort used by manual migrations.
- Change `ANCHOR_AGE_CAP` from 16 boundaries (about 2 days) to 4 boundaries
  (about 12 hours). Lowers the distinguisher of how old your wallet is.

## Acknowledgements

Thanks to the Vizor Wallet team, especially @dogemos and @thunnini, for the
analysis and recommendations. Thanks to @Kenbak for gathering the migration
data that informed these changes.
