### PR TITLE
ZIP 0: Add Marek as a ZIP editor for the Zcash Foundation

### DIFF
--- a/zips/zip-0000.rst
+++ b/zips/zip-0000.rst
@@ -6,6 +6,7 @@
           Mark Henderson <mark@shieldedlabs.net>
           Daira-Emma Hopwood <daira@jacaranda.org>
           Arya <arya@zfnd.org>
+          Marek <marek@zfnd.org>
           Kris Nuttycombe <kris@nutty.land>
           Sam H. Smith <sam@shieldedlabs.net>
           Sean Bowe <sean@bowe.tech>
@@ -191,7 +192,7 @@ The current ZIP Editors are:
 
 * Jack Grigg, Daira-Emma Hopwood, and Kris Nuttycombe in their individual
   capacities.
-* Arya, associated with the Zcash Foundation.
+* Arya and Marek, associated with the Zcash Foundation.
 * Mark Henderson and Sam H. Smith, associated with Shielded Labs.
 * Sean Bowe and Tal Derei, associated with Project Tachyon.
 * Dev Ojha, associated with Valar Group.


### PR DESCRIPTION
Adds Marek as a ZIP editor for the Zcash Foundation in `zips/zip-0000.rst`.