### PR TITLE
Bulk synchronization: v2 protocol primitives and Block Chain Synchronization ZIP

### DIFF
--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -1,0 +1,219 @@
+    ZIP: XXX
+    Title: Block Chain Synchronization
+    Owners: Arya <arya@zfnd.org>
+    Status: Draft
+    Category: Network
+    Created: 2026-08-06
+    License: MIT
+    Discussions-To: <https://github.com/zcash/zips/issues/352>
+
+
+# Terminology
+
+The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", "MAY", and
+"RECOMMENDED" in this document are to be interpreted as described in BCP 14
+[^BCP14] when, and only when, they appear in all capitals.
+
+The terms "Mainnet" and "Testnet" are to be interpreted as described in
+section 3.12 of the Zcash Protocol Specification. [^protocol-networks]
+
+The term "block chain" in this document is to be interpreted as described in
+section 3.3 of the Zcash Protocol Specification. [^protocol-blockchain]
+
+The term "v2 protocol" in this document refers to the version 2 Zcash P2P
+network protocol [^draft-p2p-v2]. The terms "peer" and "request stream", the
+`get-headers`, `get-blocks`, `get-tx`, and `get-hashes` request stream
+types, and the synchronization rules of that protocol, are to be interpreted
+as defined there.
+
+best chain
+:   The consensus block chain that a node considers current, as determined by
+    the consensus rules; its *tip* is its highest block.
+
+validated tip
+:   The highest block that a node has accepted into its best chain under the
+    v2 protocol's synchronization rules.
+
+synchronization strategy
+:   A procedure by which a node advances its validated tip toward the network
+    chain tip, using the request streams of the v2 protocol.
+
+checkpoint
+:   A (height, block hash) pair that a synchronizing node treats as
+    authoritative for the block at that height.
+
+checkpoint spacing
+:   The height interval between a node's consecutive checkpoints.
+
+hash chunk
+:   A list of checkpointed block hashes covering a contiguous span of block
+    heights, used as the unit of commitment and verification.
+
+trusted commitment
+:   Data, obtained by a node through a channel it already trusts (for
+    example, compiled into its binary or supplied by local configuration),
+    that binds the block hashes of its checkpoints — for example, a list of
+    hash chunk hashes.
+
+
+# Abstract
+
+This ZIP recommends how a node synchronizes the block chain over the version
+2 Zcash P2P network protocol. The v2 protocol defines the synchronization
+primitives — `get-headers`, `get-blocks`, `get-hashes` — and the rules that
+any use of them must satisfy; this ZIP recommends concrete *synchronization
+strategies* satisfying those rules — headers-first synchronization and
+*checkpointed synchronization* — and how a node selects between them.
+
+
+# Motivation
+
+The recommended checkpointed strategy exists because headers-first
+synchronization is expensive for deep history. A serialized Zcash block
+header is 1487 bytes on Mainnet and Testnet (including the Equihash
+solution), and `get-headers` responses are limited to 160 headers, so
+synchronizing the header chain from genesis at a Mainnet height of roughly
+3.4 million blocks transfers about 5 GB of headers in more than 21,000
+sequential round trips — and every one of those headers is transferred again
+inside its full block. Nodes that ship with checkpoints do not need the
+standalone header pass for the checkpointed span: the authenticity of a
+downloaded block there is established by its hash chain to a checkpoint.
+What they need from the network is block *hashes* — 32 bytes each, up to
+50,000 per `get-hashes` response — as checkpoint data to verify and as
+download handles for `get-blocks`.
+
+Checkpoints themselves also motivate this design. The Zebra implementation
+compiles in checkpoint lists that record a block hash at least every 400
+blocks — several hundred kilobytes of hashes that grow with the chain and
+must be regenerated for each release. Under the checkpointed strategy, a
+node can instead compile in only a short list of hash chunk hashes (its
+trusted commitment), obtain the chunks themselves from untrusted peers via
+`get-hashes`, and verify them; the compiled-in data shrinks from hundreds of
+kilobytes to a few kilobytes without weakening the trust model, since both
+are trusted only because they are part of the binary.
+
+
+# Specification
+
+The synchronization rules of the v2 protocol [^draft-p2p-v2] apply to every
+strategy below and are not restated here.
+
+In addition to those rules, this ZIP recommends that a node SHOULD spread
+block downloads across multiple peers rather than depending on one — this
+turns the v2 protocol's stalling timeout into a recovery mechanism — and
+SHOULD compare the chains offered by several peers (for example, by their
+advertised `start_height` and by probing with `get-headers`) before
+committing its download budget to one.
+
+## Recommended Strategies
+
+A node implements headers-first synchronization (the v2 protocol's fallback
+rule requires it) and MAY implement checkpointed synchronization.
+
+### Headers-First Synchronization
+
+Headers-first synchronization is specified in the v2 protocol
+[^draft-p2p-v2]. It is the full-validation strategy: it assumes no trusted
+commitments, and every accepted block is validated under the consensus
+rules.
+
+### Checkpointed Synchronization
+
+A node MAY synchronize the portion of the block chain covered by a trusted
+commitment as follows. Per the v2 protocol, the commitment scheme — the
+checkpoint spacing, the chunk boundaries, and the hash function used to
+commit to each chunk — is local to the synchronizing node.
+
+1. **Obtain checkpoint hashes.** The node requests the hashes of its
+   checkpoint heights with `get-hashes` requests whose `stride` is its
+   checkpoint spacing.
+
+2. **Verify them against the trusted commitment.** The node reassembles the
+   returned hashes into hash chunks and verifies each chunk against the
+   trusted commitment. A response that does not match is discarded without
+   a misbehavior penalty and the request MAY be retried with a different
+   peer. Hashes are checkpoints only once verified.
+
+3. **Obtain per-height hashes.** For each inter-checkpoint range being
+   synchronized, the node requests the hashes of every block in the range
+   with `get-hashes` requests with `stride = 1`. These hashes cannot be
+   verified in isolation and serve only as download handles; a mismatch
+   with the checkpoints is detected in step 5.
+
+4. **Download blocks.** The node downloads the corresponding blocks with
+   `get-blocks` requests, observing the v2 protocol's download parameters.
+
+5. **Validate against the checkpoints.** For each inter-checkpoint range,
+   the node verifies that the downloaded blocks form a hash chain: each
+   block's header hashes to the hash by which the block was requested, each
+   block's `hashPrevBlock` is the hash of its predecessor, the first
+   block's `hashPrevBlock` is the checkpoint (or previously validated
+   block) below the range, and the last block's hash is the verified
+   checkpoint hash at the top of the range. A range that fails this check
+   is discarded and MAY be re-fetched from different peers, without a
+   misbehavior penalty; provably invalid blocks are scored as specified by
+   the v2 protocol. The node then accepts the range's blocks, applying
+   whatever abbreviated validation its local policy permits for
+   checkpoint-authenticated blocks under the v2 protocol's validated
+   advancement rule.
+
+Steps 1–5 pipeline naturally: distinct ranges MAY be fetched and validated
+concurrently from different peers, subject to the download parameters, and
+contiguous validated ranges extend the node's validated tip in height
+order.
+
+## Strategy Selection
+
+A synchronizing node SHOULD proceed as follows:
+
+1. If it has a trusted commitment covering heights above its current
+   validated tip, it SHOULD use checkpointed synchronization for the
+   covered span, up to the reorganization margin of the synchronization
+   rules: checkpointed synchronization strictly dominates headers-first
+   synchronization over that span in bandwidth, round trips, and validation
+   cost.
+
+2. For heights above the span covered by its trusted commitment — including
+   the entire chain, if it has no trusted commitment — it uses
+   headers-first synchronization.
+
+3. If a peer refuses `get-hashes` (with `REFUSED` or
+   `UNSUPPORTED_STREAM_TYPE`), the node MAY retry with other peers, and
+   SHOULD fall back to headers-first synchronization if too few of its
+   peers serve `get-hashes` to sustain checkpointed synchronization.
+
+
+# Security and Privacy Considerations
+
+The security properties of the strategies are analyzed in the v2 protocol's
+security considerations [^draft-p2p-v2]. Both recommended strategies satisfy
+its synchronization rules, so the choice between them — including falling
+back from checkpointed to headers-first synchronization — affects
+performance, not the integrity of the resulting chain.
+
+**Fingerprinting.** The heights and strides a node requests reveal its
+checkpoint spacing and synchronization progress, which may identify its
+implementation and version. This is comparable to the fingerprinting
+surface of headers-first synchronization and of the `user_agent` field, and
+carries the same mitigation: nodes concerned about it can align their
+request patterns with common implementations.
+
+
+# Deployment
+
+This ZIP depends on the v2 protocol [^draft-p2p-v2], which specifies the
+`get-hashes` request stream and the synchronization rules. No version gating
+is required beyond the v2 protocol's own deployment: refusal of `get-hashes`
+degrades gracefully to headers-first synchronization (see
+[Strategy Selection](#strategyselection)).
+
+
+# References
+
+[^BCP14]: [Information on BCP 14 — "RFC 2119: Key words for use in RFCs to Indicate Requirement Levels" and "RFC 8174: Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words"](https://www.rfc-editor.org/info/bcp14)
+
+[^protocol-networks]: [Zcash Protocol Specification, Version 2026.8.0 [NU6.3]. Section 3.12: Mainnet and Testnet](protocol/protocol.pdf#networks)
+
+[^protocol-blockchain]: [Zcash Protocol Specification, Version 2026.8.0 [NU6.3]. Section 3.3: The Block Chain](protocol/protocol.pdf#blockchain)
+
+[^draft-p2p-v2]: [Draft ZIP: Version 2 Zcash P2P Network Protocol](draft-arya-jvff-p2p-quic-transport.md)

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -226,25 +226,56 @@ recomputation:
    has already authenticated, so that entries describe known blocks
    rather than the responder's view of a best chain.
 2. Verify the entries against headers that checkpointed synchronization has
-   authenticated: from NU5, rebuild the chain history tree of ZIP 221
-   [^zip-0221] from the supplied roots and counts, and check each block's
-   `hashBlockCommitments` (which binds the history tree root and the
-   authorizing data commitment, ZIP 244 [^zip-0244]) against the rebuilt
-   values — each block's header commits to the history tree containing its
-   parent's data, so verification runs one block behind the supplied
-   entries. Between Sapling and NU5, check each supplied Sapling root
-   directly against the header's `hashFinalSaplingRoot`. Before a pool's
-   activation, the supplied root MUST be the empty tree root.
-3. A verified root replaces the recomputation: the node adopts the root,
-   maintains tree *frontiers* only at strategy boundaries (where full
-   per-block validation resumes), and stores what its serving obligations
-   require.
+   authenticated. Which check applies depends on what the block's header
+   commits to at that height, which changes at Heartwood — *not* at NU5:
+
+   - **Between Sapling activation and Heartwood activation**, the header
+     field at offset 4 (`hashFinalSaplingRoot`) is the block's Sapling note
+     commitment tree root. Each supplied Sapling root is checked directly
+     against it.
+   - **From Heartwood activation**, ZIP 221 [^zip-0221] repurposes that
+     field to carry the chain history root (`hashChainHistoryRoot`, and
+     from NU5 `hashBlockCommitments`, which binds the chain history root
+     together with the authorizing data commitment of ZIP 244
+     [^zip-0244]). A direct comparison against a note commitment tree root
+     is therefore *not* a valid check anywhere above Heartwood. The node
+     instead rebuilds the chain history tree from the supplied roots and
+     counts and checks the rebuilt values against each header. Each
+     block's header commits to the history tree containing its *parent's*
+     data, so an entry is verified only once the *following* block's
+     header has been checked against it.
+   - **Before a pool's activation** at the entry's height, the entry's
+     root field is 32 zero bytes and its count is 0, as the v2 protocol
+     requires [^draft-p2p-v2]; an entry that deviates fails verification.
+   - **A root that no header commits to** at the entry's height is not
+     verifiable by this procedure. The chain history tree leaf of ZIP 221
+     binds the Sapling and (from NU5) Orchard roots, but defines no
+     Ironwood field, so no header authenticates an Ironwood root.
+
+3. A **verified** root replaces the recomputation: the node adopts the
+   root, maintains tree *frontiers* only at strategy boundaries (where
+   full per-block validation resumes), and stores what its serving
+   obligations require. A node MUST NOT adopt a root that the procedure of
+   step 2 has not verified against an authenticated header, and MUST
+   recompute that pool's tree from the blocks' note commitments instead.
+   Two cases in particular are not verified by an entry's own arrival:
+
+   - Because verification above Heartwood runs one block behind, the
+     highest entry of a response is unverified until the entry for the
+     following block is obtained and checked against its header. A node
+     either extends the requested range by one entry or holds the highest
+     entry unadopted.
+   - Entries MAY be obtained and verified in any order, but each entry is
+     adopted only when its own check passes; an entry at the boundary of a
+     range is not adopted merely because its neighbours were.
+
 4. An entry that fails verification is discarded with a misbehavior penalty
    (per the v2 protocol); the node falls back to recomputing that span's
    trees locally.
 
 No additional trust is involved: every adopted root is authenticated by a
-header that is itself authenticated by the trusted commitment.
+header that is itself authenticated by the trusted commitment, and a root
+that no header authenticates is never adopted.
 
 ### Spentness Hints
 
@@ -257,11 +288,37 @@ and make historical commits order-independent, at the cost of a small hint
 artifact whose wrongness can only ever cause synchronization to fail, never
 to accept invalid state.
 
-The node draws a uniformly random secret *salt* for each synchronization
-attempt, and maintains additive aggregates of salted hashes
-(`H(salt ‖ item)`, summed with wrapping addition), one per aggregate
-described below. An attacker who cannot predict the salt cannot craft items
-whose hashes cancel.
+The node draws a fresh secret *salt* for each synchronization attempt and
+maintains an additive aggregate for each of the item classes described
+below. The aggregate is a sum of keyed hashes, and its parameters are
+security-critical: the guarantee that a wrong hint can only cause failure
+rests on an attacker being unable to construct items whose hashes cancel.
+They are therefore specified rather than left to the implementation:
+
+- The **salt** is 32 bytes drawn from a cryptographically secure random
+  number generator, freshly for each synchronization attempt. It MUST NOT
+  be transmitted, logged, or derived from any peer-supplied or otherwise
+  predictable value, and MUST NOT be reused across attempts.
+- Each item's hash is `H_a(item) = BLAKE2b-256(item)` computed with the
+  salt as the BLAKE2b *key* and a per-aggregate 16-byte personalization
+  string `a` (for example `b"ZcashHintTrans\x00\x00"` for the transparent
+  aggregate and `b"ZcashHintNfSapl"` and the corresponding names for each
+  nullifier pool). Keying — rather than prefixing the salt to the message
+  — makes the construction a pseudorandom function and is not subject to
+  length extension, and the personalization domain-separates the
+  aggregates so that a cancellation in one cannot be transplanted into
+  another.
+- The aggregate is the sum of those hashes, interpreted as 256-bit
+  little-endian unsigned integers, **modulo 2^256**. The wide accumulator
+  is what makes an accidental or forged cancellation negligible; a
+  machine-word accumulator would admit a false zero with probability
+  around 2^-32 per attempt, which is not a sufficient margin for a check
+  whose failure is a silent retry rather than a ban.
+
+A pseudorandom function of a secret key is required, not merely "some
+hash": an affine hash such as keyed multiply-shift or a polynomial hash is
+linear over the accumulator group, so cancellation relations hold for
+*every* key and secrecy of the salt would provide no protection at all.
 
 **Transparent outputs.** A *spentness hint artifact* — bound by the trusted
 commitment and fetched like any other artifact — carries one bit per
@@ -302,15 +359,43 @@ construction and verification:
 **Value pools.** No lookups are needed for value tracking either: shielded
 pool balances are sums of the blocks' value balance fields, which commute,
 and the transparent pool balance at the terminal height is the sum of the
-constructed UTXO set's amounts.
+constructed UTXO set's amounts. These are consensus quantities, not
+aggregates: they MUST be accumulated with checked arithmetic that detects
+overflow, and a node MUST NOT reuse the deliberately modular arithmetic of
+the hint aggregates for them.
 
-Because no step reads state written by an earlier block, blocks and ranges
-MAY be verified and committed in any order within the span, and the
-per-input reads and per-output deletes disappear entirely. A nonzero
-aggregate at the terminal height means the hints, the snapshot sets, or
-the delivered blocks were wrong; the node discards the affected state and
-falls back to checkpointed synchronization without hints. As with all
-synchronization data in this ZIP, wrong hints produce failure, not fraud.
+**What order-independence does and does not cover.** The state construction
+above reads no state written by an earlier block, so the *construction* —
+the UTXO set, the nullifier sets, the aggregates, and the value pool
+totals — is order-independent, and blocks and ranges MAY be verified and
+committed in any order within the span. The per-input reads and per-output
+deletes disappear entirely.
+
+Order-independence does not extend to consensus rules whose outcome is not
+a function of the terminal totals. A node applying hints MUST account for
+each of the following, either by checking it in height order or by
+recording it as covered by the trusted commitment under the v2 protocol's
+validated advancement rule:
+
+- **Non-negative pool balances at every block.** ZIP 209 [^zip-0209]
+  requires rejecting a block at which any chain value pool balance would
+  become negative. A terminal total says nothing about a running balance
+  that dips negative at an interior height and recovers; below the final
+  checkpoint this rule is among those vouched for by the trusted
+  commitment, and above it, blocks are committed in height order under
+  full validation.
+- **Coinbase maturity and the pre-NU5 shielded-coinbase rule**, which
+  depend on the creation height and coinbase status of the *spent* output
+  — exactly the lookup that hints remove. A hint artifact that is used
+  above the reach of a trusted commitment MUST therefore carry, per output
+  hinted spent, the output's creation height and whether it was a coinbase
+  output, so that the check remains local to the spending block.
+
+A nonzero aggregate at the terminal height means the hints, the snapshot
+sets, or the delivered blocks were wrong; the node discards the affected
+state and falls back to checkpointed synchronization without hints. As with
+all synchronization data in this ZIP, wrong hints produce failure, not
+fraud.
 
 ### Snapshot Synchronization
 
@@ -333,10 +418,16 @@ A node with no chain state MAY become operational at a *snapshot height*
    frontiers (via their header-committed roots) and the chain history tree
    (via `hashBlockCommitments` of the following block, ZIP 221 [^zip-0221])
    — MUST be verified against headers authenticated by the trusted
-   commitment. The parts the chain does not commit to (the transparent UTXO
-   set, the nullifier sets, the Sprout tree) are authenticated solely by
-   the manifest commitment, which therefore carries the same trust as the
-   node's binary — the trust model of the checkpoints themselves.
+   commitment. Because the chain history tree at `H` is committed by the
+   *following* block's header, the trusted commitment MUST authenticate
+   the header at height `H + 1` for that verification to be possible; a
+   commitment that stops at `H` leaves the chain history tree unverified,
+   and the node MUST treat it as an uncommitted component. The parts the
+   chain does not commit to (the transparent UTXO set, the nullifier sets,
+   the Sprout tree, and the chain value pool balances) are authenticated
+   solely by the manifest commitment, which therefore carries the same
+   trust as the node's binary — the trust model of the checkpoints
+   themselves.
 4. **Begin operating at `H`**: validate blocks above `H` under the
    consensus rules (or checkpointed synchronization, where commitments
    reach above `H`), participate fully in relay, and serve the blocks it
@@ -347,12 +438,42 @@ A node with no chain state MAY become operational at a *snapshot height*
    below `H` using checkpointed synchronization, at low priority, and
    advertise `NODE_NETWORK` when complete. Backfill SHOULD use the
    snapshot's own sets as spentness hints (see
-   [Spentness Hints](#spentnesshints)): when the aggregates check out at
-   `H`, the node has *verified* the snapshot's transparent UTXO set and
-   nullifier sets against the chain, discharging the only components of
-   the snapshot that were trusted without chain verification. A node MAY
-   instead operate indefinitely without deep history (pruned operation),
-   never advertising `NODE_NETWORK`.
+   [Spentness Hints](#spentnesshints)), which reconciles the snapshot's
+   uncommitted components against the chain the node has just replayed.
+
+   The reconciliation discharges the snapshot's trust only to the extent
+   that each component is actually compared, so each MUST be covered
+   explicitly. A comparison over outpoints alone is **not** sufficient: a
+   snapshot entry that no span output ever created contributes no term to
+   the spend-cancellation aggregate, so a fabricated or amount-inflated
+   UTXO would pass unnoticed. Backfill therefore verifies, at `H`:
+
+   - **The transparent UTXO set**, by an aggregate over whole entries
+     rather than outpoints. The node adds `H_a` of each entry it
+     constructs — the outpoint, the value, the `scriptPubKey`, the
+     creation height, and the coinbase flag, in a canonical encoding —
+     and subtracts `H_a` of each entry of the snapshot's set as it
+     streams it in. Neither side performs a lookup. A zero aggregate
+     proves the two sets are equal as sets of complete entries, so a
+     phantom outpoint, an inflated value, or an altered script is caught.
+   - **The nullifier sets**, by the aggregates already described.
+   - **The Sprout note commitment tree**, which no header commits to, by
+     recomputing it from the JoinSplit note commitments of the replayed
+     blocks and comparing the resulting root and frontier. Sprout is a
+     closed pool of bounded size, so this is inexpensive.
+   - **The chain value pool balances**, by recomputing them over the
+     replayed span (with checked arithmetic, see
+     [Spentness Hints](#spentnesshints)) and comparing them to the
+     snapshot's.
+
+   When all four check out, the snapshot's uncommitted components have been
+   verified against the chain and the node's trust base is that of a fully
+   synchronized node. Until they do, they remain trusted on the strength of
+   the commitment. A mismatch in any of them means the snapshot was wrong:
+   the node discards it and falls back to checkpointed synchronization from
+   genesis. A node MAY instead operate indefinitely without deep history
+   (pruned operation), never advertising `NODE_NETWORK`; such a node never
+   discharges the snapshot's trust.
 
 Snapshot heights SHOULD lie at least the v2 protocol's reorganization
 margin below the network tip at the time the commitment is published, and
@@ -452,14 +573,17 @@ authenticated by header commitments; artifacts are authenticated by the
 trusted commitment; and the only data trusted without chain verification
 (the snapshot's uncommitted state components) carries exactly the trust of
 the binary that shipped the commitment, as the checkpoints already do —
-and even that trust is discharged when hint-verified backfill completes
-(see [Spentness Hints](#spentnesshints)). Malicious synchronization data
-produces failure, not fraud: every verification failure is detected and
-routed around, and is attributed and penalized where blame is provable
-under the v2 protocol's misbehavior rules. (Two failures are deliberately
-*not* attributed: a nonzero hint aggregate, which implicates the hints,
-the snapshot sets, or the blocks without distinguishing them, and an
-assembled artifact piece whose ranges came from several peers — see
+and that trust is discharged, for each component the reconciliation of
+[Snapshot Synchronization](#snapshotsynchronization) step 5 actually
+compares, when hint-verified backfill completes (see
+[Spentness Hints](#spentnesshints)). A node that never backfills never
+discharges it. Malicious synchronization data produces failure, not
+fraud: every verification failure is detected and routed around, and is
+attributed and penalized where blame is provable under the v2 protocol's
+misbehavior rules. (Two failures are deliberately *not* attributed: a
+nonzero hint aggregate, which implicates the hints, the snapshot sets,
+or the blocks without distinguishing them, and an assembled artifact
+piece whose ranges came from several peers — see
 [Download Scheduling](#downloadscheduling).) Spentness hints in
 particular cannot cause acceptance of an incorrect state — a wrong hint
 surfaces as a nonzero aggregate.
@@ -501,6 +625,8 @@ interchangeably with `get-object` peers.
 [^protocol-blockchain]: [Zcash Protocol Specification, Version 2026.8.0 [NU6.3]. Section 3.3: The Block Chain](protocol/protocol.pdf#blockchain)
 
 [^draft-p2p-v2]: [Draft ZIP: Version 2 Zcash P2P Network Protocol](draft-arya-jvff-p2p-quic-transport.md)
+
+[^zip-0209]: [ZIP 209: Prohibit Negative Shielded Chain Value Pool Balances](zip-0209.rst)
 
 [^zip-0221]: [ZIP 221: FlyClient - Consensus-Layer Changes](zip-0221.rst)
 

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -424,9 +424,9 @@ A node with no chain state MAY become operational at a *snapshot height*
 3. **Verify the state against the chain where possible.** The snapshot
    contains, at minimum: the transparent UTXO set; the Sprout, Sapling,
    Orchard, and Ironwood nullifier sets; the note commitment tree frontiers
-   of each pool; the chain history tree; and the shielded chain value pool
-   balances. (The transparent pool balance is not carried: it is the sum
-   of the UTXO set's amounts, computed locally.)
+   of each pool; the chain history tree; and the chain value pool
+   balances, which the node needs as the starting point for the
+   pool-balance consensus rules above `H`.
    The parts that the chain commits to — the Sapling, Orchard, and Ironwood
    frontiers (via their header-committed roots) and the chain history tree
    (via `hashBlockCommitments` of the following block, ZIP 221 [^zip-0221])
@@ -437,7 +437,7 @@ A node with no chain state MAY become operational at a *snapshot height*
    commitment that stops at `H` leaves the chain history tree unverified,
    and the node MUST treat it as an uncommitted component. The parts the
    chain does not commit to (the transparent UTXO set, the nullifier sets,
-   the Sprout tree, and the shielded pool balances) are authenticated
+   the Sprout tree, and the chain value pool balances) are authenticated
    solely by the manifest commitment, which therefore carries the same
    trust as the node's binary — the trust model of the checkpoints
    themselves.
@@ -473,11 +473,10 @@ A node with no chain state MAY become operational at a *snapshot height*
      recomputing it from the JoinSplit note commitments of the replayed
      blocks and comparing the resulting root and frontier. Sprout is a
      closed pool of bounded size, so this is inexpensive.
-   - **The shielded chain value pool balances**, by recomputing them over
-     the replayed span (with checked arithmetic, see
+   - **The chain value pool balances**, by recomputing them over the
+     replayed span (with checked arithmetic, see
      [Spentness Hints](#spentnesshints)) and comparing them to the
-     snapshot's. The transparent pool balance needs no separate check: it
-     is implied by the whole-entry comparison of the UTXO set.
+     snapshot's.
 
    When all four check out, the snapshot's uncommitted components have been
    verified against the chain and the node's trust base is that of a fully

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -153,14 +153,16 @@ A node's trusted commitment binds the data its strategies rely on:
   verified known-hash list makes every listed hash an anchor, and its span
   metadata gives per-height sizes and costs for scheduling.
 
-  The commitment MAY additionally bind, for each height range, the
-  SHA-256 hash of that range's *spentness-hint chunk* — the hint bits for
-  the transparent outputs created in the range (see
-  [Spentness Hints](#spentnesshints)) — obtained like any artifact and
-  verified against these hashes. Unlike entry chunks, hint chunks are
-  functions of the list's terminal height as well as of the chain, so
-  extending the commitment's coverage changes every hint-chunk hash while
-  leaving the entry-chunk hashes stable.
+  The commitment MAY additionally bind a single SHA-256 hash of the
+  *spentness hints*: the hint bits for every transparent output created
+  at or below the final checkpoint (see
+  [Spentness Hints](#spentnesshints)), serialized in canonical order,
+  obtained like any artifact and verified whole against this hash. The
+  hints are committed separately from the entry chunks — one hash rather
+  than one per range — because they are a function of the final
+  checkpoint height as well as of the chain: extending the commitment's
+  coverage would change every per-range hint hash anyway, while the
+  entry-chunk hashes stay stable.
 - **A snapshot manifest hash**, for snapshot synchronization (see
   [Snapshot Synchronization](#snapshotsynchronization)).
 
@@ -290,8 +292,8 @@ committing historical blocks is random access: looking up and deleting each
 transparent input's spent output, and inserting (and, under full
 validation, membership-testing) each revealed nullifier. Spentness hints —
 adapted from Bitcoin's SwiftSync [^swiftsync] — eliminate the random access
-and make historical commits order-independent, at the cost of small hint
-chunks bound by the same commitment as the known-hash list, whose wrongness
+and make historical commits order-independent, at the cost of a small hint
+bitmap bound by the trusted commitment, whose wrongness
 can only ever cause synchronization to fail, never to accept invalid state.
 Hints apply only within the reach of the trusted commitment: a node MUST
 NOT apply them above the final checkpoint.
@@ -328,13 +330,12 @@ hash": an affine hash such as keyed multiply-shift or a polynomial hash is
 linear over the accumulator group, so cancellation relations hold for
 *every* key and secrecy of the salt would provide no protection at all.
 
-**Transparent outputs.** Each known-hash range's spentness-hint chunk (see
-[Synchronization Data](#synchronizationdata)) carries one bit per
-transparent output created in the range, in canonical order
-(by block height, then transaction index, then output index): whether the
-output is still unspent at the *terminal height* — the highest height the
-commitment's hint chunks cover, at or below the final checkpoint. During
-the span:
+**Transparent outputs.** The spentness hints (see
+[Synchronization Data](#synchronizationdata)) carry one bit per
+transparent output created at or below the *terminal height* — the final
+checkpoint — in canonical order (by block height, then transaction index,
+then output index): whether the output is still unspent at that height.
+During the span:
 
 - An output hinted *unspent* is written to the transparent UTXO set as it
   is created — and, during the span, never looked up or deleted.

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -185,15 +185,17 @@ known-hash list as follows:
    using the span metadata toward a byte target (see
    [Download Scheduling](#downloadscheduling)), each ending at a listed
    height. Any listed hash can end a unit, so unit boundaries are chosen
-   freely — by bytes, not by a fixed block count.
+   freely — by bytes, not by a fixed block count — and each unit's
+   request carries the byte target as its `max_bytes` bound.
 
 3. **Stream each unit with `get-block-range`**, anchored at the unit's
    final hash. Delivery is descending, so each delivered block is verified
    on arrival: it must hash to the anchor or to the previously delivered
-   block's `hashPrevBlock`, and (as a cross-check) must match the
-   known-hash list at its height. A truncated or cancelled unit keeps its
-   verified prefix, and the remainder is re-requested from any peer using
-   the next expected hash as its anchor.
+   block's `hashPrevBlock`, carry transactions matching its header, and
+   (as a cross-check) match the known-hash list at its height. A
+   truncated or cancelled unit keeps its verified prefix, and the
+   remainder is re-requested from any peer using the next expected hash
+   as its anchor.
 
 4. **Commit** each completed range in height order, applying whatever
    abbreviated validation local policy permits for
@@ -202,10 +204,13 @@ known-hash list as follows:
    [Verified Tree Roots](#verifiedtreeroots) are available.
 
 A node with a commitment that binds only spaced checkpoint hashes (rather
-than a full known-hash list) applies the same procedure with units ending
-at checkpoint heights; interior per-block cross-checks are then
-unavailable, but the descending hash chain still authenticates every
-delivered block against the checkpoint anchor.
+than a full known-hash list) applies the same procedure with units
+anchored at checkpoint heights; interior per-block cross-checks and
+advance sizing are then unavailable, but neither is needed: the request's
+`max_bytes` bound makes each stream a byte-sized unit regardless of block
+sizes, the descending hash chain authenticates every delivered block
+against the checkpoint anchor, and the node continues the span by
+re-anchoring on the next expected hash.
 
 ### Verified Tree Roots
 
@@ -238,6 +243,72 @@ recomputation:
 
 No additional trust is involved: every adopted root is authenticated by a
 header that is itself authenticated by the trusted commitment.
+
+### Spentness Hints
+
+After tree work is eliminated, the dominant remaining state cost of
+committing historical blocks is random access: looking up and deleting each
+transparent input's spent output, and inserting (and, under full
+validation, membership-testing) each revealed nullifier. Spentness hints —
+adapted from Bitcoin's SwiftSync [^swiftsync] — eliminate the random access
+and make historical commits order-independent, at the cost of a small hint
+artifact whose wrongness can only ever cause synchronization to fail, never
+to accept invalid state.
+
+The node draws a uniformly random secret *salt* for each synchronization
+attempt, and maintains additive aggregates of salted hashes
+(`H(salt ‖ item)`, summed with wrapping addition), one per aggregate
+described below. An attacker who cannot predict the salt cannot craft items
+whose hashes cancel.
+
+**Transparent outputs.** A *spentness hint artifact* — bound by the trusted
+commitment and fetched like any other artifact — carries one bit per
+transparent output created in the synchronized span, in canonical order
+(by block height, then transaction index, then output index): whether the
+output is still unspent at the span's terminal height. During the span:
+
+- An output hinted *unspent* is written to the transparent UTXO set as it
+  is created — and, during the span, never looked up or deleted.
+- An output hinted *spent* is never stored; its outpoint is added to the
+  transparent aggregate.
+- Every transparent input subtracts its referenced outpoint from the
+  transparent aggregate. No lookup is performed.
+
+At the terminal height, the transparent aggregate MUST be exactly zero:
+the multiset of outputs hinted spent then equals the multiset of outputs
+actually spent, so the constructed UTXO set is exactly the set of
+never-spent outputs, without a single random read.
+
+**Nullifiers.** The nullifier sets never shrink, so no per-item hint is
+needed; what the hint mechanism provides instead is lookup-free
+construction and verification:
+
+- When synchronizing below a snapshot (backfill), the snapshot's nullifier
+  set for each pool serves as the hint: the node adds every member of the
+  snapshot set to that pool's aggregate — verifying while streaming it in
+  sorted order that its elements are strictly increasing, hence distinct —
+  and subtracts every nullifier revealed by the span's blocks. A zero
+  aggregate at the snapshot height proves the nullifiers revealed in the
+  span are exactly the snapshot set, and therefore that no nullifier was
+  revealed twice.
+- Without a snapshot, the node accumulates revealed nullifiers per pool
+  and constructs each set in one batch (for example, by external sort) at
+  the terminal height, checking distinctness in the same pass; per-spend
+  membership tests below the final checkpoint are vouched for by the
+  trusted commitment.
+
+**Value pools.** No lookups are needed for value tracking either: shielded
+pool balances are sums of the blocks' value balance fields, which commute,
+and the transparent pool balance at the terminal height is the sum of the
+constructed UTXO set's amounts.
+
+Because no step reads state written by an earlier block, blocks and ranges
+MAY be verified and committed in any order within the span, and the
+per-input reads and per-output deletes disappear entirely. A nonzero
+aggregate at the terminal height means the hints, the snapshot sets, or
+the delivered blocks were wrong; the node discards the affected state and
+falls back to checkpointed synchronization without hints. As with all
+synchronization data in this ZIP, wrong hints produce failure, not fraud.
 
 ### Snapshot Synchronization
 
@@ -272,9 +343,14 @@ A node with no chain state MAY become operational at a *snapshot height*
    can serve the most recent 2,304 blocks.
 5. **Backfill in the background.** The node SHOULD backfill the history
    below `H` using checkpointed synchronization, at low priority, and
-   advertise `NODE_NETWORK` when complete; it MAY instead operate
-   indefinitely without deep history (pruned operation), never advertising
-   `NODE_NETWORK`.
+   advertise `NODE_NETWORK` when complete. Backfill SHOULD use the
+   snapshot's own sets as spentness hints (see
+   [Spentness Hints](#spentnesshints)): when the aggregates check out at
+   `H`, the node has *verified* the snapshot's transparent UTXO set and
+   nullifier sets against the chain, discharging the only components of
+   the snapshot that were trusted without chain verification. A node MAY
+   instead operate indefinitely without deep history (pruned operation),
+   never advertising `NODE_NETWORK`.
 
 Snapshot heights SHOULD lie at least the v2 protocol's reorganization
 margin below the network tip at the time the commitment is published, and
@@ -298,10 +374,11 @@ approaches the client's link capacity and no single peer can stall
 progress. A node SHOULD apply the following discipline to bulk transfers
 (`get-block-range` units and `get-object` pieces):
 
-- **Work units of 16–64 MiB**, sized with the known-hash span metadata (for
-  block ranges) or manifest piece sizes (for artifacts). Units near the
-  commit frontier SHOULD be smaller, so the frontier advances promptly;
-  deep lookahead units MAY be larger.
+- **Work units of 16–64 MiB**, realized for block ranges by the request's
+  `max_bytes` bound (with the known-hash span metadata, where available,
+  used to plan unit boundaries in advance), and for artifacts by manifest
+  piece sizes. Units near the commit frontier SHOULD be smaller, so the
+  frontier advances promptly; deep lookahead units MAY be larger.
 - **Pull-based assignment with per-peer budgets.** Maintain an estimate of
   each peer's delivery rate (for example, an exponentially weighted moving
   average); let each peer's connection pull the next unassigned unit
@@ -344,7 +421,8 @@ A synchronizing node SHOULD proceed as follows:
 2. For spans covered by known-hash commitments — backfill below a
    snapshot, or the whole chain when no snapshot is used — it SHOULD use
    checkpointed synchronization, with verified tree roots where peers
-   serve them.
+   serve them and spentness hints where its commitment (or snapshot)
+   provides them.
 3. Above the reach of its commitments, and within the reorganization
    margin of the tip, it uses headers-first synchronization.
 4. Every strategy degrades toward headers-first synchronization when its
@@ -364,9 +442,13 @@ The trust base is unchanged by acceleration: verified tree roots are
 authenticated by header commitments; artifacts are authenticated by the
 trusted commitment; and the only data trusted without chain verification
 (the snapshot's uncommitted state components) carries exactly the trust of
-the binary that shipped the commitment, as the checkpoints already do.
-Malicious synchronization data produces failure, not fraud: every
-verification failure is detected, attributed, penalized, and routed around.
+the binary that shipped the commitment, as the checkpoints already do —
+and even that trust is discharged when hint-verified backfill completes
+(see [Spentness Hints](#spentnesshints)). Malicious synchronization data
+produces failure, not fraud: every verification failure is detected,
+attributed, penalized, and routed around, and spentness hints in
+particular cannot cause acceptance of an incorrect state — a wrong hint
+surfaces as a nonzero aggregate.
 
 **Serving capacity.** Snapshot-synchronized and pruned nodes cannot serve
 deep history; if they became the majority, historical blocks and artifacts
@@ -411,5 +493,7 @@ interchangeably with `get-object` peers.
 [^zip-0244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244.rst)
 
 [^assumeutxo]: [Bitcoin Core: assumeutxo design and usage](https://github.com/bitcoin/bitcoin/blob/master/doc/assumeutxo.md)
+
+[^swiftsync]: [Ruben Somsen: SwiftSync — speeding up IBD with pre-generated hints](https://gist.github.com/RubenSomsen/a61a37d14182ccd78760e477c78133cd)
 
 [^era1]: [era1 archival file format specification](https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md)

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -22,9 +22,10 @@ section 3.3 of the Zcash Protocol Specification. [^protocol-blockchain]
 
 The term "v2 protocol" in this document refers to the version 2 Zcash P2P
 network protocol [^draft-p2p-v2]. The terms "peer" and "request stream", the
-`get-headers`, `get-blocks`, `get-tx`, and `get-hashes` request stream
-types, and the synchronization rules of that protocol, are to be interpreted
-as defined there.
+`get-headers`, `get-blocks`, `get-tx`, `get-hashes`, `get-block-range`,
+`get-tree-roots`, and `get-object` request stream types, the service flags,
+and the synchronization rules of that protocol, are to be interpreted as
+defined there.
 
 best chain
 :   The consensus block chain that a node considers current, as determined by
@@ -42,55 +43,94 @@ checkpoint
 :   A (height, block hash) pair that a synchronizing node treats as
     authoritative for the block at that height.
 
-checkpoint spacing
-:   The height interval between a node's consecutive checkpoints.
-
-hash chunk
-:   A list of checkpointed block hashes covering a contiguous span of block
-    heights, used as the unit of commitment and verification.
-
 trusted commitment
 :   Data, obtained by a node through a channel it already trusts (for
     example, compiled into its binary or supplied by local configuration),
-    that binds the block hashes of its checkpoints — for example, a list of
-    hash chunk hashes.
+    that binds synchronization data the node will rely on — block hashes,
+    and, for snapshot synchronization, a state snapshot manifest.
+
+synchronization artifact
+:   An immutable, content-addressed byte object served via `get-object` —
+    for example, a known-hash chunk file or a snapshot piece. An artifact is
+    identified by the SHA-256 hash of its contents.
+
+known-hash list
+:   The block hashes of every height of a span of the chain, together with
+    per-block sync-cost metadata, bound by a trusted commitment (for
+    example, as the pinned hashes of a list of chunk artifacts).
+
+anchor
+:   A block hash that a synchronizing node has verified against a trusted
+    commitment (directly, or via a verified artifact), against which a
+    `get-block-range` stream authenticates every delivered block.
+
+work unit
+:   A contiguous range of blocks (or a byte range of an artifact) scheduled
+    for download as one request stream.
+
+snapshot
+:   A serialization of a node's chain state at a *snapshot height* `H`,
+    divided into a *manifest* and content-addressed *pieces*, allowing a new
+    node to begin operating at height `H` without downloading or validating
+    the chain below it.
 
 
 # Abstract
 
 This ZIP recommends how a node synchronizes the block chain over the version
 2 Zcash P2P network protocol. The v2 protocol defines the synchronization
-primitives — `get-headers`, `get-blocks`, `get-hashes` — and the rules that
-any use of them must satisfy; this ZIP recommends concrete *synchronization
-strategies* satisfying those rules — headers-first synchronization and
-*checkpointed synchronization* — and how a node selects between them.
+primitives and the rules that any use of them must satisfy; this ZIP
+recommends concrete *synchronization strategies* satisfying those rules —
+headers-first synchronization, *checkpointed synchronization* over anchored
+block-range streams, optionally accelerated by verified note commitment
+tree roots, and *snapshot synchronization*, which makes a new node
+operational in minutes — together with a download scheduling discipline and
+the policy for selecting between the strategies.
 
 
 # Motivation
 
-The recommended checkpointed strategy exists because headers-first
-synchronization is expensive for deep history. A serialized Zcash block
-header is 1487 bytes on Mainnet and Testnet (including the Equihash
-solution), and `get-headers` responses are limited to 160 headers, so
-synchronizing the header chain from genesis at a Mainnet height of roughly
-3.4 million blocks transfers about 5 GB of headers in more than 21,000
-sequential round trips — and every one of those headers is transferred again
-inside its full block. Nodes that ship with checkpoints do not need the
-standalone header pass for the checkpointed span: the authenticity of a
-downloaded block there is established by its hash chain to a checkpoint.
-What they need from the network is block *hashes* — 32 bytes each, up to
-50,000 per `get-hashes` response — as checkpoint data to verify and as
-download handles for `get-blocks`.
+The v2 protocol [^draft-p2p-v2] deliberately specifies synchronization
+primitives, the rules constraining their use, and only one baseline
+procedure — headers-first synchronization. This ZIP recommends the concrete
+procedures, because the difference between a naive procedure and a good one
+is measured in days.
 
-Checkpoints themselves also motivate this design. The Zebra implementation
-compiles in checkpoint lists that record a block hash at least every 400
-blocks — several hundred kilobytes of hashes that grow with the chain and
-must be regenerated for each release. Under the checkpointed strategy, a
-node can instead compile in only a short list of hash chunk hashes (its
-trusted commitment), obtain the chunks themselves from untrusted peers via
-`get-hashes`, and verify them; the compiled-in data shrinks from hundreds of
-kilobytes to a few kilobytes without weakening the trust model, since both
-are trusted only because they are part of the binary.
+Three costs dominate initial synchronization, in ascending order of what
+removing them is worth:
+
+1. **Round trips and scheduling.** The legacy protocol transferred blocks in
+   small per-request batches against individually requested hashes; at
+   typical peer round-trip times this bounds throughput at a few hundred
+   small blocks per second regardless of bandwidth. The v2 protocol's
+   `get-block-range` removes the round trip from the inner loop: blocks
+   stream continuously against a single verified anchor, and per-block
+   download handles are unnecessary.
+
+2. **Validation CPU.** Under checkpointed synchronization, proofs and
+   signatures below the final checkpoint are vouched for by the trusted
+   commitment, and the dominant remaining CPU cost — measured at roughly
+   70% of block-commit time in the Zebra implementation — is recomputing
+   the note commitment trees, leaf by leaf, only to learn per-block roots
+   that are already bound by header commitments. Verified tree roots
+   (`get-tree-roots`) eliminate that recomputation without adding trust.
+
+3. **The historical data itself.** A new node operator's goal is a node at
+   the tip; the chain's full history — hundreds of gigabytes — is the
+   overwhelming share of bytes and time, and most operators need it only
+   eventually (to serve peers) or never (pruned operation). Snapshot
+   synchronization removes it from the critical path entirely: the node
+   installs a verified state snapshot at a recent height and is operational
+   in minutes, backfilling history in the background if it chooses.
+
+Checkpoints themselves also motivate the artifact machinery. The Zebra
+implementation compiles in known-hash lists covering every block — over 100
+MB of hashes that grow with the chain — because the legacy protocol offered
+no way to fetch and verify them. Under this ZIP, a binary need only pin the
+SHA-256 hashes of the chunk artifacts (a few kilobytes); the artifacts
+themselves are fetched from untrusted peers via `get-object` (or any
+mirror) and verified, and every synced node can regenerate them
+byte-identically to serve others.
 
 
 # Specification
@@ -98,114 +138,262 @@ are trusted only because they are part of the binary.
 The synchronization rules of the v2 protocol [^draft-p2p-v2] apply to every
 strategy below and are not restated here.
 
-In addition to those rules, this ZIP recommends that a node SHOULD spread
-block downloads across multiple peers rather than depending on one — this
-turns the v2 protocol's stalling timeout into a recovery mechanism — and
-SHOULD compare the chains offered by several peers (for example, by their
-advertised `start_height` and by probing with `get-headers`) before
-committing its download budget to one.
+## Synchronization Data
+
+A node's trusted commitment binds the data its strategies rely on:
+
+- **Known-hash lists**, as the pinned SHA-256 hashes of chunk artifacts.
+  A node obtains the artifacts from any source — bundled with its release,
+  `get-object` requests to `NODE_SYNC_ARTIFACTS` peers, or out-of-band
+  mirrors — and accepts them only if their hashes match the commitment.
+  Equivalently, a node MAY obtain the same data via `get-hashes` and verify
+  it by reassembling the chunk artifacts and comparing their hashes. A
+  verified known-hash list makes every listed hash an anchor, and its span
+  metadata gives per-height sizes and costs for scheduling.
+- **A snapshot manifest hash**, for snapshot synchronization (see
+  [Snapshot Synchronization](#snapshotsynchronization)).
+
+Chunk artifacts are deterministic functions of the chain, so any node that
+has synchronized the covered span can regenerate them byte-identically and
+serve them; artifact pieces SHOULD be no larger than the `get-object`
+per-request maximum (32 MiB) so each piece is independently fetchable and
+verifiable.
 
 ## Recommended Strategies
 
 A node implements headers-first synchronization (the v2 protocol's fallback
-rule requires it) and MAY implement checkpointed synchronization.
+rule requires it) and MAY implement the others.
 
 ### Headers-First Synchronization
 
 Headers-first synchronization is specified in the v2 protocol
 [^draft-p2p-v2]. It is the full-validation strategy: it assumes no trusted
 commitments, and every accepted block is validated under the consensus
-rules.
+rules. It is also the strategy for the chain near the tip, above the reach
+of commitments, whatever strategy covered the history below.
 
 ### Checkpointed Synchronization
 
-A node MAY synchronize the portion of the block chain covered by a trusted
-commitment as follows. Per the v2 protocol, the commitment scheme — the
-checkpoint spacing, the chunk boundaries, and the hash function used to
-commit to each chunk — is local to the synchronizing node.
+A node MAY synchronize the span of the block chain covered by a verified
+known-hash list as follows:
 
-1. **Obtain checkpoint hashes.** The node requests the hashes of its
-   checkpoint heights with `get-hashes` requests whose `stride` is its
-   checkpoint spacing.
+1. **Obtain and verify the known-hash list** for the target span (see
+   [Synchronization Data](#synchronizationdata)). Every listed hash is now
+   an anchor.
 
-2. **Verify them against the trusted commitment.** The node reassembles the
-   returned hashes into hash chunks and verifies each chunk against the
-   trusted commitment. A response that does not match is discarded without
-   a misbehavior penalty and the request MAY be retried with a different
-   peer. Hashes are checkpoints only once verified.
+2. **Partition the span into work units**: contiguous block ranges, sized
+   using the span metadata toward a byte target (see
+   [Download Scheduling](#downloadscheduling)), each ending at a listed
+   height. Any listed hash can end a unit, so unit boundaries are chosen
+   freely — by bytes, not by a fixed block count.
 
-3. **Obtain per-height hashes.** For each inter-checkpoint range being
-   synchronized, the node requests the hashes of every block in the range
-   with `get-hashes` requests with `stride = 1`. These hashes cannot be
-   verified in isolation and serve only as download handles; a mismatch
-   with the checkpoints is detected in step 5.
+3. **Stream each unit with `get-block-range`**, anchored at the unit's
+   final hash. Delivery is descending, so each delivered block is verified
+   on arrival: it must hash to the anchor or to the previously delivered
+   block's `hashPrevBlock`, and (as a cross-check) must match the
+   known-hash list at its height. A truncated or cancelled unit keeps its
+   verified prefix, and the remainder is re-requested from any peer using
+   the next expected hash as its anchor.
 
-4. **Download blocks.** The node downloads the corresponding blocks with
-   `get-blocks` requests, observing the v2 protocol's download parameters.
-
-5. **Validate against the checkpoints.** For each inter-checkpoint range,
-   the node verifies that the downloaded blocks form a hash chain: each
-   block's header hashes to the hash by which the block was requested, each
-   block's `hashPrevBlock` is the hash of its predecessor, the first
-   block's `hashPrevBlock` is the checkpoint (or previously validated
-   block) below the range, and the last block's hash is the verified
-   checkpoint hash at the top of the range. A range that fails this check
-   is discarded and MAY be re-fetched from different peers, without a
-   misbehavior penalty; provably invalid blocks are scored as specified by
-   the v2 protocol. The node then accepts the range's blocks, applying
-   whatever abbreviated validation its local policy permits for
+4. **Commit** each completed range in height order, applying whatever
+   abbreviated validation local policy permits for
    checkpoint-authenticated blocks under the v2 protocol's validated
-   advancement rule.
+   advancement rule — with tree work eliminated where
+   [Verified Tree Roots](#verifiedtreeroots) are available.
 
-Steps 1–5 pipeline naturally: distinct ranges MAY be fetched and validated
-concurrently from different peers, subject to the download parameters, and
-contiguous validated ranges extend the node's validated tip in height
-order.
+A node with a commitment that binds only spaced checkpoint hashes (rather
+than a full known-hash list) applies the same procedure with units ending
+at checkpoint heights; interior per-block cross-checks are then
+unavailable, but the descending hash chain still authenticates every
+delivered block against the checkpoint anchor.
+
+### Verified Tree Roots
+
+Recomputing the note commitment trees is the dominant CPU cost of
+committing checkpoint-authenticated blocks. A node MAY instead obtain each
+historical block's tree roots with `get-tree-roots` from `NODE_TREE_ROOTS`
+peers and verify them against header commitments, skipping the
+recomputation:
+
+1. For each block in the span, obtain the entry (Sapling, Orchard, and
+   Ironwood roots, shielded transaction counts, and authorizing data
+   commitment).
+2. Verify the entries against headers that checkpointed synchronization has
+   authenticated: from NU5, rebuild the chain history tree of ZIP 221
+   [^zip-0221] from the supplied roots and counts, and check each block's
+   `hashBlockCommitments` (which binds the history tree root and the
+   authorizing data commitment, ZIP 244 [^zip-0244]) against the rebuilt
+   values — each block's header commits to the history tree containing its
+   parent's data, so verification runs one block behind the supplied
+   entries. Between Sapling and NU5, check each supplied Sapling root
+   directly against the header's `hashFinalSaplingRoot`. Before a pool's
+   activation, the supplied root MUST be the empty tree root.
+3. A verified root replaces the recomputation: the node adopts the root,
+   maintains tree *frontiers* only at strategy boundaries (where full
+   per-block validation resumes), and stores what its serving obligations
+   require.
+4. An entry that fails verification is discarded with a misbehavior penalty
+   (per the v2 protocol); the node falls back to recomputing that span's
+   trees locally.
+
+No additional trust is involved: every adopted root is authenticated by a
+header that is itself authenticated by the trusted commitment.
+
+### Snapshot Synchronization
+
+A node with no chain state MAY become operational at a *snapshot height*
+`H` in minutes, deferring or omitting the history below it:
+
+1. **Obtain the manifest** whose SHA-256 hash is bound by the trusted
+   commitment, from any source (`get-object`, mirrors, bundled). The
+   manifest lists the snapshot's content-addressed pieces and their sizes.
+2. **Fetch and verify the pieces** (each ≤ 32 MiB) from
+   `NODE_SYNC_ARTIFACTS` peers via `get-object` and/or out-of-band mirrors,
+   scheduling them like any other work units (see
+   [Download Scheduling](#downloadscheduling)); a piece is accepted only if
+   its hash matches the manifest.
+3. **Verify the state against the chain where possible.** The snapshot
+   contains, at minimum: the transparent UTXO set; the Sprout, Sapling,
+   Orchard, and Ironwood nullifier sets; the note commitment tree frontiers
+   of each pool; the chain history tree; and the chain value pool balances.
+   The parts that the chain commits to — the Sapling, Orchard, and Ironwood
+   frontiers (via their header-committed roots) and the chain history tree
+   (via `hashBlockCommitments` of the following block, ZIP 221 [^zip-0221])
+   — MUST be verified against headers authenticated by the trusted
+   commitment. The parts the chain does not commit to (the transparent UTXO
+   set, the nullifier sets, the Sprout tree) are authenticated solely by
+   the manifest commitment, which therefore carries the same trust as the
+   node's binary — the trust model of the checkpoints themselves.
+4. **Begin operating at `H`**: validate blocks above `H` under the
+   consensus rules (or checkpointed synchronization, where commitments
+   reach above `H`), participate fully in relay, and serve the blocks it
+   accumulates. The node MUST NOT advertise `NODE_NETWORK` while it lacks
+   the chain below `H`; it SHOULD advertise `NODE_NETWORK_LIMITED` once it
+   can serve the most recent 2,304 blocks.
+5. **Backfill in the background.** The node SHOULD backfill the history
+   below `H` using checkpointed synchronization, at low priority, and
+   advertise `NODE_NETWORK` when complete; it MAY instead operate
+   indefinitely without deep history (pruned operation), never advertising
+   `NODE_NETWORK`.
+
+Snapshot heights SHOULD lie at least the v2 protocol's reorganization
+margin below the network tip at the time the commitment is published, and
+snapshot artifacts SHOULD be deterministic functions of the chain state at
+`H`, so that any node of the same implementation that reaches `H` can
+regenerate and serve them. A wrong or corrupted snapshot cannot cause
+acceptance of a false state — a piece that does not match the manifest, or
+a frontier that fails header verification, is rejected and the node falls
+back to checkpointed synchronization; the commitment's only unverifiable
+claims are those with no on-chain commitment, and those are exactly as
+trustworthy as the binary that carried the commitment. (This is the trust
+model of Bitcoin's assumeutxo [^assumeutxo] and of Ethereum's era archives
+[^era1], with the difference that Zcash's header commitments make the tree
+components independently verifiable.)
+
+## Download Scheduling
+
+Bulk download is a scheduling problem: divide known work across untrusted
+peers of unknown and changing capacity, so that aggregate throughput
+approaches the client's link capacity and no single peer can stall
+progress. A node SHOULD apply the following discipline to bulk transfers
+(`get-block-range` units and `get-object` pieces):
+
+- **Work units of 16–64 MiB**, sized with the known-hash span metadata (for
+  block ranges) or manifest piece sizes (for artifacts). Units near the
+  commit frontier SHOULD be smaller, so the frontier advances promptly;
+  deep lookahead units MAY be larger.
+- **Pull-based assignment with per-peer budgets.** Maintain an estimate of
+  each peer's delivery rate (for example, an exponentially weighted moving
+  average); let each peer's connection pull the next unassigned unit
+  whenever its in-flight bytes fall below roughly 2–3 seconds of its
+  estimated rate. Fast peers thereby draw more work with no explicit
+  balancing step.
+- **Concurrency across peers.** Per-connection throughput is typically
+  bounded by a single CPU core (see the v2 protocol's bulk transfer
+  guidance [^draft-p2p-v2]); a node SHOULD download from at least 4–8
+  peers concurrently, preferring `NODE_NETWORK` peers for deep history and
+  respecting the flow control window guidance of the v2 protocol.
+- **Bounded lookahead.** In-flight plus downloaded-but-uncommitted data
+  SHOULD be bounded in bytes (a budget on the order of 256 MiB to 1 GiB),
+  not in blocks; block counts calibrated to near-tip synchronization are
+  meaningless across eras whose block sizes differ by three orders of
+  magnitude.
+- **Stall detection, twice over.** Cancel (with `CANCELLED`) and reassign a
+  unit whose peer delivers no bytes for a few seconds, falls below an
+  absolute configured rate floor, or sustains a rate far below the current
+  peer median (for example, a quarter). Verified prefixes of cancelled
+  block-range units are kept; the remainder re-anchors on the next
+  expected hash.
+- **End-game duplication.** When unassigned work runs out before the
+  fastest peers do, assign remaining units redundantly to the fastest
+  peers and cancel the losers; this bounds the tail of the download at the
+  cost of at most one duplicate unit per peer.
+- **Exact blame.** A block failing its arrival check, or an artifact piece
+  failing its hash, is attributable with certainty to the delivering peer
+  and is handled per the v2 protocol's error and misbehavior rules; the
+  failed unit is reassigned elsewhere.
 
 ## Strategy Selection
 
 A synchronizing node SHOULD proceed as follows:
 
-1. If it has a trusted commitment covering heights above its current
-   validated tip, it SHOULD use checkpointed synchronization for the
-   covered span, up to the reorganization margin of the synchronization
-   rules: checkpointed synchronization strictly dominates headers-first
-   synchronization over that span in bandwidth, round trips, and validation
-   cost.
-
-2. For heights above the span covered by its trusted commitment — including
-   the entire chain, if it has no trusted commitment — it uses
-   headers-first synchronization.
-
-3. If a peer refuses `get-hashes` (with `REFUSED` or
-   `UNSUPPORTED_STREAM_TYPE`), the node MAY retry with other peers, and
-   SHOULD fall back to headers-first synchronization if too few of its
-   peers serve `get-hashes` to sustain checkpointed synchronization.
+1. A new node with no chain state, holding a snapshot commitment, SHOULD
+   use snapshot synchronization: it is operational after transferring the
+   snapshot (gigabytes) rather than the history (hundreds of gigabytes),
+   and no other strategy changes what the node ultimately trusts.
+2. For spans covered by known-hash commitments — backfill below a
+   snapshot, or the whole chain when no snapshot is used — it SHOULD use
+   checkpointed synchronization, with verified tree roots where peers
+   serve them.
+3. Above the reach of its commitments, and within the reorganization
+   margin of the tip, it uses headers-first synchronization.
+4. Every strategy degrades toward headers-first synchronization when its
+   prerequisites are unavailable (no artifacts obtainable, no serving
+   peers, verification failures), per the v2 protocol's fallback rule;
+   scarcity of `NODE_TREE_ROOTS` or `NODE_SYNC_ARTIFACTS` peers slows
+   synchronization but never blocks it.
 
 
 # Security and Privacy Considerations
 
 The security properties of the strategies are analyzed in the v2 protocol's
-security considerations [^draft-p2p-v2]. Both recommended strategies satisfy
-its synchronization rules, so the choice between them — including falling
-back from checkpointed to headers-first synchronization — affects
-performance, not the integrity of the resulting chain.
+security considerations [^draft-p2p-v2]. All strategies here satisfy its
+synchronization rules, so the choice between them — including every
+fallback — affects performance, not the integrity of the resulting chain.
+The trust base is unchanged by acceleration: verified tree roots are
+authenticated by header commitments; artifacts are authenticated by the
+trusted commitment; and the only data trusted without chain verification
+(the snapshot's uncommitted state components) carries exactly the trust of
+the binary that shipped the commitment, as the checkpoints already do.
+Malicious synchronization data produces failure, not fraud: every
+verification failure is detected, attributed, penalized, and routed around.
 
-**Fingerprinting.** The heights and strides a node requests reveal its
-checkpoint spacing and synchronization progress, which may identify its
-implementation and version. This is comparable to the fingerprinting
-surface of headers-first synchronization and of the `user_agent` field, and
-carries the same mitigation: nodes concerned about it can align their
-request patterns with common implementations.
+**Serving capacity.** Snapshot-synchronized and pruned nodes cannot serve
+deep history; if they became the majority, historical blocks and artifacts
+could become scarce. The service flags let nodes advertise what they serve,
+operators of full nodes are encouraged to retain `NODE_NETWORK` and
+`NODE_SYNC_ARTIFACTS`, and artifacts remain regenerable by any backfilled
+node and servable from out-of-band mirrors.
+
+**Fingerprinting.** The heights, strides, and units a node requests reveal
+its implementation, configuration, and synchronization progress. This is
+comparable to the fingerprinting surface of headers-first synchronization
+and of the `user_agent` field, and carries the same mitigation: nodes
+concerned about it can align their request patterns with common
+implementations.
 
 
 # Deployment
 
 This ZIP depends on the v2 protocol [^draft-p2p-v2], which specifies the
-`get-hashes` request stream and the synchronization rules. No version gating
-is required beyond the v2 protocol's own deployment: refusal of `get-hashes`
-degrades gracefully to headers-first synchronization (see
-[Strategy Selection](#strategyselection)).
+request streams, service flags, and synchronization rules used here. No
+version gating is required beyond the v2 protocol's own deployment: each
+primitive is refused by nodes that do not serve it, and every strategy
+degrades gracefully (see [Strategy Selection](#strategyselection)).
+Implementations SHOULD bundle current chunk artifacts and snapshot
+manifests with releases while serving peers are scarce; the same
+content-addressed artifacts MAY be served by out-of-band HTTPS mirrors
+interchangeably with `get-object` peers.
 
 
 # References
@@ -217,3 +405,11 @@ degrades gracefully to headers-first synchronization (see
 [^protocol-blockchain]: [Zcash Protocol Specification, Version 2026.8.0 [NU6.3]. Section 3.3: The Block Chain](protocol/protocol.pdf#blockchain)
 
 [^draft-p2p-v2]: [Draft ZIP: Version 2 Zcash P2P Network Protocol](draft-arya-jvff-p2p-quic-transport.md)
+
+[^zip-0221]: [ZIP 221: FlyClient - Consensus-Layer Changes](zip-0221.rst)
+
+[^zip-0244]: [ZIP 244: Transaction Identifier Non-Malleability](zip-0244.rst)
+
+[^assumeutxo]: [Bitcoin Core: assumeutxo design and usage](https://github.com/bitcoin/bitcoin/blob/master/doc/assumeutxo.md)
+
+[^era1]: [era1 archival file format specification](https://github.com/eth-clients/e2store-format-specs/blob/main/formats/era1.md)

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -162,7 +162,9 @@ A node's trusted commitment binds the data its strategies rely on:
   than one per range — because they are a function of the final
   checkpoint height as well as of the chain: extending the commitment's
   coverage would change every per-range hint hash anyway, while the
-  entry-chunk hashes stay stable.
+  entry-chunk hashes stay stable. A commitment from an older release
+  simply covers a lower final checkpoint: its hints remain valid for that
+  shorter span, and the node synchronizes above it normally.
 - **A snapshot manifest hash**, for snapshot synchronization (see
   [Snapshot Synchronization](#snapshotsynchronization)).
 
@@ -285,6 +287,20 @@ No additional trust is involved: every adopted root is authenticated by a
 header that is itself authenticated by the trusted commitment, and a root
 that no header authenticates is never adopted.
 
+**Frontier artifacts.** Adopting verified roots leaves the node without
+the tree *frontiers* it needs to resume appending note commitments where
+full validation begins. The trusted commitment MAY bind the hash of a
+*frontier artifact* — the serialized Sapling, Orchard, and Ironwood
+frontiers at the final checkpoint — obtained like any artifact. A
+frontier whose recomputed root matches the root verified for that height
+by the procedure above is adopted, so the binding itself carries no
+trust: a wrong frontier fails the root comparison and the node falls
+back to rebuilding that pool's tree from the span's note commitments.
+The Ironwood frontier cannot be verified this way (no header
+authenticates an Ironwood root); it is authenticated only by the
+commitment's hash, or rebuilt from the pool's note commitments — a
+bounded cost, since the pool postdates NU6.3 activation.
+
 ### Spentness Hints
 
 After tree work is eliminated, the dominant remaining state cost of
@@ -310,10 +326,9 @@ They are therefore specified rather than left to the implementation:
   be transmitted, logged, or derived from any peer-supplied or otherwise
   predictable value, and MUST NOT be reused across attempts.
 - Each item's hash is `H_a(item) = BLAKE2b-256(item)` computed with the
-  salt as the BLAKE2b *key* and a per-aggregate 16-byte personalization
-  string `a` (for example `b"ZcashHintTrans\x00\x00"` for the transparent
-  aggregate and `b"ZcashHintNfSapl\x00"` and the corresponding names for each
-  nullifier pool). Keying — rather than prefixing the salt to the message
+  salt as the BLAKE2b *key* and the aggregate's 16-byte personalization
+  string `a`, as listed in the table below the next item.
+  Keying — rather than prefixing the salt to the message
   — makes the construction a pseudorandom function and is not subject to
   length extension, and the personalization domain-separates the
   aggregates so that a cancellation in one cannot be transplanted into
@@ -325,6 +340,16 @@ They are therefore specified rather than left to the implementation:
   around 2^-32 per attempt, which is not a sufficient margin for a check
   whose failure is a silent retry rather than a ban.
 
+The aggregates, their items, and their personalization strings are:
+
+| Aggregate             | Item                                                                 | Personalization             |
+|-----------------------|----------------------------------------------------------------------|-----------------------------|
+| Transparent outpoints | The 36-byte outpoint (txid, then output index), as serialized in transaction inputs | `b"ZcashHintTrans\x00\x00"` |
+| Sprout nullifiers     | The 32-byte nullifier                                                | `b"ZcashHintNfSprt\x00"`    |
+| Sapling nullifiers    | The 32-byte nullifier                                                | `b"ZcashHintNfSapl\x00"`    |
+| Orchard nullifiers    | The 32-byte nullifier                                                | `b"ZcashHintNfOrch\x00"`    |
+| Ironwood nullifiers   | The 32-byte nullifier                                                | `b"ZcashHintNfIron\x00"`    |
+
 A pseudorandom function of a secret key is required, not merely "some
 hash": an affine hash such as keyed multiply-shift or a polynomial hash is
 linear over the accumulator group, so cancellation relations hold for
@@ -335,7 +360,10 @@ linear over the accumulator group, so cancellation relations hold for
 transparent output created at or below the *terminal height* — the final
 checkpoint — in canonical order (by block height, then transaction index,
 then output index): whether the output is still unspent at that height.
-During the span:
+The `txouts` metadata of the verified entry chunks gives each height's bit
+count, so a node can check the bitmap's length before downloading any
+block bodies, and a work unit anywhere in the span can locate its first
+bit without processing the blocks below it. During the span:
 
 - An output hinted *unspent* is written to the transparent UTXO set as it
   is created — and, during the span, never looked up or deleted.
@@ -362,10 +390,11 @@ construction and verification:
   checkpoint is excluded by the trusted commitment, and the multiset
   equality transfers the revealed nullifiers' distinctness to the
   snapshot set.
-- Without a snapshot, the node accumulates revealed nullifiers per pool
-  and constructs each set in one batch (for example, by external sort) at
-  the terminal height; per-spend membership tests below the final
-  checkpoint are vouched for by the trusted commitment.
+- Without a snapshot, there is no nullifier aggregate at all: revealed
+  nullifiers are simply inserted as they are encountered — insertion is
+  sequential-write work, not the random reads the hints exist to remove —
+  and per-spend membership tests below the final checkpoint are vouched
+  for by the trusted commitment.
 
 **Value pools.** No lookups are needed for value tracking either: shielded
 pool balances are sums of the blocks' value balance fields, which commute,
@@ -402,9 +431,15 @@ validated advancement rule:
   are vouched for; above the final checkpoint, blocks are committed in
   height order with the lookups performed.
 
-A nonzero aggregate at the terminal height means the hints, the snapshot
-sets, or the delivered blocks were wrong; the node discards the affected
-state and falls back to checkpointed synchronization without hints. As with
+A node SHOULD obtain and verify the hint bitmap — its hash against the
+commitment, and its bit count against the span's transparent output
+total, summed from the verified entry chunks' `txouts` metadata — before
+processing any block bodies with hints, so that an unavailable or
+malformed bitmap costs nothing but its fetch. A nonzero aggregate at the
+terminal height means the hints, the snapshot sets, or the delivered
+blocks were wrong; the node keeps its verified known-hash list and any
+verified header chain, discards only the state derived from hinted
+processing, and re-downloads and commits the span without hints. As with
 all synchronization data in this ZIP, wrong hints produce failure, not
 fraud.
 
@@ -621,10 +656,13 @@ request streams, service flags, and synchronization rules used here. No
 version gating is required beyond the v2 protocol's own deployment: each
 primitive is refused by nodes that do not serve it, and every strategy
 degrades gracefully (see [Strategy Selection](#strategyselection)).
-Implementations SHOULD bundle current chunk artifacts and snapshot
-manifests with releases while serving peers are scarce; the same
-content-addressed artifacts MAY be served by out-of-band HTTPS mirrors
-interchangeably with `get-object` peers.
+Distribution can be purely in-band: the known-hash list is reassembled
+via `get-hashes`, and hint, frontier, and snapshot artifacts are served
+by `NODE_SYNC_ARTIFACTS` peers via `get-object` — which requires that
+seeders and any configured initial peers include such nodes.
+Implementations MAY additionally bundle current artifacts with releases,
+or serve them from out-of-band HTTPS mirrors interchangeably with
+`get-object` peers.
 
 
 # References

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -309,51 +309,13 @@ transparent input's spent output, and inserting (and, under full
 validation, membership-testing) each revealed nullifier. Spentness hints —
 adapted from Bitcoin's SwiftSync [^swiftsync] — eliminate the random access
 and make historical commits order-independent, at the cost of a small hint
-bitmap bound by the trusted commitment, whose wrongness
-can only ever cause synchronization to fail, never to accept invalid state.
+bitmap bound by the trusted commitment, which vouches for its correctness
+exactly as it vouches for the known block hashes: the bitmap is a
+deterministic function of the chain, regenerable and auditable by any
+synchronized node, and its pinned hash is updated by each release that
+updates the checkpoints.
 Hints apply only within the reach of the trusted commitment: a node MUST
 NOT apply them above the final checkpoint.
-
-The node draws a fresh secret *salt* for each synchronization attempt and
-maintains an additive aggregate for each of the item classes described
-below. The aggregate is a sum of keyed hashes, and its parameters are
-security-critical: the guarantee that a wrong hint can only cause failure
-rests on an attacker being unable to construct items whose hashes cancel.
-They are therefore specified rather than left to the implementation:
-
-- The **salt** is 32 bytes drawn from a cryptographically secure random
-  number generator, freshly for each synchronization attempt. It MUST NOT
-  be transmitted, logged, or derived from any peer-supplied or otherwise
-  predictable value, and MUST NOT be reused across attempts.
-- Each item's hash is `H_a(item) = BLAKE2b-256(item)` computed with the
-  salt as the BLAKE2b *key* and the aggregate's 16-byte personalization
-  string `a`, as listed in the table below the next item.
-  Keying — rather than prefixing the salt to the message
-  — makes the construction a pseudorandom function and is not subject to
-  length extension, and the personalization domain-separates the
-  aggregates so that a cancellation in one cannot be transplanted into
-  another.
-- The aggregate is the sum of those hashes, interpreted as 256-bit
-  little-endian unsigned integers, **modulo 2^256**. The wide accumulator
-  is what makes an accidental or forged cancellation negligible; a
-  32-bit accumulator would admit a false zero with probability
-  around 2^-32 per attempt, which is not a sufficient margin for a check
-  whose failure is a silent retry rather than a ban.
-
-The aggregates, their items, and their personalization strings are:
-
-| Aggregate             | Item                                                                 | Personalization             |
-|-----------------------|----------------------------------------------------------------------|-----------------------------|
-| Transparent outpoints | The 36-byte outpoint (txid, then output index), as serialized in transaction inputs | `b"ZcashHintTrans\x00\x00"` |
-| Sprout nullifiers     | The 32-byte nullifier                                                | `b"ZcashHintNfSprt\x00"`    |
-| Sapling nullifiers    | The 32-byte nullifier                                                | `b"ZcashHintNfSapl\x00"`    |
-| Orchard nullifiers    | The 32-byte nullifier                                                | `b"ZcashHintNfOrch\x00"`    |
-| Ironwood nullifiers   | The 32-byte nullifier                                                | `b"ZcashHintNfIron\x00"`    |
-
-A pseudorandom function of a secret key is required, not merely "some
-hash": an affine hash such as keyed multiply-shift or a polynomial hash is
-linear over the accumulator group, so cancellation relations hold for
-*every* key and secrecy of the salt would provide no protection at all.
 
 **Transparent outputs.** The spentness hints (see
 [Synchronization Data](#synchronizationdata)) carry one bit per
@@ -367,46 +329,31 @@ bit without processing the blocks below it. During the span:
 
 - An output hinted *unspent* is written to the transparent UTXO set as it
   is created — and, during the span, never looked up or deleted.
-- An output hinted *spent* is never stored; its outpoint is added to the
-  transparent aggregate.
-- Every transparent input subtracts its referenced outpoint from the
-  transparent aggregate. No lookup is performed.
+- An output hinted *spent* is never stored.
+- Transparent inputs perform no lookup at all.
 
-At the terminal height, the transparent aggregate MUST be exactly zero:
-the multiset of outputs hinted spent then equals the multiset of outputs
-actually spent, so the constructed UTXO set is exactly the set of
-never-spent outputs, without a single random read.
+The constructed UTXO set is then exactly the set of outputs unspent at
+the terminal height, without a single random read: every output hinted
+spent is one the committed chain spends within the span, on the
+authority of the commitment.
 
-**Nullifiers.** The nullifier sets never shrink, so no per-item hint is
-needed; what the hint mechanism provides instead is lookup-free
-construction and verification:
-
-- When synchronizing below a snapshot (backfill), the snapshot's nullifier
-  set for each pool serves as the hint: the node adds every member of the
-  snapshot set to that pool's aggregate and subtracts every nullifier
-  revealed by the span's blocks. A zero aggregate at the snapshot height
-  proves the nullifiers revealed in the span are exactly the snapshot set.
-  No distinctness check is needed: double-reveal below the final
-  checkpoint is excluded by the trusted commitment, and the multiset
-  equality transfers the revealed nullifiers' distinctness to the
-  snapshot set.
-- Without a snapshot, there is no nullifier aggregate at all: revealed
-  nullifiers are simply inserted as they are encountered — insertion is
-  sequential-write work, not the random reads the hints exist to remove —
-  and per-spend membership tests below the final checkpoint are vouched
-  for by the trusted commitment.
+**Nullifiers.** The nullifier sets never shrink, so no hint is needed at
+all: revealed nullifiers are simply inserted as they are encountered —
+insertion is sequential-write work, not the random reads the hints exist
+to remove — and per-spend membership tests below the final checkpoint
+are vouched for by the trusted commitment. When backfilling below a
+snapshot, the reconstructed sets are compared with the snapshot's at `H`
+(see [Snapshot Synchronization](#snapshotsynchronization)).
 
 **Value pools.** No lookups are needed for value tracking either: shielded
 pool balances are sums of the blocks' value balance fields, which commute,
 and the transparent pool balance at the terminal height is the sum of the
-constructed UTXO set's amounts. These are consensus quantities, not
-aggregates: they MUST be accumulated with checked arithmetic that detects
-overflow, and a node MUST NOT reuse the deliberately modular arithmetic of
-the hint aggregates for them.
+constructed UTXO set's amounts. These are consensus quantities: they MUST
+be accumulated with checked arithmetic that detects overflow.
 
 **What order-independence does and does not cover.** The state construction
 above reads no state written by an earlier block, so the *construction* —
-the UTXO set, the nullifier sets, the aggregates, and the value pool
+the UTXO set, the nullifier sets, and the value pool
 totals — is order-independent, and blocks and ranges MAY be verified and
 committed in any order within the span. The per-input reads and per-output
 deletes disappear entirely.
@@ -435,13 +382,12 @@ A node SHOULD obtain and verify the hint bitmap — its hash against the
 commitment, and its bit count against the span's transparent output
 total, summed from the verified entry chunks' `txouts` metadata — before
 processing any block bodies with hints, so that an unavailable or
-malformed bitmap costs nothing but its fetch. A nonzero aggregate at the
-terminal height means the hints, the snapshot sets, or the delivered
-blocks were wrong; the node keeps its verified known-hash list and any
-verified header chain, discards only the state derived from hinted
-processing, and re-downloads and commits the span without hints. As with
-all synchronization data in this ZIP, wrong hints produce failure, not
-fraud.
+malformed bitmap costs nothing but its fetch; a bitmap that fails either
+check is discarded and the span is synchronized without hints. A
+published bitmap that is wrong despite matching its pinned hash is a
+defect of the commitment itself, exactly as a wrong checkpoint hash would
+be; because the bitmap is deterministic, publishers and third parties can
+regenerate and cross-check it, and release processes SHOULD do so.
 
 ### Snapshot Synchronization
 
@@ -483,27 +429,25 @@ A node with no chain state MAY become operational at a *snapshot height*
    node that lacks the complete chain [^draft-p2p-v2].
 5. **Backfill in the background.** The node SHOULD backfill the history
    below `H` using checkpointed synchronization, at low priority, and
-   advertise `NODE_NETWORK` when complete. Backfill SHOULD use the
-   snapshot's own sets as spentness hints (see
-   [Spentness Hints](#spentnesshints)), which reconciles the snapshot's
-   uncommitted components against the chain the node has just replayed.
+   advertise `NODE_NETWORK` when complete. On completion, backfill
+   reconciles the snapshot's uncommitted components against the chain the
+   node has just replayed. (The hint bitmap's bits are relative to the
+   final checkpoint rather than `H`, so backfill below a snapshot
+   proceeds without transparent hints; as background work, it is not on
+   the critical path that hints exist to shorten.)
 
    The reconciliation discharges the snapshot's trust only to the extent
    that each component is actually compared, so each MUST be covered
-   explicitly. A comparison over outpoints alone is **not** sufficient: a
-   snapshot entry that no span output ever created contributes no term to
-   the spend-cancellation aggregate, so a fabricated or amount-inflated
-   UTXO would pass unnoticed. Backfill therefore verifies, at `H`:
+   explicitly, and over complete entries: a comparison over outpoints
+   alone would let a fabricated or amount-inflated UTXO entry pass
+   unnoticed. Backfill therefore verifies, at `H`:
 
-   - **The transparent UTXO set**, by an aggregate over whole entries
-     rather than outpoints. The node adds `H_a` of each entry it
-     constructs — the outpoint, the value, the `scriptPubKey`, the
-     creation height, and the coinbase flag, in a canonical encoding —
-     and subtracts `H_a` of each entry of the snapshot's set as it
-     streams it in. Neither side performs a lookup. A zero aggregate
-     proves the two sets are equal as sets of complete entries, so a
+   - **The transparent UTXO set**, compared as complete entries — the
+     outpoint, the value, the `scriptPubKey`, the creation height, and
+     the coinbase flag, in a canonical encoding — between the set the
+     replay constructs and the set the snapshot supplied, so that a
      phantom outpoint, an inflated value, or an altered script is caught.
-   - **The nullifier sets**, by the aggregates already described.
+   - **The nullifier sets**, by the same whole-value comparison per pool.
    - **The Sprout note commitment tree**, which no header commits to, by
      recomputing it from the JoinSplit note commitments of the replayed
      blocks and comparing the resulting root and frontier. Sprout is a
@@ -617,22 +561,24 @@ fallback — affects performance, not the integrity of the resulting chain.
 The trust base is unchanged by acceleration: every accelerating input is
 either authenticated against the chain or bound by the trusted commitment,
 and the only data trusted without chain verification
-(the snapshot's uncommitted state components) carries exactly the trust of
-the binary that shipped the commitment, as the checkpoints already do —
-and that trust is discharged, for each component the reconciliation of
+(the spentness hints and the snapshot's uncommitted state components)
+carries exactly the trust of
+the binary that shipped the commitment, as the checkpoints already do.
+The snapshot components' trust is discharged, for each component the
+reconciliation of
 [Snapshot Synchronization](#snapshotsynchronization) step 5 actually
-compares, when hint-verified backfill completes (see
-[Spentness Hints](#spentnesshints)). A node that never backfills never
-discharges it. Malicious synchronization data produces failure, not
+compares, when backfill completes; a node that never backfills never
+discharges it. The spentness hints stand or fall with the commitment
+itself, exactly as the checkpoint hashes do, and are auditable in the
+same way: the bitmap is a deterministic function of the chain that any
+synchronized node can regenerate and cross-check. Malicious
+synchronization data from peers produces failure, not
 fraud: every verification failure is detected and routed around, and is
 attributed and penalized where blame is provable under the v2 protocol's
-misbehavior rules. (Two failures are deliberately *not* attributed: a
-nonzero hint aggregate, which implicates the hints, the snapshot sets,
-or the blocks without distinguishing them, and an assembled artifact
+misbehavior rules. (One failure is deliberately *not* attributed: an
+assembled artifact
 piece whose ranges came from several peers — see
-[Download Scheduling](#downloadscheduling).) Spentness hints in
-particular cannot cause acceptance of an incorrect state — a wrong hint
-surfaces as a nonzero aggregate.
+[Download Scheduling](#downloadscheduling).)
 
 **Serving capacity.** Snapshot-synchronized and pruned nodes cannot serve
 deep history; if they became the majority, historical blocks and artifacts

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -28,8 +28,9 @@ and the synchronization rules of that protocol, are to be interpreted as
 defined there.
 
 best chain
-:   The consensus block chain that a node considers current, as determined by
-    the consensus rules; its *tip* is its highest block.
+:   The best valid block chain, as described in section 3.3 of the Zcash
+    Protocol Specification [^protocol-blockchain]; its *tip* is its highest
+    block.
 
 validated tip
 :   The highest block that a node has accepted into its best chain under the
@@ -44,15 +45,14 @@ checkpoint
     authoritative for the block at that height.
 
 trusted commitment
-:   Data, obtained by a node through a channel it already trusts (for
-    example, compiled into its binary or supplied by local configuration),
-    that binds synchronization data the node will rely on — block hashes,
-    and, for snapshot synchronization, a state snapshot manifest.
+:   As defined in the v2 protocol's checkpointed synchronization rules
+    [^draft-p2p-v2]; extended in this ZIP to also bind, for snapshot
+    synchronization, a state snapshot manifest.
 
 synchronization artifact
-:   An immutable, content-addressed byte object served via `get-object` —
-    for example, a known-hash chunk file or a snapshot piece. An artifact is
-    identified by the SHA-256 hash of its contents.
+:   The immutable, content-addressed byte object served via `get-object`, as
+    defined in the v2 protocol [^draft-p2p-v2] — for example, a known-hash
+    chunk file or a snapshot piece.
 
 known-hash list
 :   The block hashes of every height of a span of the chain, together with
@@ -60,9 +60,9 @@ known-hash list
     example, as the pinned hashes of a list of chunk artifacts).
 
 anchor
-:   A block hash that a synchronizing node has verified against a trusted
-    commitment (directly, or via a verified artifact), against which a
-    `get-block-range` stream authenticates every delivered block.
+:   The anchor of a `get-block-range` stream, as defined in the v2 protocol
+    [^draft-p2p-v2]; in this ZIP, always a block hash verified against a
+    trusted commitment (directly, or via a verified artifact).
 
 work unit
 :   A contiguous range of blocks (or a byte range of an artifact) scheduled
@@ -128,9 +128,8 @@ implementation compiles in known-hash lists covering every block — over 100
 MB of hashes that grow with the chain — because the legacy protocol offered
 no way to fetch and verify them. Under this ZIP, a binary need only pin the
 SHA-256 hashes of the chunk artifacts (a few kilobytes); the artifacts
-themselves are fetched from untrusted peers via `get-object` (or any
-mirror) and verified, and every synced node can regenerate them
-byte-identically to serve others.
+themselves are obtained and verified as specified in
+[Synchronization Data](#synchronizationdata).
 
 
 # Specification
@@ -156,8 +155,8 @@ A node's trusted commitment binds the data its strategies rely on:
 Chunk artifacts are deterministic functions of the chain, so any node that
 has synchronized the covered span can regenerate them byte-identically and
 serve them; artifact pieces SHOULD be no larger than the `get-object`
-per-request maximum (32 MiB) so each piece is independently fetchable and
-verifiable.
+per-request maximum [^draft-p2p-v2] so each piece is independently fetchable
+and verifiable.
 
 ## Recommended Strategies
 
@@ -167,9 +166,8 @@ rule requires it) and MAY implement the others.
 ### Headers-First Synchronization
 
 Headers-first synchronization is specified in the v2 protocol
-[^draft-p2p-v2]. It is the full-validation strategy: it assumes no trusted
-commitments, and every accepted block is validated under the consensus
-rules. It is also the strategy for the chain near the tip, above the reach
+[^draft-p2p-v2], where it is characterized as the baseline, full-validation
+method. It is also the strategy for the chain near the tip, above the reach
 of commitments, whatever strategy covered the history below.
 
 ### Checkpointed Synchronization
@@ -178,8 +176,7 @@ A node MAY synchronize the span of the block chain covered by a verified
 known-hash list as follows:
 
 1. **Obtain and verify the known-hash list** for the target span (see
-   [Synchronization Data](#synchronizationdata)). Every listed hash is now
-   an anchor.
+   [Synchronization Data](#synchronizationdata)).
 
 2. **Partition the span into work units**: contiguous block ranges, sized
    using the span metadata toward a byte target (see
@@ -189,13 +186,12 @@ known-hash list as follows:
    request carries the byte target as its `max_bytes` bound.
 
 3. **Stream each unit with `get-block-range`**, anchored at the unit's
-   final hash. Delivery is descending, so each delivered block is verified
-   on arrival: it must hash to the anchor or to the previously delivered
-   block's `hashPrevBlock`, carry transactions matching its header, and
-   (as a cross-check) match the known-hash list at its height. A
+   final hash. Each delivered block is verified on arrival under the v2
+   protocol's `get-block-range` delivery rules [^draft-p2p-v2] and — as a
+   cross-check — matched against the known-hash list at its height. A
    truncated or cancelled unit keeps its verified prefix, and the
-   remainder is re-requested from any peer using the next expected hash
-   as its anchor.
+   remainder is re-requested from any peer per the v2 protocol's
+   resumption rule.
 
 4. **Commit** each completed range in height order, applying whatever
    abbreviated validation local policy permits for
@@ -206,19 +202,17 @@ known-hash list as follows:
 A node with a commitment that binds only spaced checkpoint hashes (rather
 than a full known-hash list) applies the same procedure with units
 anchored at checkpoint heights; interior per-block cross-checks and
-advance sizing are then unavailable, but neither is needed: the request's
-`max_bytes` bound makes each stream a byte-sized unit regardless of block
-sizes, the descending hash chain authenticates every delivered block
-against the checkpoint anchor, and the node continues the span by
-re-anchoring on the next expected hash.
+advance sizing are then unavailable, but neither is needed — steps 2 and 3
+already bound each unit in bytes and authenticate every delivered block
+against its anchor.
 
 ### Verified Tree Roots
 
-Recomputing the note commitment trees is the dominant CPU cost of
-committing checkpoint-authenticated blocks. A node MAY instead obtain each
-historical block's tree roots with `get-tree-roots` from `NODE_TREE_ROOTS`
-peers and verify them against header commitments, skipping the
-recomputation:
+A node MAY avoid the note commitment tree recomputation that dominates the
+CPU cost of committing checkpoint-authenticated blocks (see
+[Motivation](#motivation)) by obtaining each historical block's tree roots
+with `get-tree-roots` from `NODE_TREE_ROOTS` peers and verifying them
+against header commitments:
 
 1. For each block in the span, obtain the entry (Sapling, Orchard, and
    Ironwood roots, shielded transaction counts, and authorizing data
@@ -405,7 +399,7 @@ A node with no chain state MAY become operational at a *snapshot height*
 1. **Obtain the manifest** whose SHA-256 hash is bound by the trusted
    commitment, from any source (`get-object`, mirrors, bundled). The
    manifest lists the snapshot's content-addressed pieces and their sizes.
-2. **Fetch and verify the pieces** (each ≤ 32 MiB) from
+2. **Fetch and verify the pieces** from
    `NODE_SYNC_ARTIFACTS` peers via `get-object` and/or out-of-band mirrors,
    scheduling them like any other work units (see
    [Download Scheduling](#downloadscheduling)); a piece is accepted only if
@@ -431,9 +425,8 @@ A node with no chain state MAY become operational at a *snapshot height*
 4. **Begin operating at `H`**: validate blocks above `H` under the
    consensus rules (or checkpointed synchronization, where commitments
    reach above `H`), participate fully in relay, and serve the blocks it
-   accumulates. The node MUST NOT advertise `NODE_NETWORK` while it lacks
-   the chain below `H`; it SHOULD advertise `NODE_NETWORK_LIMITED` once it
-   can serve the most recent 2,304 blocks.
+   accumulates, advertising service flags as the v2 protocol requires of a
+   node that lacks the complete chain [^draft-p2p-v2].
 5. **Backfill in the background.** The node SHOULD backfill the history
    below `H` using checkpointed synchronization, at low priority, and
    advertise `NODE_NETWORK` when complete. Backfill SHOULD use the
@@ -483,8 +476,7 @@ regenerate and serve them. A wrong or corrupted snapshot cannot cause
 acceptance of a false state — a piece that does not match the manifest, or
 a frontier that fails header verification, is rejected and the node falls
 back to checkpointed synchronization; the commitment's only unverifiable
-claims are those with no on-chain commitment, and those are exactly as
-trustworthy as the binary that carried the commitment. (This is the trust
+claims are those with no on-chain commitment (see step 3). (This is the trust
 model of Bitcoin's assumeutxo [^assumeutxo] and of Ethereum's era archives
 [^era1], with the difference that Zcash's header commitments make the tree
 components independently verifiable.)
@@ -521,9 +513,9 @@ progress. A node SHOULD apply the following discipline to bulk transfers
 - **Stall detection, twice over.** Cancel (with `CANCELLED`) and reassign a
   unit whose peer delivers no bytes for a few seconds, falls below an
   absolute configured rate floor, or sustains a rate far below the current
-  peer median (for example, a quarter). Verified prefixes of cancelled
-  block-range units are kept; the remainder re-anchors on the next
-  expected hash.
+  peer median (for example, a quarter). Cancelled block-range units keep
+  their verified prefix and are resumed per step 3 of
+  [Checkpointed Synchronization](#checkpointedsynchronization).
 - **End-game duplication.** When unassigned work runs out before the
   fastest peers do, assign remaining units redundantly to the fastest
   peers and cancel the losers; this bounds the tail of the download at the
@@ -568,9 +560,9 @@ The security properties of the strategies are analyzed in the v2 protocol's
 security considerations [^draft-p2p-v2]. All strategies here satisfy its
 synchronization rules, so the choice between them — including every
 fallback — affects performance, not the integrity of the resulting chain.
-The trust base is unchanged by acceleration: verified tree roots are
-authenticated by header commitments; artifacts are authenticated by the
-trusted commitment; and the only data trusted without chain verification
+The trust base is unchanged by acceleration: every accelerating input is
+either authenticated against the chain or bound by the trusted commitment,
+and the only data trusted without chain verification
 (the snapshot's uncommitted state components) carries exactly the trust of
 the binary that shipped the commitment, as the checkpoints already do —
 and that trust is discharged, for each component the reconciliation of

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -152,6 +152,15 @@ A node's trusted commitment binds the data its strategies rely on:
   mirrors — accepted only if their hashes match the commitment. A
   verified known-hash list makes every listed hash an anchor, and its span
   metadata gives per-height sizes and costs for scheduling.
+
+  The commitment MAY additionally bind, for each height range, the
+  SHA-256 hash of that range's *spentness-hint chunk* — the hint bits for
+  the transparent outputs created in the range (see
+  [Spentness Hints](#spentnesshints)) — obtained like any artifact and
+  verified against these hashes. Unlike entry chunks, hint chunks are
+  functions of the list's terminal height as well as of the chain, so
+  extending the commitment's coverage changes every hint-chunk hash while
+  leaving the entry-chunk hashes stable.
 - **A snapshot manifest hash**, for snapshot synchronization (see
   [Snapshot Synchronization](#snapshotsynchronization)).
 
@@ -281,9 +290,11 @@ committing historical blocks is random access: looking up and deleting each
 transparent input's spent output, and inserting (and, under full
 validation, membership-testing) each revealed nullifier. Spentness hints —
 adapted from Bitcoin's SwiftSync [^swiftsync] — eliminate the random access
-and make historical commits order-independent, at the cost of a small hint
-artifact whose wrongness can only ever cause synchronization to fail, never
-to accept invalid state.
+and make historical commits order-independent, at the cost of small hint
+chunks bound by the same commitment as the known-hash list, whose wrongness
+can only ever cause synchronization to fail, never to accept invalid state.
+Hints apply only within the reach of the trusted commitment: a node MUST
+NOT apply them above the final checkpoint.
 
 The node draws a fresh secret *salt* for each synchronization attempt and
 maintains an additive aggregate for each of the item classes described
@@ -317,11 +328,13 @@ hash": an affine hash such as keyed multiply-shift or a polynomial hash is
 linear over the accumulator group, so cancellation relations hold for
 *every* key and secrecy of the salt would provide no protection at all.
 
-**Transparent outputs.** A *spentness hint artifact* — bound by the trusted
-commitment and fetched like any other artifact — carries one bit per
-transparent output created in the synchronized span, in canonical order
+**Transparent outputs.** Each known-hash range's spentness-hint chunk (see
+[Synchronization Data](#synchronizationdata)) carries one bit per
+transparent output created in the range, in canonical order
 (by block height, then transaction index, then output index): whether the
-output is still unspent at the span's terminal height. During the span:
+output is still unspent at the *terminal height* — the highest height the
+commitment's hint chunks cover, at or below the final checkpoint. During
+the span:
 
 - An output hinted *unspent* is written to the transparent UTXO set as it
   is created — and, during the span, never looked up or deleted.
@@ -341,17 +354,17 @@ construction and verification:
 
 - When synchronizing below a snapshot (backfill), the snapshot's nullifier
   set for each pool serves as the hint: the node adds every member of the
-  snapshot set to that pool's aggregate — verifying while streaming it in
-  sorted order that its elements are strictly increasing, hence distinct —
-  and subtracts every nullifier revealed by the span's blocks. A zero
-  aggregate at the snapshot height proves the nullifiers revealed in the
-  span are exactly the snapshot set, and therefore that no nullifier was
-  revealed twice.
+  snapshot set to that pool's aggregate and subtracts every nullifier
+  revealed by the span's blocks. A zero aggregate at the snapshot height
+  proves the nullifiers revealed in the span are exactly the snapshot set.
+  No distinctness check is needed: double-reveal below the final
+  checkpoint is excluded by the trusted commitment, and the multiset
+  equality transfers the revealed nullifiers' distinctness to the
+  snapshot set.
 - Without a snapshot, the node accumulates revealed nullifiers per pool
   and constructs each set in one batch (for example, by external sort) at
-  the terminal height, checking distinctness in the same pass; per-spend
-  membership tests below the final checkpoint are vouched for by the
-  trusted commitment.
+  the terminal height; per-spend membership tests below the final
+  checkpoint are vouched for by the trusted commitment.
 
 **Value pools.** No lookups are needed for value tracking either: shielded
 pool balances are sums of the blocks' value balance fields, which commute,
@@ -383,10 +396,10 @@ validated advancement rule:
   full validation.
 - **Coinbase maturity and the pre-NU5 shielded-coinbase rule**, which
   depend on the creation height and coinbase status of the *spent* output
-  — exactly the lookup that hints remove. A hint artifact that is used
-  above the reach of a trusted commitment MUST therefore carry, per output
-  hinted spent, the output's creation height and whether it was a coinbase
-  output, so that the check remains local to the spending block.
+  — exactly the lookup that hints remove. This is why hints are confined
+  to the reach of the trusted commitment, where these per-spend checks
+  are vouched for; above the final checkpoint, blocks are committed in
+  height order with the lookups performed.
 
 A nonzero aggregate at the terminal height means the hints, the snapshot
 sets, or the delivered blocks were wrong; the node discards the affected
@@ -410,7 +423,9 @@ A node with no chain state MAY become operational at a *snapshot height*
 3. **Verify the state against the chain where possible.** The snapshot
    contains, at minimum: the transparent UTXO set; the Sprout, Sapling,
    Orchard, and Ironwood nullifier sets; the note commitment tree frontiers
-   of each pool; the chain history tree; and the chain value pool balances.
+   of each pool; the chain history tree; and the shielded chain value pool
+   balances. (The transparent pool balance is not carried: it is the sum
+   of the UTXO set's amounts, computed locally.)
    The parts that the chain commits to — the Sapling, Orchard, and Ironwood
    frontiers (via their header-committed roots) and the chain history tree
    (via `hashBlockCommitments` of the following block, ZIP 221 [^zip-0221])
@@ -421,7 +436,7 @@ A node with no chain state MAY become operational at a *snapshot height*
    commitment that stops at `H` leaves the chain history tree unverified,
    and the node MUST treat it as an uncommitted component. The parts the
    chain does not commit to (the transparent UTXO set, the nullifier sets,
-   the Sprout tree, and the chain value pool balances) are authenticated
+   the Sprout tree, and the shielded pool balances) are authenticated
    solely by the manifest commitment, which therefore carries the same
    trust as the node's binary — the trust model of the checkpoints
    themselves.
@@ -457,10 +472,11 @@ A node with no chain state MAY become operational at a *snapshot height*
      recomputing it from the JoinSplit note commitments of the replayed
      blocks and comparing the resulting root and frontier. Sprout is a
      closed pool of bounded size, so this is inexpensive.
-   - **The chain value pool balances**, by recomputing them over the
-     replayed span (with checked arithmetic, see
+   - **The shielded chain value pool balances**, by recomputing them over
+     the replayed span (with checked arithmetic, see
      [Spentness Hints](#spentnesshints)) and comparing them to the
-     snapshot's.
+     snapshot's. The transparent pool balance needs no separate check: it
+     is implied by the whole-entry comparison of the UTXO set.
 
    When all four check out, the snapshot's uncommitted components have been
    verified against the chain and the node's trust base is that of a fully

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -587,7 +587,7 @@ operators of full nodes are encouraged to retain `NODE_NETWORK` and
 `NODE_SYNC_ARTIFACTS`, and artifacts remain regenerable by any backfilled
 node and servable from out-of-band mirrors.
 
-**Fingerprinting.** The heights, strides, and units a node requests reveal
+**Fingerprinting.** The heights, ranges, and units a node requests reveal
 its implementation, configuration, and synchronization progress. This is
 comparable to the fingerprinting surface of headers-first synchronization
 and of the `user_agent` field, and carries the same mitigation: nodes

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -222,7 +222,9 @@ recomputation:
 
 1. For each block in the span, obtain the entry (Sapling, Orchard, and
    Ironwood roots, shielded transaction counts, and authorizing data
-   commitment).
+   commitment), anchoring each request's `final_hash` at a hash the node
+   has already authenticated, so that entries describe known blocks
+   rather than the responder's view of a best chain.
 2. Verify the entries against headers that checkpointed synchronization has
    authenticated: from NU5, rebuild the chain history tree of ZIP 221
    [^zip-0221] from the supplied roots and counts, and check each block's
@@ -405,10 +407,17 @@ progress. A node SHOULD apply the following discipline to bulk transfers
   fastest peers do, assign remaining units redundantly to the fastest
   peers and cancel the losers; this bounds the tail of the download at the
   cost of at most one duplicate unit per peer.
-- **Exact blame.** A block failing its arrival check, or an artifact piece
-  failing its hash, is attributable with certainty to the delivering peer
-  and is handled per the v2 protocol's error and misbehavior rules; the
-  failed unit is reassigned elsewhere.
+- **Exact blame.** A block failing its arrival check is attributable with
+  certainty to the delivering peer, as is an artifact piece that fails
+  its hash after being delivered entirely by one peer; both are handled
+  per the v2 protocol's error and misbehavior rules, and the failed unit
+  is reassigned elsewhere. A piece assembled from ranges delivered by
+  several peers is *not* attributable when it fails its hash — the v2
+  protocol forbids assigning a penalty in that case — so the node
+  re-fetches the piece with each candidate peer serving it whole, which
+  isolates a misbehaving peer; a scheduler that assigns each piece to a
+  single peer (as the unit sizes above make natural) keeps blame exact
+  from the start.
 
 ## Strategy Selection
 
@@ -445,8 +454,13 @@ trusted commitment; and the only data trusted without chain verification
 the binary that shipped the commitment, as the checkpoints already do —
 and even that trust is discharged when hint-verified backfill completes
 (see [Spentness Hints](#spentnesshints)). Malicious synchronization data
-produces failure, not fraud: every verification failure is detected,
-attributed, penalized, and routed around, and spentness hints in
+produces failure, not fraud: every verification failure is detected and
+routed around, and is attributed and penalized where blame is provable
+under the v2 protocol's misbehavior rules. (Two failures are deliberately
+*not* attributed: a nonzero hint aggregate, which implicates the hints,
+the snapshot sets, or the blocks without distinguishing them, and an
+assembled artifact piece whose ranges came from several peers — see
+[Download Scheduling](#downloadscheduling).) Spentness hints in
 particular cannot cause acceptance of an incorrect state — a wrong hint
 surfaces as a nonzero aggregate.
 

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -22,7 +22,7 @@ section 3.3 of the Zcash Protocol Specification. [^protocol-blockchain]
 
 The term "v2 protocol" in this document refers to the version 2 Zcash P2P
 network protocol [^draft-p2p-v2]. The terms "peer" and "request stream", the
-`get-headers`, `get-blocks`, `get-tx`, `get-hashes`, `get-block-range`,
+`get-headers`, `get-blocks`, `get-hashes`, `get-block-range`,
 `get-tree-roots`, and `get-object` request stream types, the service flags,
 and the synchronization rules of that protocol, are to be interpreted as
 defined there.
@@ -190,8 +190,8 @@ known-hash list as follows:
    protocol's `get-block-range` delivery rules [^draft-p2p-v2] and — as a
    cross-check — matched against the known-hash list at its height. A
    truncated or cancelled unit keeps its verified prefix, and the
-   remainder is re-requested from any peer per the v2 protocol's
-   resumption rule.
+   remainder is re-requested from any peer, anchored at the next expected
+   hash, as the v2 protocol's `get-block-range` truncation rules provide.
 
 4. **Commit** each completed range in height order, applying whatever
    abbreviated validation local policy permits for
@@ -223,8 +223,8 @@ against header commitments:
    authenticated. Which check applies depends on what the block's header
    commits to at that height, which changes at Heartwood — *not* at NU5:
 
-   - **Between Sapling activation and Heartwood activation**, the header
-     field at offset 4 (`hashFinalSaplingRoot`) is the block's Sapling note
+   - **Between Sapling activation and Heartwood activation**, the fourth
+     header field (`hashFinalSaplingRoot`) is the block's Sapling note
      commitment tree root. Each supplied Sapling root is checked directly
      against it.
    - **From Heartwood activation**, ZIP 221 [^zip-0221] repurposes that
@@ -296,7 +296,7 @@ They are therefore specified rather than left to the implementation:
 - Each item's hash is `H_a(item) = BLAKE2b-256(item)` computed with the
   salt as the BLAKE2b *key* and a per-aggregate 16-byte personalization
   string `a` (for example `b"ZcashHintTrans\x00\x00"` for the transparent
-  aggregate and `b"ZcashHintNfSapl"` and the corresponding names for each
+  aggregate and `b"ZcashHintNfSapl\x00"` and the corresponding names for each
   nullifier pool). Keying — rather than prefixing the salt to the message
   — makes the construction a pseudorandom function and is not subject to
   length extension, and the personalization domain-separates the
@@ -305,7 +305,7 @@ They are therefore specified rather than left to the implementation:
 - The aggregate is the sum of those hashes, interpreted as 256-bit
   little-endian unsigned integers, **modulo 2^256**. The wide accumulator
   is what makes an accidental or forged cancellation negligible; a
-  machine-word accumulator would admit a false zero with probability
+  32-bit accumulator would admit a false zero with probability
   around 2^-32 per attempt, which is not a sufficient margin for a check
   whose failure is a silent retry rather than a ban.
 

--- a/zips/draft-arya-block-chain-sync.md
+++ b/zips/draft-arya-block-chain-sync.md
@@ -123,12 +123,13 @@ removing them is worth:
    installs a verified state snapshot at a recent height and is operational
    in minutes, backfilling history in the background if it chooses.
 
-Checkpoints themselves also motivate the artifact machinery. The Zebra
+Checkpoints themselves also motivate this machinery. The Zebra
 implementation compiles in known-hash lists covering every block — over 100
 MB of hashes that grow with the chain — because the legacy protocol offered
-no way to fetch and verify them. Under this ZIP, a binary need only pin the
-SHA-256 hashes of the chunk artifacts (a few kilobytes); the artifacts
-themselves are obtained and verified as specified in
+no way to fetch and verify them. Under this ZIP, a binary compiles in only
+the expected hashes of the list itself, chunked by height range (a few
+kilobytes); the full known-hash list is then obtained verifiably from the
+P2P network with `get-hashes`, as specified in
 [Synchronization Data](#synchronizationdata).
 
 
@@ -141,12 +142,14 @@ strategy below and are not restated here.
 
 A node's trusted commitment binds the data its strategies rely on:
 
-- **Known-hash lists**, as the pinned SHA-256 hashes of chunk artifacts.
-  A node obtains the artifacts from any source — bundled with its release,
+- **Known-hash lists**, as pinned SHA-256 hashes of the list's *chunks*:
+  each chunk is the canonical serialization of the `get-hashes` entries
+  for a fixed height range. A node obtains the entries from its peers with
+  `get-hashes` and verifies them by reassembling each chunk and comparing
+  its hash against the commitment. The same bytes MAY instead be obtained
+  as chunk artifacts from any source — bundled with the release,
   `get-object` requests to `NODE_SYNC_ARTIFACTS` peers, or out-of-band
-  mirrors — and accepts them only if their hashes match the commitment.
-  Equivalently, a node MAY obtain the same data via `get-hashes` and verify
-  it by reassembling the chunk artifacts and comparing their hashes. A
+  mirrors — accepted only if their hashes match the commitment. A
   verified known-hash list makes every listed hash an anchor, and its span
   metadata gives per-height sizes and costs for scheduling.
 - **A snapshot manifest hash**, for snapshot synchronization (see


### PR DESCRIPTION
Recommends how nodes synchronize over the version 2 P2P protocol. The v2 protocol draft (#1344) now defines the primitives (`get-headers`/`get-blocks`/`get-hashes`) and the normative synchronization rules for both headers-first and checkpointed synchronization; this ZIP recommends concrete strategies satisfying those rules:

- Headers-first synchronization (the baseline full-validation method).
- Checkpointed synchronization: verify checkpoint-spaced `get-hashes` responses against a local trusted commitment (e.g. compiled-in hash chunk hashes), fetch stride-1 hashes as download handles, and hash-chain each downloaded range to its verified checkpoints.

Plus strategy selection and peer-diversity recommendations, degrading gracefully to headers-first when `get-hashes` is unavailable.

Stacked on #1344, which it references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C36xn69yRXtupScMCYarca