### PR TITLE
ZIP-2005: remove dangling K

### DIFF
--- a/zips/zip-2005.md
+++ b/zips/zip-2005.md
@@ -1020,7 +1020,6 @@ the prover knows an auxiliary input:
 $\begin{array}{rl}
   \hspace{4em}           ( \mathsf{path} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,q_{\mathbb{P}}-1 \}^{[\mathsf{MerkleDepth^{Orchard}}]}, \\
                             \mathsf{pos} \!\!\!\!&{\small ⦂}\; \{ 0\,..\,2^{\mathsf{MerkleDepth^{Orchard}}}-1 \}, \\
-                                       K \!\!\!\!&{\small ⦂}\; \mathbb{B}^{[\ell_{\mathsf{sk}}]}, \\
                          \mathsf{\alpha} \!\!\!\!&{\small ⦂}\; \mathbb{F}_{r_{\mathbb{P}}}, \\
                 \mathsf{ak}^{\mathbb{P}} \!\!\!\!&{\small ⦂}\; \mathbb{P}^*, \\
                              \mathsf{nk} \!\!\!\!&{\small ⦂}\; \mathbb{F}_{q_{\mathbb{P}}}, \\


### PR DESCRIPTION
[ZIP-2005](https://zips.z.cash/zip-2005) Recovery Statement contains a dangling auxiliary input $K$ which this PR removes.